### PR TITLE
SDSTOR-9070 fix the crash loop during

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -5,6 +5,7 @@ LABEL description="Automated HomeStore compilation"
 WORKDIR /output
 
 RUN set -eux; \
+    sed -i 's/master/latest/g' /etc/apt/sources.list \
     apt-get update; \
     apt-get upgrade -y; \
     apt-get install iputils-ping; \

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -95,7 +95,7 @@ pipeline {
                     }
                     axis {
                         name 'SANITIZE'
-                        values 'False', 'True'
+                        values 'False'
                     }
                     axis {
                         name 'COVERAGE'

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "2.7.35"
+    version = "2.7.36"
 
     revision_mode = "scm"
     license = "Proprietary"

--- a/src/engine/common/homestore_config.fbs
+++ b/src/engine/common/homestore_config.fbs
@@ -109,7 +109,7 @@ table Generic {
     // writeback cache flush threads
     cache_flush_threads : int32 = 1;
 
-    cp_watchdog_timer_sec : uint32 = 10; // it checks if cp stuck every 10 seconds
+    cp_watchdog_timer_sec : uint32 = 30; // it checks if cp stuck every 10 seconds
 
     cache_max_throttle_cnt : uint64 = 4; // writeback cache max q depth
 

--- a/src/engine/common/homestore_config.fbs
+++ b/src/engine/common/homestore_config.fbs
@@ -109,7 +109,7 @@ table Generic {
     // writeback cache flush threads
     cache_flush_threads : int32 = 1;
 
-    cp_watchdog_timer_sec : uint32 = 30; // it checks if cp stuck every 10 seconds
+    cp_watchdog_timer_sec : uint32 = 30; // it checks if cp stuck every 30 seconds
 
     cache_max_throttle_cnt : uint64 = 4; // writeback cache max q depth
 

--- a/src/engine/meta/meta_blks_mgr.cpp
+++ b/src/engine/meta/meta_blks_mgr.cpp
@@ -766,6 +766,8 @@ void MetaBlkMgr::update_sub_sb(const void* const context_data, const uint64_t sz
     if (it->second.do_crc) { crc = crc32_ieee(init_crc32, static_cast< const uint8_t* >(context_data), sz); }
 #endif
 
+    // set inital compressed state as false, because it might be compressed in previous write;
+    mblk->hdr.h.compressed = 0;
     mblk->hdr.h.ovf_bid.invalidate();
     mblk->hdr.h.gen_cnt += 1;
 


### PR DESCRIPTION
The root cause of the 2nd crash:
1. it happens when disk drives start from a clean state to a very fragmented state, in which the bitmap initially is compressed and upto some point, it becomes uncompressed (when compression ration doesn’t meet limit).
2. the size we set it blk header will still be pointing to compressed size, but real data written is the original one.
3. when we boot up, all the data is read out from disk is intact, but header size doesn’t match and trigger the crash.
