### PR TITLE
Read before flush and device truncation fix

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.0.2"
+    version = "4.0.3"
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")

--- a/src/lib/logstore/log_dev.cpp
+++ b/src/lib/logstore/log_dev.cpp
@@ -124,6 +124,7 @@ void LogDev::stop() {
     m_pending_flush_size.store(0);
     m_is_flushing.store(false);
     m_last_flush_idx = -1;
+    m_last_flush_dev_offset = 0;
     m_last_truncate_idx = -1;
     m_last_crc = INVALID_CRC32_VALUE;
     if (m_block_flush_q != nullptr) {
@@ -199,6 +200,7 @@ void LogDev::do_load(const off_t device_cursor) {
     // Update the tail offset with where we finally end up loading, so that new append entries can be written from
     // here.
     m_vdev->update_tail_offset(group_dev_offset);
+    m_last_flush_dev_offset = group_dev_offset;
 }
 
 void LogDev::assert_next_pages(log_stream_reader& lstream) {
@@ -458,7 +460,8 @@ void LogDev::on_flush_completion(LogGroup* lg) {
 
     m_log_records->complete(lg->m_flush_log_idx_from, lg->m_flush_log_idx_upto);
     m_last_flush_idx = lg->m_flush_log_idx_upto;
-    const auto flush_ld_key = logdev_key{m_last_flush_idx, lg->m_log_dev_offset + lg->header()->total_size()};
+    m_last_flush_dev_offset = lg->m_log_dev_offset + lg->header()->total_size();
+    const auto flush_ld_key = logdev_key{m_last_flush_idx, m_last_flush_dev_offset};
     m_last_crc = lg->header()->cur_grp_crc;
 
     auto from_indx = lg->m_flush_log_idx_from;
@@ -586,6 +589,7 @@ void LogDev::rollback(logstore_id_t store_id, logid_range_t id_range) {
 void LogDev::get_status(const int verbosity, nlohmann::json& js) const {
     js["current_log_idx"] = m_log_idx.load(std::memory_order_relaxed);
     js["last_flush_log_idx"] = m_last_flush_idx;
+    js["last_flush_dev_offset"] = m_last_flush_dev_offset;
     js["last_truncate_log_idx"] = m_last_truncate_idx;
     js["time_since_last_log_flush_ns"] = get_elapsed_time_ns(m_last_flush_time);
     if (verbosity == 2) {

--- a/src/lib/logstore/log_dev.hpp
+++ b/src/lib/logstore/log_dev.hpp
@@ -745,6 +745,7 @@ public:
     }
 
     uint64_t get_flush_size_multiple() const { return m_flush_size_multiple; }
+    logdev_key get_last_flush_ld_key() const { return logdev_key{m_last_flush_idx, m_last_flush_dev_offset}; }
 
     LogDevMetadata& log_dev_meta() { return m_logdev_meta; }
     static bool can_flush_in_this_thread();
@@ -789,7 +790,8 @@ private:
     std::multimap< logid_t, logstore_id_t > m_garbage_store_ids;
     Clock::time_point m_last_flush_time;
 
-    logid_t m_last_flush_idx{-1}; // Track last flushed and truncated log idx
+    logid_t m_last_flush_idx{-1}; // Track last flushed, last device offset and truncated log idx
+    off_t m_last_flush_dev_offset{0};
     logid_t m_last_truncate_idx{-1};
 
     crc32_t m_last_crc{INVALID_CRC32_VALUE};

--- a/src/lib/logstore/log_dev.hpp
+++ b/src/lib/logstore/log_dev.hpp
@@ -90,7 +90,6 @@ struct serialized_log_record {
 
 /* This structure represents the in-memory representation of a log record */
 struct log_record {
-    serialized_log_record* pers_record{nullptr};
     sisl::io_blob data;
     void* context;
     logstore_id_t store_id;

--- a/src/lib/logstore/log_store.cpp
+++ b/src/lib/logstore/log_store.cpp
@@ -118,6 +118,16 @@ logstore_seq_num_t HomeLogStore::append_async(const sisl::io_blob& b, void* cook
 }
 
 log_buffer HomeLogStore::read_sync(logstore_seq_num_t seq_num) {
+    // If seq_num has not been flushed yet, but issued, then we flush them before reading
+    auto const s = m_records.status(seq_num);
+    if (s.is_out_of_range || s.is_hole) {
+        THIS_LOGSTORE_LOG(DEBUG, "ld_key not valid {}", seq_num);
+        throw std::out_of_range("key not valid");
+    } else if (!s.is_completed) {
+        THIS_LOGSTORE_LOG(TRACE, "Reading lsn={}:{} before flushed, doing flush first", m_store_id, seq_num);
+        flush_sync(seq_num);
+    }
+
     const auto record = m_records.at(seq_num);
     const logdev_key ld_key = record.m_dev_key;
     if (!ld_key.is_valid()) {
@@ -130,7 +140,7 @@ log_buffer HomeLogStore::read_sync(logstore_seq_num_t seq_num) {
                       ld_key.idx, ld_key.dev_offset);
     COUNTER_INCREMENT(m_metrics, logstore_read_count, 1);
     serialized_log_record header;
-    const auto b{m_logdev.read(ld_key, header)};
+    const auto b = m_logdev.read(ld_key, header);
     HISTOGRAM_OBSERVE(m_metrics, logstore_read_latency, get_elapsed_time_us(start_time));
     return b;
 }


### PR DESCRIPTION
2 changes in this PR:
1. There are use cases where read on logstore for a seq_num to return valid value even if those entries are not flushed. This is done by flushing the data if seq_num is not already flushed and then read from the persistent store. Alternative to that would be to read from cache, which would be more performant. However, this could cause a scenario where read could give different result before and after flush. (Thanks @yamingk for pointing that out)
2. There is an issue where if a logstore is created, appended with logs but it has not truncated ever, logdevice truncate (which truncates on least log_id of all logstore) doesn't truncate until the said logstore actually calls truncation. While this is not a huge issue as it is expected that all logstores should call truncate at some point, one can see lots of corner cases. This is fixed by setting the logdev upon first insertion.