### PR TITLE
Gcc 11 fixes

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -196,6 +196,7 @@ pipeline {
                     }
                     stage("Image") {
                         when { allOf { 
+                            branch "master"
                             expression { "${COVERAGE}" == 'False' }
                             }
                         }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
         stage('Build') {
             failFast true
             matrix {
-                agent { label 'sds-builder' }
+                agent { docker { image 'hub.tess.io/sds/sds_tess_build:4.x-latest' } }
                 axes {
                     axis {
                         name 'BUILD_TYPE'

--- a/src/include/homestore/homestore_decl.hpp
+++ b/src/include/homestore/homestore_decl.hpp
@@ -27,6 +27,7 @@
 #include <sisl/flip/flip.hpp>
 #endif
 #include <spdlog/fmt/fmt.h>
+#include <nlohmann/json.hpp>
 
 namespace homestore {
 ////////////// All Typedefs ///////////////////

--- a/src/include/homestore/index/index_internal.hpp
+++ b/src/include/homestore/index/index_internal.hpp
@@ -61,8 +61,7 @@ enum class index_buf_state_t : uint8_t {
 class IndexBuffer;
 typedef std::shared_ptr< IndexBuffer > IndexBufferPtr;
 
-class IndexBuffer {
-private:
+struct IndexBuffer {
     uint8_t* m_node_buf{nullptr};                            // Actual buffer
     index_buf_state_t m_buf_state{index_buf_state_t::CLEAN}; // Is buffer yet to persist?
     BlkId m_blkid;                                           // BlkId where this needs to be persisted
@@ -70,7 +69,6 @@ private:
     // Number of leader buffers we are waiting for before we write this buffer
     sisl::atomic_counter< int > m_wait_for_leaders{0};
 
-public:
     IndexBuffer(BlkId blkid, uint32_t buf_size, uint32_t align_size);
 
     BlkId blkid() const { return m_blkid; }

--- a/src/include/homestore/logstore/log_store_internal.hpp
+++ b/src/include/homestore/logstore/log_store_internal.hpp
@@ -152,7 +152,6 @@ struct logstore_req {
         if (req->is_internal_req) { sisl::ObjectAllocator< logstore_req >::deallocate(req); }
     }
 
-private:
     logstore_req() = default;
 };
 

--- a/src/lib/blkalloc/blk_allocator.h
+++ b/src/lib/blkalloc/blk_allocator.h
@@ -318,11 +318,11 @@ public:
     nlohmann::json get_status(int log_level) const;
 
     bool realtime_bm_on() const { return (m_cfg.m_realtime_bm_on && m_auto_recovery); }
+    void reset_disk_bm_dirty() { is_disk_bm_dirty = false; }
 
 private:
     sisl::Bitset* get_debug_bm() { return m_debug_bm.get(); }
     sisl::ThreadVector< BlkId >* get_alloc_blk_list();
-    void reset_disk_bm_dirty() { is_disk_bm_dirty = false; }
     void set_disk_bm_dirty() { is_disk_bm_dirty = true; }
 
 protected:

--- a/src/lib/blkalloc/blk_cache_queue.cpp
+++ b/src/lib/blkalloc/blk_cache_queue.cpp
@@ -104,14 +104,14 @@ blk_count_t FreeBlkCacheQueue::try_free_blks(const blk_cache_entry& entry,
         }
 #endif
 
-        e.set_nblks(m_slab_queues[slab_idx]->m_slab_size);
+        e.set_nblks(m_slab_queues[slab_idx]->get_slab_size());
         if (!push_slab(slab_idx, e, false /* only_this_level */)) {
             excess_blks.push_back(e);
             num_zombied += e.get_nblks();
         }
 
         if (excess == 0) { break; }
-        e.set_blk_num(e.get_blk_num() + m_slab_queues[slab_idx]->m_slab_size);
+        e.set_blk_num(e.get_blk_num() + m_slab_queues[slab_idx]->get_slab_size());
         e.set_nblks(excess);
     }
 
@@ -306,7 +306,7 @@ SlabCacheQueue::SlabCacheQueue(const blk_count_t slab_size, const std::vector< b
 
 std::optional< blk_temp_t > SlabCacheQueue::push(const blk_cache_entry& entry, const bool only_this_level) {
     const blk_temp_t start_level{
-        static_cast< blk_temp_t >((entry.m_temp >= m_level_queues.size()) ? m_level_queues.size() - 1 : entry.m_temp)};
+        static_cast< blk_temp_t >((entry.get_temperature() >= m_level_queues.size()) ? m_level_queues.size() - 1 : entry.get_temperature())};
     blk_temp_t level{start_level};
     bool pushed{m_level_queues[start_level]->write(entry)};
 

--- a/src/lib/blkalloc/blk_cache_queue.h
+++ b/src/lib/blkalloc/blk_cache_queue.h
@@ -71,6 +71,8 @@ public:
 
     [[nodiscard]] SlabMetrics& metrics() { return m_metrics; }
 
+    blk_count_t get_slab_size() const { return m_slab_size; }
+
 private:
     blk_count_t m_slab_size; // Slab size in-terms of number of pages
     std::vector< std::unique_ptr< folly::MPMCQueue< blk_cache_entry > > > m_level_queues;

--- a/src/lib/blkalloc/varsize_blk_allocator.cpp
+++ b/src/lib/blkalloc/varsize_blk_allocator.cpp
@@ -72,7 +72,7 @@ VarsizeBlkAllocator::VarsizeBlkAllocator(const VarsizeBlkAllocConfig& cfg, bool 
 
     // Create free blk Cache of type Queue
     if (m_cfg.get_use_slabs()) {
-        m_fb_cache = std::make_unique< FreeBlkCacheQueue >(cfg.m_slab_config, &m_metrics);
+        m_fb_cache = std::make_unique< FreeBlkCacheQueue >(cfg.get_slab_config(), &m_metrics);
 
         LOGINFO("m_fb_cache total free blks: {}", m_fb_cache->total_free_blks());
     }

--- a/src/lib/blkalloc/varsize_blk_allocator.h
+++ b/src/lib/blkalloc/varsize_blk_allocator.h
@@ -115,6 +115,9 @@ public:
     VarsizeBlkAllocConfig& operator=(VarsizeBlkAllocConfig&&) noexcept = delete;
     virtual ~VarsizeBlkAllocConfig() override = default;
 
+    ///////////// SlabConfig getter /////////////
+    SlabCacheConfig get_slab_config() const { return m_slab_config; }
+
     //////////// Physical page size related getters/setters /////////////
     void set_phys_page_size(const uint32_t page_size) { m_phys_page_size = page_size; }
     uint32_t get_phys_page_size() const { return m_phys_page_size; }

--- a/src/lib/common/homestore_status_mgr.cpp
+++ b/src/lib/common/homestore_status_mgr.cpp
@@ -15,6 +15,8 @@
  *********************************************************************************/
 #include "homestore_status_mgr.hpp"
 
+#include <mutex>
+
 namespace homestore {
 void HomeStoreStatusMgr::register_status_cb(const std::string& module, const get_status_cb_t get_status_cb) {
     std::unique_lock lock(m_mtx);

--- a/src/lib/common/resource_mgr.hpp
+++ b/src/lib/common/resource_mgr.hpp
@@ -20,6 +20,7 @@
 
 namespace homestore {
 class RsrcMgrMetrics : public sisl::MetricsGroup {
+public:
     explicit RsrcMgrMetrics() : sisl::MetricsGroup("resource_mgr", "resource_mgr") {
         REGISTER_COUNTER(dirty_buf_cnt, "Total wb cache dirty buffer cnt", sisl::_publish_as::publish_as_gauge);
         REGISTER_COUNTER(free_blk_size_in_cp, "Total free blks size accumulated in a cp",

--- a/src/lib/device/physical_dev.hpp
+++ b/src/lib/device/physical_dev.hpp
@@ -517,6 +517,7 @@ public:
 
     void init_done();
 
+    bool is_hdd() const;
     void close_device();
 
     hs_uuid_t sys_uuid() { return m_super_blk->get_system_uuid(); }
@@ -564,7 +565,6 @@ private:
     /* Validate if this device is a homestore validated device. If there is any corrupted device, then it
      * throws std::system_exception */
     bool validate_device() const;
-    bool is_hdd() const;
 
     /*
      * return true if we are upgrading from some version that is supported for upgrade;

--- a/src/lib/logstore/log_dev.cpp
+++ b/src/lib/logstore/log_dev.cpp
@@ -571,7 +571,7 @@ void LogDev::get_status(const int verbosity, nlohmann::json& js) const {
         js["logdev_stopped?"] = m_stopped;
         js["is_log_flushing_now?"] = m_is_flushing.load(std::memory_order_relaxed);
         js["logdev_sb_start_offset"] = m_logdev_meta.get_start_dev_offset();
-        js["logdev_sb_num_stores_reserved"] = m_logdev_meta.m_sb->num_stores_reserved();
+        js["logdev_sb_num_stores_reserved"] = m_logdev_meta.num_stores_reserved();
     }
 }
 

--- a/src/lib/logstore/log_store.cpp
+++ b/src/lib/logstore/log_store.cpp
@@ -40,7 +40,7 @@ HomeLogStore::HomeLogStore(LogStoreFamily& family, logstore_id_t id, bool append
         m_records{"HomeLogStoreRecords", start_lsn - 1},
         m_append_mode{append_mode},
         m_seq_num{start_lsn},
-        m_fq_name{fmt::format("{}.{}", family.m_family_id, id)},
+        m_fq_name{fmt::format("{}.{}", family.get_family_id(), id)},
         m_metrics{logstore_service().metrics()} {
     m_truncation_barriers.reserve(10000);
     m_safe_truncation_boundary.seq_num.store(start_lsn - 1, std::memory_order_release);
@@ -385,7 +385,7 @@ nlohmann::json HomeLogStore::get_status(int verbosity) const {
     js["truncation_pending_on_device?"] = m_safe_truncation_boundary.pending_dev_truncation;
     js["truncation_parallel_to_writes?"] = m_safe_truncation_boundary.active_writes_not_part_of_truncation;
     js["logstore_records"] = m_records.get_status(verbosity);
-    js["logstore_sb_first_lsn"] = m_logdev.m_logdev_meta.store_superblk(m_store_id).m_first_seq_num;
+    js["logstore_sb_first_lsn"] = m_logdev.log_dev_meta().store_superblk(m_store_id).m_first_seq_num;
     return js;
 }
 

--- a/src/lib/logstore/log_store_family.hpp
+++ b/src/lib/logstore/log_store_family.hpp
@@ -90,8 +90,11 @@ public:
     nlohmann::json get_status(int verbosity) const;
     std::string get_name() const { return m_metablk_name; }
 
-private:
+    logstore_family_id_t get_family_id() const { return m_family_id; }
+
     logdev_key do_device_truncate(bool dry_run = false);
+
+private:
 
     void on_log_store_found(logstore_id_t store_id, const logstore_superblk& meta);
     void on_io_completion(logstore_id_t id, logdev_key ld_key, logdev_key flush_idx, uint32_t nremaining_in_batch,

--- a/src/tests/test_meta_blk_mgr.cpp
+++ b/src/tests/test_meta_blk_mgr.cpp
@@ -111,9 +111,11 @@ struct sb_info_t {
 
 class VMetaBlkMgrTest : public ::testing::Test {
     enum class meta_op_type : uint8_t { write = 1, update = 2, remove = 3, read = 4 };
-    std::string mtype;
 
 public:
+    std::string mtype;
+    Clock::time_point m_start_time;
+
     VMetaBlkMgrTest() = default;
     VMetaBlkMgrTest(const VMetaBlkMgrTest&) = delete;
     VMetaBlkMgrTest& operator=(const VMetaBlkMgrTest&) = delete;
@@ -570,7 +572,6 @@ private:
     uint64_t m_update_cnt{0};
     uint64_t m_rm_cnt{0};
     uint64_t m_total_wrt_sz{0};
-    Clock::time_point m_start_time;
     MetaBlkService* m_mbm{nullptr};
     std::map< uint64_t, sb_info_t > m_write_sbs; // during write, save blkid to buf map;
     std::map< uint64_t, std::string > m_cb_blks; // during recover, save blkid to buf map;


### PR DESCRIPTION
GCC 11.3 apparently is stricter than GCC 9.2 with member visibility rules. These changes allow all of Homestore to build with GCC 11.3 and successful test runs.