### PR TITLE
SDSTOR-8781 Read Blk Tracker

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.0.2"
+    version = "4.0.3"
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")

--- a/src/include/homestore/blk.h
+++ b/src/include/homestore/blk.h
@@ -82,6 +82,8 @@ public:
 
     void set_blk_num(blk_num_t blk_num);
     blk_num_t get_blk_num() const { return m_blk_num; }
+    // last blk num is the last blk num that belongs this blkid;
+    blk_num_t get_last_blk_num() const { return get_blk_num() + get_nblks() - 1; }
 
     void set_nblks(blk_count_t nblks);
     blk_count_t get_nblks() const { return static_cast< blk_count_t >(m_nblks) + 1; }

--- a/src/lib/blkdata_svc/blk_read_tracker.cpp
+++ b/src/lib/blkdata_svc/blk_read_tracker.cpp
@@ -1,7 +1,6 @@
 /*********************************************************************************
  * Modifications Copyright 2017-2019 eBay Inc.
  *
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,69 +17,91 @@
 namespace homestore {
 static BlkId extract_key(const BlkTrackRecord& rec) { return rec.m_key; }
 
-static bool blkid_overlaps(const BlkId& a, const BlkId& b) {
-    if (a.get_chunk_num() != b.get_blk_num()) { return false; }
-    if (a.get_blk_num() == b.get_blk_num()) { return true; }
-    if (a.get_blk_num < b.get_blk_num()) { return ((a.get_blk_num() + a.get_nblks()) >= b.get_blk_num()); }
-    return ((b.get_blk_num() + b.get_nblks()) >= a.get_blk_num());
-}
-
-static bool merge_records(BlkTrackRecord& rec, const BlkTrackRecord& other) {
-    assert(rec.m_key == other.m_key);
-    assert(other.m_sub_record.size() == 1); // We don't support multiple elements to merge with each other
-
-    const auto& new_rec = other.m_sub_record[0];
-    rec.m_total_refcount += other.m_total_refcount;
-
-    bool inserted{false};
-    auto it = rec.m_sub_record.begin();
-    while (it != rec.m_sub_record.end()) {
-        if (blkid_overlaps(it->sub_range, new_rec.sub_range)) {
-            it->ref_count += new_rec.ref_count;
-            if (it->ref_count == 0) { // No one references, removed from list
-                it = rec.m_sub_record.erase(it);
-            } else {
-                it->waiter = new_rec.waiter;
-                inserted = true;
-            }
-        }
-        ++it;
-    }
-
-    if (!inserted) { rec.m_sub_record.push_back(new_rec); }
-    return (rec.m_total_refcount == 0);
-}
-
-BlkReadTracker::BlkReadTracker() : m_pending_reads_map(expected_num_records, extract_key, nullptr, merge_records) {}
+BlkReadTracker::BlkReadTracker() : m_pending_reads_map(s_expected_num_records, extract_key, nullptr /* access_cb */) {}
 
 void BlkReadTracker::merge(const BlkId& blkid, int64_t new_ref_count,
                            const std::shared_ptr< blk_track_waiter >& waiters) {
-    auto cur_blk_num = blkid.get_blk_num();
-    auto max_this_entry = entries_per_record - (cur_blk_num - sisl::round_down(cur_blk_num, entries_per_record));
+    if (new_ref_count == 0) {
+        assert(waiters);
+    } else {
+        assert(!waiters);
+    }
 
-    while (cur_blk_num <= blkid.get_last_blk_num()) {
-        const auto count = std::min(max_this_entry, (blkid.get_last_blk_num() - cur_blk_num + 1));
+    //
+    // Don't move alignment handling outside of this function, because the nblks between (first and last blk num after
+    // alignment) could be larger than 255 which exceeds a BlkId can hold;
+    //
+    auto cur_blk_num_aligned = s_cast< blk_num_t >(sisl::round_down(blkid.get_blk_num(), entries_per_record()));
+    auto last_blk_num_aligned_up = s_cast< blk_num_t >(sisl::round_up(blkid.get_last_blk_num(), entries_per_record()) -
+                                                       1); //  -1 so that it does not cover next base id;
+    if (blkid.get_last_blk_num() % entries_per_record() == 0) {
+        // if last blk num happens to be aligned, it actually belongs to next base id, so add 1 back;
+        last_blk_num_aligned_up += 1;
+    }
 
-        BlkId base_blkid{sisl::round_down(cur_blk_num, entries_per_record), entries_per_record, blkid.get_chunk_num()};
-        BlkId sub_blkid{cur_blk_num, count, blkid.get_chunk_num()};
+    // everything is aligned after this point, so we don't need to handle sub_range in a base blkid;
+    while (cur_blk_num_aligned <= last_blk_num_aligned_up) {
+        BlkId base_blkid{cur_blk_num_aligned, entries_per_record(), blkid.get_chunk_num()};
 
         BlkTrackRecord rec;
-        rec.m_key = base_blkid;
-        rec.m_total_refcount = new_ref_count;
-        rec.m_sub_record.emplace_back(sub_blkid, new_ref_count, waiters);
+        const auto rec_found = m_pending_reads_map.get(base_blkid, rec);
 
-        m_pending_reads_map.merge(base_blkid, rec);
+        if (new_ref_count != 0) {
+            // this is insert/remove operations
+            if (rec_found) {
+                // if some read is already happening on this record, just update the ref_cnt;
+                rec.m_ref_cnt += new_ref_count;
+            } else {
+                // if no record found, no read is happening on this record;
+                rec.m_key = base_blkid;
+                rec.m_ref_cnt = new_ref_count;
+            }
 
-        cur_blk_num += count;
-        max_this_entry = entries_per_record;
+            // in either case, ref_cnt can not drop below zero;
+            assert(rec.m_ref_cnt >= 0);
+
+            if (rec.m_ref_cnt > 0) {
+                m_pending_reads_map.upsert(base_blkid, rec);
+            } else {
+                // ref_cnt drops to zer, clear all the references held by this record;
+                assert(rec_found);
+                rec.m_waiters.clear();
+                BlkTrackRecord dummy_rec;
+                m_pending_reads_map.erase(base_blkid, dummy_rec);
+            }
+        } else {
+            // this is wait_on operation
+            if (rec_found) {
+                // apply waiter to this record;
+                rec.m_waiters.push_back(waiters);
+                // overwirte existing record;
+                m_pending_reads_map.upsert(base_blkid, rec);
+            }
+
+            // not found, nothing needs to be done; fall through and visit remaining records;
+        }
+
+        cur_blk_num_aligned += entries_per_record();
     }
+
+    // if no record is found for a wait-on operation, it means no one is holding reference for this waiter and cb will
+    // be called automatically when this function exits (waiter's destrctor will be called);
 }
 
 void BlkReadTracker::insert(const BlkId& blkid) { merge(blkid, 1, nullptr); }
-
 void BlkReadTracker::remove(const BlkId& blkid) { merge(blkid, -1, nullptr); }
 
-void BlkReadTracker::ensure_no_record(const BlkId& blkid, after_remove_cb_t&& after_remove_cb) {
+void BlkReadTracker::wait_on(const BlkId& blkid, after_remove_cb_t&& after_remove_cb) {
     merge(blkid, 0, std::make_shared< blk_track_waiter >(std::move(after_remove_cb)));
 }
+
+uint16_t BlkReadTracker::entries_per_record() const {
+    // TODO: read from config;
+    return m_entries_per_record;
+}
+
+#ifdef _PRERELEASE
+void BlkReadTracker::set_entries_per_record(uint16_t num_entries) { m_entries_per_record = num_entries; }
+#endif
+
 } // namespace homestore

--- a/src/lib/blkdata_svc/blk_read_tracker.hpp
+++ b/src/lib/blkdata_svc/blk_read_tracker.hpp
@@ -27,13 +27,13 @@ typedef std::function< void(void) > after_remove_cb_t;
 
 struct blk_track_waiter {
     blk_track_waiter(after_remove_cb_t&& cb) : m_cb{std::move(cb)} {
-#ifdef _PRERELEASEA
-        m_start_time = CLock::now();
+#ifdef _PRERELEASE
+        m_start_time = Clock::now();
 #endif
     }
 
     ~blk_track_waiter() {
-#ifdef _PRERELEASEA
+#ifdef _PRERELEASE
         // TODO: enable this after data service is ready;
         // HISTOGRAM_OBSERVE(get_data_service().get_blk_read_tracker_inst().get_metrics(),
         //                   blktrack_erase_blk_rescheduled_latency, get_elapsed_time_us(m_start_time, CLock::now()));
@@ -43,7 +43,7 @@ struct blk_track_waiter {
 
     after_remove_cb_t m_cb;
 
-#ifdef _PRERELEASEA
+#ifdef _PRERELEASE
     Clock::time_point m_start_time;
 #endif
 };

--- a/src/lib/blkdata_svc/blk_read_tracker.hpp
+++ b/src/lib/blkdata_svc/blk_read_tracker.hpp
@@ -1,7 +1,6 @@
 /*********************************************************************************
  * Modifications Copyright 2017-2019 eBay Inc.
  *
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,9 +17,10 @@
 
 #include <folly/small_vector.h>
 #include <sisl/cache/simple_hashmap.hpp>
+#include <sisl/fds/utils.hpp>
 #include <sisl/metrics/metrics.hpp>
 
-#include "../blkalloc/blk.h"
+#include "homestore/blk.h"
 
 namespace homestore {
 typedef std::function< void(void) > after_remove_cb_t;
@@ -32,6 +32,9 @@ struct blk_track_waiter {
     after_remove_cb_t m_cb;
 };
 
+typedef std::shared_ptr< blk_track_waiter > blk_track_waiter_ptr;
+
+#if 0
 struct blk_sub_range_record {
     blk_sub_range_record(const BlkId& bid, int64_t ref) : sub_range{bid}, ref_count{ref} {}
 
@@ -45,6 +48,46 @@ struct BlkTrackRecord {
     int64_t m_total_refcount{0};
     folly::small_vector< blk_sub_range_record, 8 > m_sub_record;
 };
+#endif
+
+//
+// clang-format off
+//
+//  A read can never overlap a unfinished free-blk id;
+//  A read can overlap a pending read;
+//
+//  Say alignment is 16;
+//  1. read-1: {17, 32, 0}
+//  2. free blk: {8, 32, 0}
+//  3. read-2: {0, 4, 0}  // <<< this read will also create track record on {0, 16, 0}, it is fine though as we don't
+//  create any record under {0, 16, 0} on free;
+//
+
+//
+// When ref_cnt drops to zero (read completes), remove every waiter from the vector in this Record;
+// same waiter can be attached to multple BlkTrackRecord's vector and whom ever is the last to dereference the
+// shared_ptr of a waiter, triggers waiter's destrctor which sends the callback;
+//
+//
+//  Chunk_id: 0 (alignment: 16)
+//   ---------------------------------------------------------------
+//  | 1, 2, ... 15, 16 | 17, 18, ..., 31, 32 | 33, 34, ..., 47, 48 |  Blk Number (unique within same chunk)
+//   ---------------------------------------------------------------
+//     BlkTrackRecord-1    BlkTrackRecord-2             Record-1 and Record-2 could belongs to two different read (or one read); 
+//                                                      Record-1/2 could be referenced by multiple reads fall through on same base ids;
+//      [ ],  [ ],  [ ]     [ ], [ ], [ ]               m_waiters: vector of shared_ptr
+//       |     |      \     /     |    |
+//       |     |       \   /      |    |
+//       |     |         |        |    |
+//      ( )   ( )       ( )      ( )  ( )                waiter's instance
+//
+//  clang-format on
+//
+struct BlkTrackRecord {
+    BlkId m_key; // aligned key
+    int64_t m_ref_cnt{0};
+    folly::small_vector< blk_track_waiter_ptr, 8 > m_waiters; // multiple waiters can wait on same record
+};
 
 class BlkReadTrackerMetrics : public sisl::MetricsGroup {
 public:
@@ -52,37 +95,85 @@ public:
         REGISTER_COUNTER(blktrack_pending_blk_read_map_sz, "Size of pending blk read map",
                          sisl::_publish_as::publish_as_gauge);
         REGISTER_COUNTER(blktrack_erase_blk_rescheduled, "Erase blk rescheduled due to concurrent rw");
+        // TODO: add latency for average waiter's cb, from the time being wait_on to the point we trigger this cb back
+        // to caller;
         register_me_to_farm();
     }
+
+    BlkReadTrackerMetrics(const BlkReadTrackerMetrics&) = delete;
+    BlkReadTrackerMetrics& operator=(const BlkReadTrackerMetrics&) = delete;
+    BlkReadTrackerMetrics(BlkReadTrackerMetrics&&) noexcept = delete;
+    BlkReadTrackerMetrics& operator=(BlkReadTrackerMetrics&&) noexcept = delete;
 
     ~BlkReadTrackerMetrics() { deregister_me_from_farm(); }
 };
 
 class BlkReadTracker {
-    static constexpr uint32_t expected_num_records = 1000;
-    static constexpr uint32_t entries_per_record = 64;
+    static constexpr uint32_t s_expected_num_records = 1000;
+    static constexpr uint16_t s_entries_per_record = 8; // this number could be candidate to tune perf;
 
-    sisl::SimpleCache< BlkId, BlkTrackRecord > m_pending_reads_map;
+private:
+    sisl::SimpleHashMap< BlkId, BlkTrackRecord > m_pending_reads_map;
     BlkReadTrackerMetrics m_metrics;
+    uint32_t m_entries_per_record{s_entries_per_record};
 
 public:
     BlkReadTracker();
+    ~BlkReadTracker() = default;
 
-    // Insert the blkid into read tracker. If entry already exists, it will increment the reference count of the blkid
-    // It symbolises that this blkid is being read right now
+    BlkReadTracker(const BlkReadTracker&) = delete;
+    BlkReadTracker& operator=(const BlkReadTracker&) = delete;
+    BlkReadTracker(BlkReadTracker&&) noexcept = delete;
+    BlkReadTracker& operator=(BlkReadTracker&&) noexcept = delete;
+
+    uint16_t entries_per_record() const;
+
+#ifdef _PRERELEASE
+    void set_entries_per_record(uint16_t num_entries);
+#endif
+
+    /**
+     * @brief :  Insert the blkid into read tracker. If entry already exists, it will increment the reference count of
+     * the blkid It symbolises that this blkid is being read right now.
+     *
+     * @param blkid : the blkid that is being added for reference;
+     */
     void insert(const BlkId& blkid);
 
-    // Decrement the reference count of the BlkId in this read tracker. If refcount is It symbolises that this blkid is
-    // no-longer being read right now
+    /**
+     * @brief : decrease the reference count of the BlkId by 1 in this read tracker.
+     * If the ref count drops to zero, it means no read is pending on this blkid and if there is a waiter on this blkid,
+     * callback should be trigggered and all entries associated with this blkid (there could be more than one
+     * sub_ranges) should be removed.
+     *
+     * @param blkid : blkid that is being dereferneced;
+     */
     void remove(const BlkId& blkid);
 
-    // Check if the reference count of the blkid is 0 or entry itself doesn't exists. It will optionally callback when
-    // the reference count becomes 0 and the entry is removed
-    bool ensure_no_record(const BlkId& blkid, after_remove_cb_t&& after_remove_cb);
+    /**
+     * @brief : Check if the reference count of the blkid is 0 or entry itself doesn't exists.
+     * It will do the callback if the ref count is zero or the blkid entry doesn't exsit;
+     *
+     * @param blkid : blkid that caller wants to wait on for pending read;
+     * @param after_remove_cb : the callback to be sent after read on this blkid are all completed;
+     */
+    void wait_on(const BlkId& blkid, after_remove_cb_t&& after_remove_cb);
 
-    uint64_t get_size() const { return m_pending_reads_map.get_size(); }
+    /**
+     * @brief : get size of the pending map;
+     *
+     * @return : size of the pending map;
+     */
+    // uint64_t get_size() const { return m_pending_reads_map.get_size(); }
 
 private:
+    /**
+     * @brief
+     *
+     * @param blkid
+     * @param new_ref_count
+     * @param waiters
+     */
     void merge(const BlkId& blkid, int64_t new_ref_count, const std::shared_ptr< blk_track_waiter >& waiters);
 };
 } // namespace homestore

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -35,6 +35,11 @@ if (${build_nonio_tests})
     add_executable(test_mem_btree ${TEST_MEMBTREE_SOURCE_FILES})
     target_link_libraries(test_mem_btree ${COMMON_TEST_DEPS} GTest::gtest)
     add_test(NAME MemBtree COMMAND test_mem_btree)
+
+    add_executable(test_blk_read_tracker)
+    target_sources(test_blk_read_tracker PRIVATE test_blk_read_tracker.cpp ../lib/blkdata_svc/blk_read_tracker.cpp ../lib/blkalloc/blk.cpp)
+    target_link_libraries(test_blk_read_tracker ${COMMON_TEST_DEPS} GTest::gtest)
+    add_test(NAME BlkReadTracker COMMAND test_blk_read_tracker)
 endif()
 
 can_build_io_tests(io_tests)

--- a/src/tests/test_blk_read_tracker.cpp
+++ b/src/tests/test_blk_read_tracker.cpp
@@ -1,0 +1,362 @@
+/*********************************************************************************
+ * Modifications Copyright 2017-2019 eBay Inc.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ *********************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "blkdata_svc/blk_read_tracker.hpp"
+
+using namespace homestore;
+
+SISL_LOGGING_INIT(test_blk_read_tracker)
+SISL_OPTIONS_ENABLE(logging, test_blk_read_tracker)
+
+class BlkReadTrackerTest : public testing::Test {
+public:
+    void init() { m_blk_read_tracker = std::make_unique< BlkReadTracker >(); }
+    std::shared_ptr< BlkReadTracker > get_inst() { return m_blk_read_tracker; }
+
+private:
+    std::shared_ptr< BlkReadTracker > m_blk_read_tracker;
+};
+
+/*
+ * 1. alignment: 16
+ * 2. no overlap insert and remove without any waiter,
+ * */
+TEST_F(BlkReadTrackerTest, TestBaiscInsertRemoveWithNoWaiter) {
+    LOGINFO("Step 0: initialize BlkReadTracker instance. ");
+    init();
+
+    LOGINFO("Step 1: set entries per record to 16");
+    get_inst()->set_entries_per_record(16);
+
+    const uint32_t nblkids = 128;
+    const blk_count_t nblks = 64;
+    blk_num_t start_blk_num{0};
+
+    LOGINFO("Step 2: read {} BlkId (no overlap), with nblks:{} to hash map.", nblkids, nblks);
+    for (uint32_t i = 0; i < nblkids; ++i) {
+        // blk num:
+        // first  : {0, 1, nblks-1},
+        // second : { nblks, nblk+1, ..., 2*nblk -1},
+        // so on so forth;
+        get_inst()->insert(BlkId{start_blk_num, nblks, 0});
+        start_blk_num += nblks;
+    }
+
+    LOGINFO("Step 3: remove {} BlkIds, with nblks {} from hash map.", nblkids, nblks);
+    start_blk_num = 0;
+    for (uint32_t i = 0; i < nblkids; ++i) {
+        get_inst()->remove(BlkId{start_blk_num, nblks, 0});
+        start_blk_num += nblks;
+    }
+}
+
+/*
+ * alignment: 16
+ * */
+TEST_F(BlkReadTrackerTest, TestOverlapInsertThenRemoveWithNoWaiter) {
+    LOGINFO("Step 0: initialize BlkReadTracker instance. ");
+    init();
+
+    LOGINFO("Step 1: set entries per record to 16");
+    get_inst()->set_entries_per_record(16);
+
+    LOGINFO("Step 2: read olverlaped BlkIds to hash map.");
+
+    // insert same BlkId to accumulate ref_cnt;
+    BlkId b{100, 64, 10};
+    get_inst()->insert(b);
+    get_inst()->insert(b);
+    get_inst()->insert(b);
+
+    // different chunk
+    BlkId c{100, 64, 2};
+    get_inst()->insert(c);
+    get_inst()->insert(c);
+
+    get_inst()->remove(b);
+    get_inst()->remove(b);
+    get_inst()->remove(b);
+
+    get_inst()->remove(c);
+    get_inst()->remove(c);
+
+    // differnt BlkId with same base ID (after alignment)
+    get_inst()->insert(BlkId{70, 51, 5});
+    get_inst()->insert(BlkId{72, 50, 5});
+    get_inst()->insert(BlkId{68, 44, 5});
+
+    get_inst()->remove(BlkId{70, 51, 5});
+    get_inst()->remove(BlkId{72, 50, 5});
+    get_inst()->remove(BlkId{68, 44, 5});
+}
+
+/*
+ * waiter overlap with read, but there is no read completes, waiter's cb should NOT be triggered;
+ * */
+TEST_F(BlkReadTrackerTest, TestInsertWithWaiter) {
+    LOGINFO("Step 0: initialize BlkReadTracker instance. ");
+    init();
+
+    BlkId b{16, 20, 0};
+    get_inst()->insert(b);
+
+    bool called{false};
+    get_inst()->wait_on(b, [&called, &b]() {
+        called = true;
+        LOGINFO("wait_on called on blkid: {};", b.to_string());
+    });
+
+    // cb should be called in same thread serving remove;
+    assert(!called);
+
+    // remove the record so that waiter can be destroyed to avoid crash in shared_ptr<BlkTrackRecord>::~shared_ptr on
+    // exit of this test case;
+    get_inst()->remove(b);
+}
+
+/*
+ * free same blkid as read.
+ * free bid callback should be called after read completes
+ * */
+TEST_F(BlkReadTrackerTest, TestInsRmWithWaiterOnSameBid) {
+    LOGINFO("Step 0: initialize BlkReadTracker instance. ");
+    init();
+
+    BlkId b{16, 20, 0};
+    LOGINFO("Step 1: read blkid: {} into hash map.", b.to_string());
+    get_inst()->insert(b);
+
+    bool called{false};
+    LOGINFO("Step 2: free blkid: {} to be completed on reading");
+    get_inst()->wait_on(b, [&called, &b]() {
+        called = true;
+        LOGINFO("wait_on callback triggered on blkid: {};", b.to_string());
+    });
+
+    LOGINFO("Step 3: try to do read completed on blkid: {}. ", b.to_string());
+    get_inst()->remove(b);
+
+    // cb should be called in same thread serving remove;
+    LOGINFO("Step 4: assert that callback is triggered by read complete.");
+    assert(called);
+}
+
+/*
+ * Alignment:16
+ * 1. read-1: {16, 40, 0} // read on two base ids: {16, 16, 0}, {32, 16, 0}, {48, 16, 0}
+ * 2. free: {10, 8, 0, cb1} // across two base ids, {0, 16, 0}, {16, 16, 0} , overlap with read-1 on 2nd base id;
+ * 3. read-2: {64, 8, 0} // read on base id: {64, 16, 0}, which not overlap with free's base id
+ * 4. read-2: complete;  // callback of free should not be triggered
+ * 5. read-1 complete;  // callback of free should be triggered;
+ *
+ * free cb1 should be called only after read-1 completes;
+ * */
+TEST_F(BlkReadTrackerTest, TestInsRmeWithWaiterOverlapOneRead) {
+    LOGINFO("Step 0: initialize BlkReadTracker instance. ");
+    init();
+
+    auto align = 16ul;
+    LOGINFO("Step 1: set entries per record to {}.", align);
+    get_inst()->set_entries_per_record(align);
+
+    BlkId b{16, 40, 0};
+    LOGINFO("Step 2: read on blkid: {}. ", b.to_string());
+    get_inst()->insert(b);
+
+    bool called{false};
+    BlkId free_bid{10, 8, 0};
+    LOGINFO("Step 3: free blkid: {}.", free_bid);
+    get_inst()->wait_on(free_bid, [&called, &free_bid]() {
+        called = true;
+        LOGINFO("wait_on callback triggered on blkid: {}.", free_bid.to_string());
+    });
+
+    BlkId c{64, 8, 0};
+    LOGINFO("Step 4: read on blkid: {}.", c.to_string());
+    get_inst()->insert(c);
+
+    LOGINFO("Step 5a: read on blkid: {} completed.", c.to_string());
+    get_inst()->remove(c);
+
+    LOGINFO("Step 5b: assert callback on free_bid should NOT be triggered.");
+    assert(!called);
+
+    LOGINFO("Step 6a: read on blkid: {} completed. ", b.to_string());
+    get_inst()->remove(b);
+
+    LOGINFO("Step 6b: assert callback should be triggered");
+    assert(called);
+}
+
+/*
+ *  Alignment: 16
+ *  Read-1, free-blk, Read-2
+ *
+ *  1. Read-1: {35, 20, 0}, covers two base ids: {32, 16, 0}, {48, 16, 0}
+ *  2. free: {36, 2, 0}, covers base id: {32, 16, 0}
+ *  3. Read-2: {40, 5, 0} covers same base id as free {32, 16, 0}
+ *  4. Read-2 completes // <<< free cb should not be triggered
+ *  5. Read-1 completes // <<< free cb should be triggered
+ * */
+TEST_F(BlkReadTrackerTest, TestInsRmWithWaiterOverlapMultiReads0) {
+    LOGINFO("Step 0: initialize BlkReadTracker instance. ");
+    init();
+
+    auto align = 16ul;
+    LOGINFO("Step 1: set entries per record to {}.", align);
+    get_inst()->set_entries_per_record(align);
+
+    BlkId b{35, 20, 0};
+    LOGINFO("Step 2: read 1 blkid: {}.", b.to_string());
+    get_inst()->insert(b);
+
+    BlkId free_bid{36, 2, 0};
+    LOGINFO("Step 3: free blkid: {}.", free_bid.to_string());
+    bool called{false};
+    get_inst()->wait_on(free_bid, [&free_bid, &called]() {
+        called = true;
+        LOGINFO("wait on callback triggered on blkid: {}", free_bid.to_string());
+    });
+
+    BlkId c{40, 5, 0};
+    LOGINFO("Step 4: read 2 blkid: {}.", c.to_string());
+    get_inst()->insert(c);
+
+    LOGINFO("Step 5: read 2 completes");
+    get_inst()->remove(c);
+
+    LOGINFO("Step 5a: assert callback should NOT be triggered.");
+    assert(!called);
+
+    LOGINFO("Step 6: read 1 completes");
+    get_inst()->remove(b);
+
+    LOGINFO("Step 6a: assert callback should be triggered.");
+    assert(called);
+}
+
+/*
+ * Alignment: 8
+ * Waiter overlap with two read base ids, waiter cb to be called after both read completes
+ *
+ * 1. Read-1: {35, 12, 1}, covers two base id: {32, 8, 1}, {40, 8, 1}
+ * 2. Read-2: {50, 16, 1}, covers three base ids: {48, 8, 1}, {56, 8, 1}, {64, 8, 1}
+ * 3. free: {44, 6, 1}, covers two base id: {40, 8, 1}, {48, 8, 1}
+ * 4, Read-1 completes; // free cb should NOT be triggered;
+ * 5. Read-2 completes; // free cb should be triggered;
+ * */
+TEST_F(BlkReadTrackerTest, TestInsRmWithWaiterOverlapMultiReads1) {
+    LOGINFO("Step 0: initialize BlkReadTracker instance. ");
+    init();
+
+    auto align = 8ul;
+    LOGINFO("Step 1: set entries per record to {}.", align);
+    get_inst()->set_entries_per_record(align);
+
+    // Read-1 covers two base id: {32, 8, 1}, {40, 8, 1}
+    BlkId b{35, 12, 1};
+    LOGINFO("Step 2: read 1 blkid: {}. ", b.to_string());
+    get_inst()->insert(b);
+
+    // Read-2 covers three base ids: {48, 8, 1}, {56, 8, 1}, {64, 8, 0}
+    BlkId c{48, 16, 1};
+    LOGINFO("Step 3: read 2 blkid: {}. ", c.to_string());
+    get_inst()->insert(c);
+
+    // free blk wait on two base ids: {40, 8, 1}, {48, 8, 1}
+    BlkId free_bid{44, 6, 1};
+    bool called{false};
+    LOGINFO("Step 4: free blkid: {}.", free_bid);
+    get_inst()->wait_on(free_bid, [&free_bid, &called]() {
+        called = true;
+        LOGINFO("wait_on callback triggered on blkid: {}", free_bid.to_string());
+    });
+
+    LOGINFO("Step 5a: read complete on blkid: {}", b.to_string());
+    get_inst()->remove(b);
+
+    LOGINFO("Step 5b: assert callback not triggered yet.");
+    assert(!called);
+
+    LOGINFO("Step 6a: read complete on blkid: {}", c.to_string());
+    get_inst()->remove(c);
+
+    LOGINFO("Step 6b: assert that callback is triggered by read completes");
+    assert(called);
+}
+
+/*
+ * Alignment: 16
+ * 1. read-1: {16, 40, 0} // read on base ids: {16, 16, 0}, {32, 16, 0}, {48, 16, 0}
+ * 2. free: {10, 8, 0, cb1} // across two base ids, {0, 16, 0}, {16, 16, 0}
+ * 3. read-2: {5, 4, 0} // read on base id {0, 16, 0}, which overlap free's base id, but actual block is not
+ * overlapping;
+ * 4. read-1 completes // callback of free should be called, even though read-2 is not completed yet;
+ * 5. read-2 completes
+ * Note: read should never olverap with unfinished free blkid; read-2 is not vialating this rule;
+ *
+ * free cb1 should only wait on read-1 to completes, read-2 should not block free;
+ * */
+TEST_F(BlkReadTrackerTest, TestInsRmWithWaiterOverlapMultiReads2) {
+    LOGINFO("Step 0: initialize BlkReadTracker instance. ");
+    init();
+
+    auto align = 16ul;
+    LOGINFO("Step 1: set entries per record to {}.", align);
+    get_inst()->set_entries_per_record(align);
+
+    BlkId b{16, 40, 0};
+    LOGINFO("Step 2: read-1 on blkid: {}. ", b.to_string());
+    get_inst()->insert(b);
+
+    BlkId free_bid{10, 8, 0};
+    LOGINFO("Step 3: free on blkid: {}. ", free_bid.to_string());
+    bool called{false};
+    get_inst()->wait_on(free_bid, [&free_bid, &called]() {
+        called = true;
+        LOGINFO("wait on callback triggered on free_bid: {}", free_bid.to_string());
+    });
+
+    BlkId c{5, 4, 0};
+    LOGINFO("Step 4: read-2 on blkid: {}.", c.to_string());
+    get_inst()->insert(c);
+
+    LOGINFO("Step 5a: read-1 completed on blkid: {}.", b.to_string());
+    get_inst()->remove(b);
+
+    LOGINFO("Step 5b: assert free blk callback should be triggered");
+    assert(called);
+
+    LOGINFO("Step 6: read-2 completed on blkid: {}.", c.to_string());
+    get_inst()->remove(c);
+}
+
+SISL_OPTION_GROUP(test_blk_read_tracker,
+                  (num_threads, "", "num_threads", "number of threads",
+                   ::cxxopts::value< uint32_t >()->default_value("2"), "number"));
+
+int main(int argc, char* argv[]) {
+    int parsed_argc{argc};
+    ::testing::InitGoogleTest(&parsed_argc, argv);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, test_blk_read_tracker);
+    sisl::logging::SetLogger("test_blk_read_tracker");
+    spdlog::set_pattern("[%D %T%z] [%^%l%$] [%n] [%t] %v");
+
+    const auto ret{RUN_ALL_TESTS()};
+    return ret;
+}


### PR DESCRIPTION
BlkReadTracker implementation.

BlkId will be aligned before we merge them into hash map, this simplifies the implementation by without need to handle the sub ranges of blkids;

Unit test all passed. 