### PR TITLE
SDSTOR-xxxx add new test case to fix bad data during upgrade

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.5.17"
+    version = "3.5.18"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/api/meta_interface.hpp
+++ b/src/api/meta_interface.hpp
@@ -339,6 +339,7 @@ private:
     [[nodiscard]] uint64_t get_max_compress_memory_size() const;
     [[nodiscard]] uint64_t get_init_compress_memory_size() const;
     [[nodiscard]] uint32_t get_compress_ratio_limit() const;
+    [[nodiscard]] bool get_skip_hdr_check() const;
     [[nodiscard]] bool compress_feature_on() const;
 
     [[nodiscard]] nlohmann::json get_status(const int log_level);

--- a/src/engine/common/homestore_config.fbs
+++ b/src/engine/common/homestore_config.fbs
@@ -169,6 +169,9 @@ table MetaBlkStore {
     // turn on/off compression feature 
     compress_feature_on : bool = true (hotswap);
 
+    // turn on/off skip header check
+    skip_header_size_check : bool = false (hotswap);
+
     // Compress buffer larger than this memory limit in MB will not trigger compress; 
     max_compress_memory_size_mb: uint32 = 512 (hotswap);
     

--- a/src/engine/meta/meta_blks_mgr.cpp
+++ b/src/engine/meta/meta_blks_mgr.cpp
@@ -337,7 +337,7 @@ bool MetaBlkMgr::scan_and_load_meta_blks(meta_blk_map_t& meta_blks, ovf_hdr_map_
             // we are here because we write uncompressed data, but left compressed field as true and context_sz still
             // setting to compressed size;
 
-            if (HS_DYNAMIC_CONFIG(metablk.skip_header_size_check) == false) {
+            if (!(HS_DYNAMIC_CONFIG(metablk.skip_header_size_check))) {
                 HS_REL_ASSERT_EQ(read_sz, static_cast< uint64_t >(mblk->hdr.h.context_sz),
                                  "[type={}], total size read: {} mismatch from meta blk context_sz: {}",
                                  mblk->hdr.h.type, read_sz, mblk->hdr.h.context_sz);

--- a/src/engine/meta/meta_blks_mgr.cpp
+++ b/src/engine/meta/meta_blks_mgr.cpp
@@ -331,9 +331,27 @@ bool MetaBlkMgr::scan_and_load_meta_blks(meta_blk_map_t& meta_blks, ovf_hdr_map_
             obid = ovf_hdr->h.next_bid;
         }
 
-        HS_REL_ASSERT_EQ(read_sz, static_cast< uint64_t >(mblk->hdr.h.context_sz),
-                         "[type={}], total size read: {} mismatch from meta blk context_sz: {}", mblk->hdr.h.type,
-                         read_sz, mblk->hdr.h.context_sz);
+        if (read_sz != static_cast< uint64_t >(mblk->hdr.h.context_sz)) {
+            LOGERROR("[type={}], total size read: {} mismatch from meta blk context_sz: {}", mblk->hdr.h.type, read_sz,
+                     mblk->hdr.h.context_sz);
+            // we are here because we write uncompressed data, but left compressed field as true and context_sz still
+            // setting to compressed size;
+
+            if (HS_DYNAMIC_CONFIG(metablk.skip_header_size_check) == false) {
+                HS_REL_ASSERT_EQ(read_sz, static_cast< uint64_t >(mblk->hdr.h.context_sz),
+                                 "[type={}], total size read: {} mismatch from meta blk context_sz: {}",
+                                 mblk->hdr.h.type, read_sz, mblk->hdr.h.context_sz);
+            }
+
+            LOGINFO("[type={}], fixing mblk's context_sz from {} to read_sz: {}", mblk->hdr.h.type,
+                    mblk->hdr.h.context_sz, read_sz);
+
+            // upgrade fix: needed for fixing bad data during upgrade;
+            mblk->hdr.h.compressed = 0;
+            mblk->hdr.h.context_sz = read_sz;
+        } else {
+            LOGINFO("[type={}], meta blk size check passed!", mblk->hdr.h.type);
+        }
 
         // move on to next meta blk;
         bid = mblk->hdr.h.next_bid;
@@ -786,8 +804,18 @@ void MetaBlkMgr::update_sub_sb(const void* context_data, const uint64_t sz, void
     if (it->second.do_crc) { crc = crc32_ieee(init_crc32, static_cast< const uint8_t* >(context_data), sz); }
 #endif
 
+#ifdef _PRERELEASE
+    auto old_compressed_val = mblk->hdr.h.compressed;
+#endif
+
     // init compression field to be false;
     mblk->hdr.h.compressed = 0;
+
+#ifdef _PRERELEASE
+    // simulate without above fix to generate bad data written to disk (to test recover from bad data);
+    if (HomeStoreFlip::instance()->test_flip("without_compress_init")) { mblk->hdr.h.compressed = old_compressed_val; }
+#endif
+
     mblk->hdr.h.ovf_bid.invalidate();
     mblk->hdr.h.gen_cnt += 1;
 
@@ -1211,6 +1239,8 @@ uint64_t MetaBlkMgr::get_meta_size(const void* cookie) const {
 }
 
 bool MetaBlkMgr::compress_feature_on() const { return HS_DYNAMIC_CONFIG(metablk.compress_feature_on); }
+
+bool MetaBlkMgr::get_skip_hdr_check() const { return HS_DYNAMIC_CONFIG(metablk.skip_header_size_check); }
 
 uint64_t MetaBlkMgr::get_min_compress_size() const {
     return HS_DYNAMIC_CONFIG(metablk.min_compress_size_mb) * static_cast< uint64_t >(1024) * 1024;

--- a/src/engine/meta/test_meta_blk_mgr.cpp
+++ b/src/engine/meta/test_meta_blk_mgr.cpp
@@ -626,6 +626,7 @@ protected:
                                 [this](bool success) { HS_DBG_ASSERT_EQ(success, true); });
     }
 
+#ifdef _PRERELEASE
     void set_flip_point(const std::string flip_name) {
         FlipCondition null_cond;
         FlipFrequency freq;
@@ -634,6 +635,7 @@ protected:
         m_fc.inject_noreturn_flip(flip_name, {null_cond}, freq);
         LOGDEBUG("Flip " + flip_name + " set");
     }
+#endif
 
 private:
     uint64_t m_wrt_cnt{0};

--- a/src/engine/meta/test_meta_blk_mgr.cpp
+++ b/src/engine/meta/test_meta_blk_mgr.cpp
@@ -645,7 +645,9 @@ private:
     std::map< uint64_t, sb_info_t > m_write_sbs; // during write, save blkid to buf map;
     std::map< uint64_t, std::string > m_cb_blks; // during recover, save blkid to buf map;
     std::mutex m_mtx;
+#ifdef _PRERELEASE
     FlipClient m_fc{HomeStoreFlip::instance()};
+#endif
 };
 
 static constexpr uint64_t MIN_DRIVE_SIZE{2147483648}; // 2 GB
@@ -712,6 +714,7 @@ TEST_F(VMetaBlkMgrTest, random_load_test) {
     this->shutdown();
 }
 
+#ifdef _PRERELEASE // release build doens't have flip point
 //
 // 1. Turn on flip to simulate fix is not there;
 // 2. Write compressed then uncompressed to reproduce the issue which ends up writing bad data (hdr size mismatch) to
@@ -760,6 +763,7 @@ TEST_F(VMetaBlkMgrTest, RecoveryFromBadData) {
 
     this->shutdown();
 }
+#endif
 
 TEST_F(VMetaBlkMgrTest, CompressionBackoff) {
     start_homestore(1, MIN_DRIVE_SIZE, gp.num_threads);

--- a/src/test_scripts/vol_test.py
+++ b/src/test_scripts/vol_test.py
@@ -325,6 +325,12 @@ def vdev_nightly():
 
 def meta_blk_store_nightly():
     print("meta blk store test started")
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.CompressionBackoff"
+    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
+    
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.RecoveryFromBadData"
+    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
+
     cmd_opts = "--gtest_filter=VMetaBlkMgrTest.min_drive_size_test"
     subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
 


### PR DESCRIPTION
1. added a new test case to simulate prod issue that bad data is written to disk and upgrade to a new image with the fix and verify bad data can be recovered;
2. added a flip point to turn on/off the fix, so that we can generate bad data without the fix
3. Testing steps can be found in test case
4. add to nightly test

Test passed by running the meta blkstore nightly script locally.

Update: 2/8: Jenkinds PR build passed.