### PR TITLE
Rollback of journal/logstore support

### DIFF
--- a/src/include/homestore/logstore/log_store.hpp
+++ b/src/include/homestore/logstore/log_store.hpp
@@ -40,6 +40,7 @@ class LogDev;
 class LogStoreServiceMetrics;
 
 static constexpr logstore_seq_num_t invalid_lsn() { return std::numeric_limits< logstore_seq_num_t >::min(); }
+typedef std::function< void(logstore_seq_num_t) > on_rollback_cb_t;
 
 class HomeLogStore : public std::enable_shared_from_this< HomeLogStore > {
 public:
@@ -256,26 +257,12 @@ public:
     void flush_sync(logstore_seq_num_t upto_seq_num = invalid_lsn());
 
     /**
-     * @brief Sync the log store to disk
-     *
-     * @param
-     * @return True on success
-     */
-    bool sync() {
-        // TODO: Implement this method
-        return true;
-    }
-
-    /**
      * @brief Rollback the given instance to the given sequence number
      *
      * @param seq_num Sequence number back which logs are to be rollbacked
      * @return True on success
      */
-    bool rollback(logstore_seq_num_t seq_num) {
-        // TODO: Implement this method
-        return true;
-    }
+    uint64_t rollback_async(logstore_seq_num_t to_lsn, on_rollback_cb_t cb);
 
     auto seq_num() const { return m_seq_num.load(std::memory_order_acquire); }
 

--- a/src/include/homestore/logstore/log_store_internal.hpp
+++ b/src/include/homestore/logstore/log_store_internal.hpp
@@ -52,6 +52,7 @@ typedef std::function< void(std::shared_ptr< HomeLogStore >) > log_store_opened_
 typedef std::function< void(std::shared_ptr< HomeLogStore >, logstore_seq_num_t) > log_replay_done_cb_t;
 
 typedef int64_t logid_t;
+
 struct logdev_key {
     logid_t idx;
     off_t dev_offset;

--- a/src/lib/logstore/log_dev.hpp
+++ b/src/lib/logstore/log_dev.hpp
@@ -72,12 +72,11 @@ struct serialized_log_record {
     logstore_seq_num_t store_seq_num; // Seqnum by the log store
     logstore_id_t store_id;           // ID of the store this log is associated with
 
-    void set_inlined(const bool inlined) { is_inlined = static_cast< uint32_t >(inlined ? 0x1 : 0x0); }
+    void set_inlined(bool inlined) { is_inlined = static_cast< uint32_t >(inlined ? 0x1 : 0x0); }
     bool get_inlined() const { return ((is_inlined == static_cast< uint32_t >(0x1)) ? true : false); }
 
     serialized_log_record() = default;
-    serialized_log_record(const uint32_t s, const uint32_t o, const bool inlined, const logstore_seq_num_t sq,
-                          const logstore_id_t id) :
+    serialized_log_record(uint32_t s, uint32_t o, bool inlined, logstore_seq_num_t sq, logstore_id_t id) :
             size{s}, offset{o}, store_seq_num{sq}, store_id{id} {
         set_inlined(inlined);
     }
@@ -425,10 +424,53 @@ struct logdev_superblk {
 };
 #pragma pack()
 
+#pragma pack(1)
+typedef std::pair< logid_t, logid_t > logid_range_t;
+
+struct rollback_record {
+    logstore_id_t store_id;
+    logid_range_t idx_range;
+};
+
+struct rollback_superblk {
+    static constexpr uint32_t ROLLBACK_SB_MAGIC{0xDABAF00D};
+    static constexpr uint32_t ROLLBACK_SB_VERSION{1};
+    static constexpr uint32_t num_record_increment{8};
+
+    uint32_t magic{ROLLBACK_SB_MAGIC};
+    uint32_t version{ROLLBACK_SB_VERSION};
+    uint32_t num_records{0};
+
+    uint32_t get_magic() const { return magic; }
+    uint32_t get_version() const { return version; }
+
+    static uint32_t size_needed(uint32_t nrecords) {
+        return sizeof(rollback_superblk) + (sisl::round_up(nrecords, num_record_increment) * sizeof(rollback_record));
+    }
+
+    rollback_record& at(uint32_t idx) {
+        auto r = r_cast< rollback_record* >(uintptr_cast(this) + sizeof(rollback_superblk));
+        return r[idx];
+    }
+
+    void remove_ith_record(uint32_t i) {
+        uint8_t* rmem = uintptr_cast(&at(i));
+        std::memmove(rmem, rmem + sizeof(rollback_record), sizeof(rollback_record) * (num_records - i - 1));
+        --num_records;
+    }
+
+    void add_record(logstore_id_t store_id, logid_range_t idx_range) {
+        rollback_record& r = at(num_records++);
+        r.store_id = store_id;
+        r.idx_range = idx_range;
+    }
+};
+#pragma pack()
+
 // This class represents the metadata of logdev providing methods to change/access log dev super block.
 class LogDevMetadata {
 public:
-    LogDevMetadata(const std::string& metablk_name);
+    LogDevMetadata(const std::string& logdev_name);
     LogDevMetadata(const LogDevMetadata&) = delete;
     LogDevMetadata& operator=(const LogDevMetadata&) = delete;
     LogDevMetadata(LogDevMetadata&&) noexcept = delete;
@@ -437,7 +479,6 @@ public:
 
     logdev_superblk* create();
     void reset();
-    void meta_buf_found(const sisl::byte_view& buf, void* meta_cookie);
     std::vector< std::pair< logstore_id_t, logstore_superblk > > load();
     void persist();
 
@@ -451,29 +492,38 @@ public:
     void unreserve_store(logstore_id_t idx, bool persist_now);
     const std::set< logstore_id_t >& reserved_store_ids() const { return m_store_info; }
 
-    void update_store_superblk(logstore_id_t idx, const logstore_superblk& meta, const bool persist_now);
+    void update_store_superblk(logstore_id_t idx, const logstore_superblk& meta, bool persist_now);
     const logstore_superblk& store_superblk(logstore_id_t idx) const;
     logstore_superblk& mutable_store_superblk(logstore_id_t idx);
 
     auto num_stores_reserved() const { return m_sb->num_stores_reserved(); }
 
+    void add_rollback_record(logstore_id_t store_id, logid_range_t id_range, bool persist_now);
+    void remove_rollback_record_upto(logid_t upto_id, bool persist_now);
+    void remove_all_rollback_records(logstore_id_t store_id, bool persist_now);
+    uint32_t num_rollback_records(logstore_id_t store_id) const;
+    bool is_rolled_back(logstore_id_t store_id, logid_t logid) const;
+
 private:
-    bool resize_if_needed();
+    bool resize_logdev_sb_if_needed();
+    bool resize_rollback_sb_if_needed();
+    void logdev_super_blk_found(const sisl::byte_view& buf, void* meta_cookie);
+    void rollback_super_blk_found(const sisl::byte_view& buf, void* meta_cookie);
 
-    uint32_t required_sb_size(uint32_t nstores) const {
-        // TO DO: Might need to differentiate based on data or fast type
-        return size_needed(nstores);
-    }
-
-    uint32_t size_needed(uint32_t nstores) const {
-        return sizeof(logdev_superblk) + (nstores * sizeof(logstore_seq_num_t));
+    uint32_t logdev_sb_size_needed(uint32_t nstores) const {
+        return sizeof(logdev_superblk) + (nstores * sizeof(logstore_superblk));
     }
 
     uint32_t store_capacity() const;
+    void remove_all_rollback_records(logstore_id_t id);
 
+private:
     superblk< logdev_superblk > m_sb;
+    superblk< rollback_superblk > m_rollback_sb;
     std::unique_ptr< sisl::IDReserver > m_id_reserver;
     std::set< logstore_id_t > m_store_info;
+    std::multimap< logstore_id_t, logid_range_t > m_rollback_info;
+    bool m_rollback_info_dirty{false};
 };
 
 class HomeStore;
@@ -675,7 +725,16 @@ public:
      * @return number of records to truncate
      */
     uint64_t truncate(const logdev_key& key);
-    void meta_blk_found(meta_blk* mblk, sisl::byte_view buf, size_t size);
+
+    /**
+     * @brief Rollback the logid range specific to the given store id. This method persists the information
+     * synchronously to the underlying storage. Once rolledback those logids in this range are ignored (only for
+     * this logstore) during load.
+     *
+     * @param store_id : Store id whose logids are to be rolled back or invalidated
+     * @param id_range : Log id range to rollback/invalidate
+     */
+    void rollback(logstore_id_t store_id, logid_range_t id_range);
 
     void update_store_superblk(logstore_id_t idx, const logstore_superblk& meta, bool persist_now);
 
@@ -689,6 +748,7 @@ public:
     uint64_t get_flush_size_multiple() const { return m_flush_size_multiple; }
 
     LogDevMetadata& log_dev_meta() { return m_logdev_meta; }
+    static bool can_flush_in_this_thread();
 
 private:
     LogGroup* make_log_group(uint32_t estimated_records) {

--- a/src/lib/logstore/log_store.cpp
+++ b/src/lib/logstore/log_store.cpp
@@ -381,6 +381,11 @@ logstore_seq_num_t HomeLogStore::get_contiguous_completed_seq_num(logstore_seq_n
 }
 
 void HomeLogStore::flush_sync(logstore_seq_num_t upto_seq_num) {
+    // Logdev flush is async call and if flush_sync is called on the same thread which could potentially do logdev
+    // flush, waiting sync would cause deadlock.
+    HS_DBG_ASSERT_EQ(LogDev::can_flush_in_this_thread(), false,
+                     "Logstore flush sync cannot be called on same thread which could do logdev flush");
+
     if (upto_seq_num == invalid_lsn()) { upto_seq_num = m_records.active_upto(); }
 
     // if we have flushed already, we are done
@@ -406,6 +411,49 @@ void HomeLogStore::flush_sync(logstore_seq_num_t upto_seq_num) {
         // NOTE: We are not resetting the lsn because same seq number should never have 2 completions and thus not
         // doing it saves an atomic instruction
     }
+}
+
+uint64_t HomeLogStore::rollback_async(logstore_seq_num_t to_lsn, on_rollback_cb_t cb) {
+    // Validate if the lsn to which it is rolledback to is not truncated.
+    auto ret = m_records.status(to_lsn + 1);
+    if (ret.is_out_of_range) {
+        HS_LOG_ASSERT(false, "Attempted to rollback to {} which is already truncated", to_lsn);
+        return 0;
+    }
+
+    // Ensure that there are no pending lsn to flush. If so lets flush them now.
+    const auto from_lsn = get_contiguous_issued_seq_num(0);
+    if (get_contiguous_completed_seq_num(0) < from_lsn) { flush_sync(); }
+    HS_DBG_ASSERT_EQ(get_contiguous_completed_seq_num(0), get_contiguous_issued_seq_num(0),
+                     "Still some pending lsns to flush, concurrent write and rollback is not supported");
+
+    // Do an in-memory rollback of lsns before we persist the log ids. This is done, so that subsequent appends can
+    // be queued without waiting for rollback async operation completion. It is safe to do so, since before returning
+    // from this method, we will queue ourselves to the flush lock and thus subsequent writes are guaranteed to go after
+    // this rollback is completed.
+    m_seq_num.store(to_lsn + 1, std::memory_order_release); // Rollback the next append lsn
+    logid_range_t logid_range = std::make_pair(m_records.at(to_lsn + 1).m_dev_key.idx,
+                                               m_records.at(from_lsn).m_dev_key.idx); // Get the logid range to rollback
+    m_records.rollback(to_lsn); // Rollback all bitset records and from here on, we can't access any lsns beyond to_lsn
+
+    if (m_logdev.try_lock_flush([logid_range, to_lsn, this, comp_cb = std::move(cb)]() {
+            // Rollback the log_ids in the range, for this log store (which persists this info in its superblk)
+            m_logdev.rollback(m_store_id, logid_range);
+
+            // Remove all truncation barriers on rolled back lsns
+            for (auto it = std::rbegin(m_truncation_barriers); it != std::rend(m_truncation_barriers); ++it) {
+                if (it->seq_num > to_lsn) {
+                    m_truncation_barriers.erase(std::next(it).base());
+                } else {
+                    break;
+                }
+            }
+            m_flush_batch_max_lsn = invalid_lsn(); // Reset the flush batch for next batch.
+            if (comp_cb) { comp_cb(to_lsn); }
+        })) {
+        m_logdev.unlock_flush();
+    }
+    return from_lsn - to_lsn;
 }
 
 nlohmann::json HomeLogStore::get_status(int verbosity) const {

--- a/src/lib/logstore/log_store_family.cpp
+++ b/src/lib/logstore/log_store_family.cpp
@@ -31,13 +31,7 @@ namespace homestore {
 SISL_LOGGING_DECL(logstore)
 
 LogStoreFamily::LogStoreFamily(logstore_family_id_t f_id) :
-        m_family_id{f_id},
-        m_metablk_name{std::string("LogDevFamily") + std::to_string(f_id)},
-        m_log_dev{f_id, m_metablk_name} {}
-
-void LogStoreFamily::meta_blk_found_cb(meta_blk* mblk, sisl::byte_view buf, size_t size) {
-    m_log_dev.meta_blk_found(mblk, buf, size);
-}
+        m_family_id{f_id}, m_name{std::string("LogDevFamily") + std::to_string(f_id)}, m_log_dev{f_id, m_name} {}
 
 void LogStoreFamily::start(bool format, JournalVirtualDev* blk_store) {
     m_log_dev.register_store_found_cb(bind_this(LogStoreFamily::on_log_store_found, 2));

--- a/src/lib/logstore/log_store_family.hpp
+++ b/src/lib/logstore/log_store_family.hpp
@@ -68,7 +68,6 @@ public:
     LogStoreFamily& operator=(const LogStoreFamily&) = delete;
     LogStoreFamily& operator=(LogStoreFamily&&) noexcept = delete;
 
-    void meta_blk_found_cb(meta_blk* mblk, sisl::byte_view buf, size_t size);
     void start(const bool format, JournalVirtualDev* blk_store);
     void stop();
 
@@ -83,12 +82,11 @@ public:
     void device_truncate_in_user_reactor(const std::shared_ptr< truncate_req >& treq);
 
     nlohmann::json dump_log_store(const log_dump_req& dum_req);
-    std::string metablk_name() const { return m_metablk_name; }
 
     LogDev& logdev() { return m_log_dev; }
 
     nlohmann::json get_status(int verbosity) const;
-    std::string get_name() const { return m_metablk_name; }
+    std::string get_name() const { return m_name; }
 
     logstore_family_id_t get_family_id() const { return m_family_id; }
 
@@ -109,7 +107,7 @@ private:
     std::unordered_set< logstore_id_t > m_unopened_store_id;
     std::unordered_map< logstore_id_t, logid_t > m_last_flush_info;
     logstore_family_id_t m_family_id;
-    std::string m_metablk_name;
+    std::string m_name;
     LogDev m_log_dev;
 };
 } // namespace homestore


### PR DESCRIPTION
Rollback of logstore requirement is to make sure that every entry after the given seq_num will be invalidated. This needs to be recovery and truncation proof (in the sense after rollback - after restart of logstore we should still not see those entries). It is implemented at layer below logstore - which is log_dev, to make sure the above requirements are met. Everytime a log store is rolledback, log_dev writes the logstore_id and log_id (which is the key for log_dev) into a separate persistent rollback record in its superblock. This marks any log_id corresponding to the given logstore is invalid going forward and can be safely ignored during recovery. Upon truncation of the given log_id, this rollback record can be truncated.
NOTE
1. log_id is common id across log_stores. 
2. lsn (logstore_seq_num) is unique within log_store
3. logstore_id: ID indicating the logstore.