### PR TITLE
SDSTOR-9207 : concurrent btree operations unit tests

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -155,7 +155,7 @@ pipeline {
                                     sh "mv /root/.conan/data/homestore ."
                                     sh "find . -name *_log -print | xargs tar cif logs.tar"
                                 }
-                                archiveArtifacts artifacts: "logs.tar", fingerprint: true
+                                archiveArtifacts artifacts: "*logs.tar", fingerprint: false
                             }
                         }
                     }

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.0.9"
+    version = "4.0.10"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.0.10"
+    version = "4.0.11"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/btree/btree.hpp
+++ b/src/include/homestore/btree/btree.hpp
@@ -97,6 +97,7 @@ public:
     virtual std::pair< btree_status_t, uint64_t > destroy_btree(void* context);
     nlohmann::json get_status(int log_level) const;
     void print_tree() const;
+    void print_tree_keys() const;
     nlohmann::json get_metrics_in_json(bool updated = true);
 
     // static void set_io_flip();
@@ -162,6 +163,7 @@ protected:
     uint64_t get_btree_node_cnt() const;
     uint64_t get_child_node_cnt(bnodeid_t bnodeid) const;
     void to_string(bnodeid_t bnodeid, std::string& buf) const;
+    void to_string_keys(bnodeid_t bnodeid, std::string& buf) const;
     void validate_sanity_child(const BtreeNodePtr& parent_node, uint32_t ind) const;
     void validate_sanity_next_child(const BtreeNodePtr& parent_node, uint32_t ind) const;
     void print_node(const bnodeid_t& bnodeid) const;

--- a/src/include/homestore/btree/btree.ipp
+++ b/src/include/homestore/btree/btree.ipp
@@ -328,6 +328,16 @@ void Btree< K, V >::print_tree() const {
 }
 
 template < typename K, typename V >
+void Btree< K, V >::print_tree_keys() const {
+    std::string buf;
+    m_btree_lock.lock_shared();
+    to_string_keys(m_root_node_info.bnode_id(), buf);
+    m_btree_lock.unlock_shared();
+
+    BT_LOG(INFO, "Pre order traversal of tree:\n<{}>", buf);
+}
+
+template < typename K, typename V >
 nlohmann::json Btree< K, V >::get_metrics_in_json(bool updated) {
     return m_metrics.get_result_in_json(updated);
 }

--- a/src/include/homestore/btree/detail/btree_internal.hpp
+++ b/src/include/homestore/btree/detail/btree_internal.hpp
@@ -223,7 +223,8 @@ struct BtreeConfig {
     uint8_t m_suggested_min_pct{30};
     uint8_t m_split_pct{50};
     uint32_t m_max_merge_nodes{3};
-    uint32_t m_rebalance_turned_on{false};
+    bool m_rebalance_turned_on{false};
+    bool m_merge_turned_on{false};
 
     btree_node_type m_leaf_node_type{btree_node_type::VAR_OBJECT};
     btree_node_type m_int_node_type{btree_node_type::VAR_KEY};

--- a/src/include/homestore/btree/detail/btree_node.hpp
+++ b/src/include/homestore/btree/detail/btree_node.hpp
@@ -464,6 +464,7 @@ public:
     virtual uint32_t move_in_from_right_by_size(const BtreeConfig& cfg, BtreeNode& other_node, uint32_t size) = 0;*/
     virtual uint32_t available_size(const BtreeConfig& cfg) const = 0;
     virtual std::string to_string(bool print_friendly = false) const = 0;
+    virtual std::string to_string_keys(bool print_friendly = false) const = 0;
     virtual void get_nth_value(uint32_t ind, BtreeValue* out_val, bool copy) const = 0;
     virtual void get_nth_key_internal(uint32_t ind, BtreeKey& out_key, bool copykey) const = 0;
 

--- a/src/include/homestore/btree/detail/btree_remove_impl.ipp
+++ b/src/include/homestore/btree/detail/btree_remove_impl.ipp
@@ -390,20 +390,20 @@ btree_status_t Btree< K, V >::merge_nodes(const BtreeNodePtr& parent_node, const
     // doing a dry run and if for some reason there is a problem in balancing the nodes, then it is easy to give up.
     available_size = balanced_size - leftmost_node->occupied_size(m_bt_cfg);
     src_cursor.ith_node = old_nodes.size();
-    for (uint32_t i{0}; (i < old_nodes.size()) && (available_size >= 0); ++i) {
+    for (uint32_t i{0}; (i < old_nodes.size()); ++i) {
         leftmost_src.ith_nodes.push_back(i);
         // TODO: check whether value size of the node is greater than available_size? If so nentries is 0. Suppose if a
         // node contains one entry and the value size is much bigger than available size
         auto const nentries = old_nodes[i]->num_entries_by_size(0, available_size);
         if ((old_nodes[i]->total_entries() - nentries) == 0) { // Entire node goes in
             available_size -= old_nodes[i]->occupied_size(m_bt_cfg);
-            // we reach the end so the "else" statement gets no chance to run
             if (i >= old_nodes.size() - 1) {
                 src_cursor.ith_node = i + 1;
                 src_cursor.nth_entry = std::numeric_limits< uint32_t >::max();
                 leftmost_src.last_node_upto = nentries;
                 BT_NODE_LOG(DEBUG, parent_node, "MERGE: no new nodes is supposed to be created");
             }
+            // we reach the end so the "else" statement gets no chance to run
         } else {
             src_cursor.ith_node = i;
             src_cursor.nth_entry = nentries;
@@ -455,7 +455,7 @@ btree_status_t Btree< K, V >::merge_nodes(const BtreeNodePtr& parent_node, const
             post_merge_size += old_node->get_nth_obj_size(
                 std::min(leftmost_src.last_node_upto, old_node->total_entries() - 1)); // New leftmost entry
         }
-        post_merge_size -= parent_node->get_nth_obj_size(start_idx); // Previous left entry
+        post_merge_size -= parent_node->get_nth_obj_size(start_idx);                   // Previous left entry
 
         for (auto& node : new_nodes) {
             if (node->total_entries()) { post_merge_size += node->get_nth_obj_size(node->total_entries() - 1); }

--- a/src/include/homestore/btree/detail/btree_remove_impl.ipp
+++ b/src/include/homestore/btree/detail/btree_remove_impl.ipp
@@ -21,6 +21,7 @@ template < typename K, typename V >
 template < typename ReqT >
 btree_status_t Btree< K, V >::do_remove(const BtreeNodePtr& my_node, locktype_t curlock, ReqT& req) {
     btree_status_t ret = btree_status_t::success;
+    btree_status_t at_least_one_child_modified = btree_status_t::not_found;
     if (my_node->is_leaf()) {
         BT_NODE_DBG_ASSERT_EQ(curlock, locktype_t::WRITE, my_node);
 
@@ -36,16 +37,20 @@ btree_status_t Btree< K, V >::do_remove(const BtreeNodePtr& my_node, locktype_t 
             if (req.next_key().is_extent_key()) {
                 modified = remove_extents_in_leaf(my_node, req);
             } else {
-                auto& subrange = req.current_sub_range();
-                auto const [start_found, start_idx] = my_node->find(subrange.start_key(), nullptr, false);
-                auto [end_found, end_idx] = my_node->find(subrange.end_key(), nullptr, false);
-                if (end_found) { ++end_idx; }
-                for (auto idx{start_idx}; idx < end_idx; ++idx) {
-                    call_on_remove_kv_cb(my_node, idx, req);
-                    my_node->remove(idx);
-                    modified = true;
+                if (my_node->total_entries()) {
+                    auto& subrange = req.working_range();
+                    auto const [start_found, start_idx] = my_node->find(subrange.start_key(), nullptr, false);
+                    auto [end_found, end_idx] = my_node->find(subrange.end_key(), nullptr, false);
+                    if (end_found) { ++end_idx; }
+
+                    removed_count = end_idx - start_idx;
+                    for (uint32_t count = 0; count < removed_count; ++count) {
+                        call_on_remove_kv_cb(my_node, start_idx, req);
+                        // since start_idx is getting updated, always call remove_start_idx
+                        my_node->remove(start_idx);
+                        modified = true;
+                    }
                 }
-                removed_count = end_idx - start_idx;
             }
         } else if constexpr (std::is_same_v< ReqT, BtreeRemoveAnyRequest< K > >) {
             if ((modified = my_node->remove_any(req.m_range, req.m_outkey.get(), req.m_outval.get()))) {
@@ -64,6 +69,7 @@ btree_status_t Btree< K, V >::do_remove(const BtreeNodePtr& my_node, locktype_t 
         return modified ? btree_status_t::success : btree_status_t::not_found;
     }
 
+    bool go_to_out = false;
 retry:
     locktype_t child_cur_lock = locktype_t::NONE;
     uint32_t curr_idx;
@@ -76,15 +82,20 @@ retry:
         ASSERT_IS_VALID_INTERIOR_CHILD_INDX(found, idx, my_node);
         end_idx = start_idx = idx;
     } else if constexpr (std::is_same_v< ReqT, BtreeRangeRemoveRequest< K > >) {
-        const auto count = my_node->template get_all< V >(req.next_range(), UINT32_MAX, start_idx, end_idx);
-        BT_NODE_REL_ASSERT_NE(count, 0, my_node, "get_all returns 0 entries for interior node is not valid pattern");
+        const auto count = my_node->template get_all< K, V >(req.next_range(), UINT32_MAX, start_idx, end_idx);
+        if (!count) {
+            ret = btree_status_t::not_found;
+            go_to_out = true;
+        }
+        //        BT_NODE_REL_ASSERT_NE(count, 0, my_node, "get_all returns 0 entries for interior node is not valid
+        //        pattern");
 
     } else if constexpr (std::is_same_v< ReqT, BtreeRemoveAnyRequest< K > >) {
         const auto count = my_node->template get_all< V >(req.m_range, UINT32_MAX, start_idx, end_idx);
         BT_NODE_REL_ASSERT_NE(count, 0, my_node, "get_all returns 0 entries for interior node is not valid pattern");
         end_idx = start_idx = (end_idx - start_idx) / 2; // Pick the middle, TODO: Ideally we need to pick random
     }
-
+    if (go_to_out) { goto out_return; }
     curr_idx = start_idx;
     while (curr_idx <= end_idx) {
         BtreeLinkInfo child_info;
@@ -129,6 +140,11 @@ retry:
                     COUNTER_INCREMENT(m_metrics, btree_merge_count, 1);
                     goto retry;
                 }
+
+                if (ret == btree_status_t::merge_not_required) {
+                    BT_NODE_LOG(DEBUG, my_node, "merge is not required for child = {} keys: {}", curr_idx,
+                                child_node->to_string_keys());
+                }
             }
         }
 
@@ -143,7 +159,7 @@ retry:
                     is_inp_key_lesser ? req.input_range().is_end_inclusive() : true);
 
                 BT_NODE_LOG(DEBUG, my_node, "Subrange:idx=[{}-{}],c={},working={}", start_idx, end_idx, curr_idx,
-                            req.current_range().to_string());
+                            req.working_range().to_string());
             }
         }
 
@@ -170,14 +186,15 @@ retry:
         }
 
         ret = do_remove(child_node, child_cur_lock, req);
-        if (ret != btree_status_t::success) { break; }
+        if (ret == btree_status_t::success) { at_least_one_child_modified = btree_status_t::success; }
         ++curr_idx;
     }
 
+out_return:
     // Warning: Do not access childNode or myNode beyond this point, since it would
     // have been unlocked by the recursive function and it could also been deleted.
     if (curlock != locktype_t::NONE) { unlock_node(my_node, curlock); }
-    return ret;
+    return (at_least_one_child_modified == btree_status_t::success) ? btree_status_t::success : ret;
 }
 
 template < typename K, typename V >
@@ -304,6 +321,7 @@ done:
 template < typename K, typename V >
 btree_status_t Btree< K, V >::merge_nodes(const BtreeNodePtr& parent_node, const BtreeNodePtr& leftmost_node,
                                           uint32_t start_idx, uint32_t end_idx, void* context) {
+    if (!m_bt_cfg.m_merge_turned_on) { return btree_status_t::merge_not_required; }
     btree_status_t ret{btree_status_t::success};
     folly::small_vector< BtreeNodePtr, 3 > old_nodes;
     folly::small_vector< BtreeNodePtr, 3 > new_nodes;
@@ -323,6 +341,7 @@ btree_status_t Btree< K, V >::merge_nodes(const BtreeNodePtr& parent_node, const
         uint32_t nth_entry{0};
     };
 
+    auto plast_key = parent_node->get_last_key< K >();
     _leftmost_src_info leftmost_src;
     _src_cursor_info src_cursor;
 
@@ -347,7 +366,7 @@ btree_status_t Btree< K, V >::merge_nodes(const BtreeNodePtr& parent_node, const
 
     // Determine if packing the nodes would result in reducing the number of nodes, if so go with that. If else
     // we revert back to rebalancing the nodes.
-    num_nodes = (total_size - 1) / m_bt_cfg.ideal_fill_size() + 1;
+    num_nodes = (total_size == 0) ? 1 : (total_size - 1) / m_bt_cfg.ideal_fill_size() + 1;
     if (num_nodes >= (old_nodes.size() + 1)) {
         // Only option is to rebalance the nodes across. If we are asked not to do so, skip it.
         if (!m_bt_cfg.m_rebalance_turned_on) {
@@ -356,7 +375,7 @@ btree_status_t Btree< K, V >::merge_nodes(const BtreeNodePtr& parent_node, const
         }
     }
 
-    balanced_size = (total_size - 1) / num_nodes + 1;
+    balanced_size = (total_size == 0) ? 0 : (total_size - 1) / num_nodes + 1;
     if (leftmost_node->occupied_size(m_bt_cfg) > balanced_size) {
         // If for some reason balancing increases the current size, give up.
         // TODO: Is this a real case, isn't happening would mean some sort of bug in calculation of is_merge_needed?
@@ -371,11 +390,20 @@ btree_status_t Btree< K, V >::merge_nodes(const BtreeNodePtr& parent_node, const
     // doing a dry run and if for some reason there is a problem in balancing the nodes, then it is easy to give up.
     available_size = balanced_size - leftmost_node->occupied_size(m_bt_cfg);
     src_cursor.ith_node = old_nodes.size();
-    for (uint32_t i{0}; (i < old_nodes.size()) && (available_size > 0); ++i) {
+    for (uint32_t i{0}; (i < old_nodes.size()) && (available_size >= 0); ++i) {
         leftmost_src.ith_nodes.push_back(i);
+        // TODO: check whether value size of the node is greater than available_size? If so nentries is 0. Suppose if a
+        // node contains one entry and the value size is much bigger than available size
         auto const nentries = old_nodes[i]->num_entries_by_size(0, available_size);
         if ((old_nodes[i]->total_entries() - nentries) == 0) { // Entire node goes in
             available_size -= old_nodes[i]->occupied_size(m_bt_cfg);
+            // we reach the end so the "else" statement gets no chance to run
+            if (i >= old_nodes.size() - 1) {
+                src_cursor.ith_node = i + 1;
+                src_cursor.nth_entry = std::numeric_limits< uint32_t >::max();
+                leftmost_src.last_node_upto = nentries;
+                BT_NODE_LOG(DEBUG, parent_node, "MERGE: no new nodes is supposed to be created");
+            }
         } else {
             src_cursor.ith_node = i;
             src_cursor.nth_entry = nentries;
@@ -419,7 +447,7 @@ btree_status_t Btree< K, V >::merge_nodes(const BtreeNodePtr& parent_node, const
     }
 
     if (!K::is_fixed_size()) {
-        // Lets see if we have enough room in parent node to accomodate changes. This is needed only if the key is not
+        // Lets see if we have enough room in parent node to accommodate changes. This is needed only if the key is not
         // fixed length. For fixed length node merge will always result in lesser or equal size
         int64_t post_merge_size{0};
         auto& old_node = old_nodes[leftmost_src.ith_nodes.back()];
@@ -474,7 +502,8 @@ btree_status_t Btree< K, V >::merge_nodes(const BtreeNodePtr& parent_node, const
         for (auto it = new_nodes.rbegin(); it != new_nodes.rend(); ++it) {
             (*it)->set_next_bnode(next_node_id);
             auto this_node_id = (*it)->node_id();
-            parent_node->update(cur_idx--, (*it)->get_last_key< K >(), BtreeLinkInfo{this_node_id, 0});
+            if ((*it)->total_entries())
+                parent_node->update(cur_idx--, (*it)->get_last_key< K >(), BtreeLinkInfo{this_node_id, 0});
             last_new_node = *it;
             next_node_id = this_node_id;
         }
@@ -482,9 +511,18 @@ btree_status_t Btree< K, V >::merge_nodes(const BtreeNodePtr& parent_node, const
         std::string parent_node_step3 = parent_node->to_string();
 
         // Finally update the leftmost node with latest key
-        leftmost_node->inc_link_version();
         leftmost_node->set_next_bnode(next_node_id);
-        parent_node->update(start_idx, leftmost_node->get_last_key< K >(), leftmost_node->link_info());
+        if (leftmost_node->total_entries()) {
+            leftmost_node->inc_link_version();
+            parent_node->update(start_idx, leftmost_node->get_last_key< K >(), leftmost_node->link_info());
+        }
+
+        if (parent_node->total_entries() && !parent_node->has_valid_edge()) {
+            if (parent_node->compare_nth_key(plast_key, parent_node->total_entries() - 1)) {
+                auto last_node = new_nodes.size() > 0 ? new_nodes[new_nodes.size() - 1] : leftmost_node;
+                parent_node->update(parent_node->total_entries() - 1, plast_key, last_node->link_info());
+            }
+        }
 
 #if 0
         /////////// Old code /////////////

--- a/src/include/homestore/btree/detail/simple_node.hpp
+++ b/src/include/homestore/btree/detail/simple_node.hpp
@@ -260,6 +260,56 @@ public:
         return str;
     }
 
+    std::string to_string_keys(bool print_friendly = false) const override {
+        std::string delimiter = print_friendly ? "\n" : "\t";
+        auto str = fmt::format("{} nEntries={} {} ",
+                               print_friendly ? "------------------------------------------------------------\n" : "",
+                               this->total_entries(), (this->is_leaf() ? "LEAF" : "INTERIOR"));
+        if (!this->is_leaf() && (this->has_valid_edge())) {
+            fmt::format_to(std::back_inserter(str), "edge_id={}.{}", this->edge_info().m_bnodeid,
+                           this->edge_info().m_link_version);
+        }
+        if (this->total_entries() == 0) {
+            fmt::format_to(std::back_inserter(str), " [EMPTY] ");
+            return str;
+        }
+        if (!this->is_leaf()) {
+            fmt::format_to(std::back_inserter(str), " [");
+            for (uint32_t i{0}; i < this->total_entries(); ++i) {
+                uint32_t cur_key = get_nth_key< K >(i, false).key();
+                fmt::format_to(std::back_inserter(str), "{}{}", cur_key, i == this->total_entries() - 1 ? "" : ", ");
+            }
+            fmt::format_to(std::back_inserter(str), "]");
+            return str;
+        }
+        uint32_t prev_key = get_nth_key< K >(0, false).key();
+        uint32_t cur_key = prev_key;
+        uint32_t last_key = get_nth_key< K >(this->total_entries() - 1, false).key();
+        if (last_key - prev_key == this->total_entries() - 1) {
+            if (this->total_entries() == 1)
+                fmt::format_to(std::back_inserter(str), "{}[{}]", delimiter, prev_key);
+            else
+                fmt::format_to(std::back_inserter(str), "{}[{}-{}]", delimiter, prev_key, last_key);
+            return str;
+        }
+        fmt::format_to(std::back_inserter(str), "{}0 - [{}", delimiter, prev_key);
+
+        for (uint32_t i{1}; i < this->total_entries(); ++i) {
+            cur_key = get_nth_key< K >(i, false).key();
+            if (cur_key != prev_key + 1) {
+                fmt::format_to(std::back_inserter(str), "-{}]{}{}- [{}", prev_key, delimiter, i, cur_key);
+            }
+            prev_key = cur_key;
+        }
+
+        if (last_key - prev_key == this->total_entries() - 1) {
+            fmt::format_to(std::back_inserter(str), "]");
+        } else {
+            fmt::format_to(std::back_inserter(str), "-{}]", cur_key);
+        }
+        return str;
+    }
+
     uint8_t* get_node_context() override { return uintptr_cast(this) + sizeof(SimpleNode< K, V >); }
 
 #ifndef NDEBUG

--- a/src/lib/checkpoint/cp_mgr.cpp
+++ b/src/lib/checkpoint/cp_mgr.cpp
@@ -24,6 +24,8 @@
 #include "cp.hpp"
 
 namespace homestore {
+thread_local std::stack< CP* > CPGuard::t_cp_stack;
+
 CPManager::CPManager(bool first_time_boot) :
         m_metrics{std::make_unique< CPMgrMetrics >()},
         m_wd_cp{std::make_unique< CPWatchdog >(this)},
@@ -48,7 +50,7 @@ void CPManager::on_meta_blk_found(const sisl::byte_view& buf, void* meta_cookie)
 }
 
 void CPManager::create_first_cp() {
-    m_cur_cp = new CP();
+    m_cur_cp = new CP(this);
     m_cur_cp->m_cp_status = cp_status_t::cp_io_ready;
     m_cur_cp->m_cp_id = m_sb->m_last_flushed_cp + 1;
 }
@@ -69,30 +71,38 @@ void CPManager::register_consumer(cp_consumer_t consumer_id, std::unique_ptr< CP
     }
 }
 
+[[nodiscard]] CPGuard CPManager::cp_guard() { return CPGuard{this}; }
+
 CP* CPManager::cp_io_enter() {
     rcu_read_lock();
     auto cp = get_cur_cp();
+
+    HS_DBG_ASSERT_NE((void*)cp, nullptr, "get_cur_cp returned null, cp_io_enter() after shutdown?");
     if (!cp) {
         rcu_read_unlock();
         return nullptr;
     }
+    cp_ref(cp);
+    rcu_read_unlock();
 
-    auto cnt = cp->m_enter_cnt.fetch_add(1);
+    return cp;
+}
+
+void CPManager::cp_ref(CP* cp) {
+    cp->m_enter_cnt.increment(1);
 #ifndef NDEBUG
     auto status = cp->m_cp_status.load();
     HS_DBG_ASSERT((status == cp_status_t::cp_io_ready || status == cp_status_t::cp_trigger ||
                    status == cp_status_t::cp_flush_prepare),
                   "cp status {}", status);
 #endif
-
-    rcu_read_unlock();
-    return cp;
 }
 
 void CPManager::cp_io_exit(CP* cp) {
     HS_DBG_ASSERT_NE(cp->m_cp_status, cp_status_t::cp_flushing);
-    auto cnt = cp->m_enter_cnt.fetch_sub(1);
-    if (cnt == 1 && cp->m_cp_status == cp_status_t::cp_flush_prepare) { cp_start_flush(cp); }
+    if (cp->m_enter_cnt.decrement_testz(1) && (cp->m_cp_status == cp_status_t::cp_flush_prepare)) {
+        cp_start_flush(cp);
+    }
 }
 
 CP* CPManager::get_cur_cp() {
@@ -105,48 +115,48 @@ void CPManager::trigger_cp_flush(cp_done_cb_t&& cb, bool force) {
     bool expected = false;
     auto ret = m_in_flush_phase.compare_exchange_strong(expected, true);
     if (!ret) {
-        // They are already an existing CP on-going, but if force is set, we create a back-to-back CP.
+        // There is already an existing CP on-going, but if force is set, we create a back-to-back CP.
         if (force) {
             std::unique_lock< std::mutex > lk(trigger_cp_mtx);
-            auto cp = cp_io_enter();
-            HS_DBG_ASSERT_NE(cp->m_cp_status, cp_status_t::cp_flush_prepare);
-            cp->m_done_cb = cb;
-            cp->m_cp_waiting_to_trigger = true;
-            cp_io_exit(cp);
+            auto cpg = cp_guard();
+            HS_DBG_ASSERT_NE(cpg->m_cp_status, cp_status_t::cp_flush_prepare);
+            cpg->m_done_cb = cb;
+            cpg->m_cp_waiting_to_trigger = true;
         }
         return;
     }
 
-    auto cur_cp = cp_io_enter();
-    cur_cp->m_cp_status = cp_status_t::cp_trigger;
-    HS_PERIODIC_LOG(INFO, cp, "<<<<<<<<<<< Triggering flush of the CP {}", cur_cp->to_string());
-    COUNTER_INCREMENT(*m_metrics, cp_cnt, 1);
-    m_cp_start_time = Clock::now();
-
-    /* allocate a new cp */
-    auto new_cp = new CP();
     {
-        std::unique_lock< std::mutex > lk(trigger_cp_mtx);
-        new_cp->m_cp_id = cur_cp->m_cp_id + 1;
+        auto cpg = cp_guard();
+        CP* cur_cp = cpg.get();
+        cur_cp->m_cp_status = cp_status_t::cp_trigger;
+        HS_PERIODIC_LOG(INFO, cp, "<<<<<<<<<<< Triggering flush of the CP {}", cur_cp->to_string());
+        COUNTER_INCREMENT(*m_metrics, cp_cnt, 1);
+        m_cp_start_time = Clock::now();
 
-        HS_PERIODIC_LOG(DEBUG, cp, "Create New CP session", new_cp->id());
-        size_t idx{0};
-        for (auto& consumer : m_cp_cb_table) {
-            if (consumer) { new_cp->m_contexts[idx] = std::move(consumer->on_switchover_cp(cur_cp, new_cp)); }
-            ++idx;
+        /* allocate a new cp */
+        auto new_cp = new CP(this);
+        {
+            std::unique_lock< std::mutex > lk(trigger_cp_mtx);
+            new_cp->m_cp_id = cur_cp->m_cp_id + 1;
+
+            HS_PERIODIC_LOG(DEBUG, cp, "Create New CP session", new_cp->id());
+            size_t idx{0};
+            for (auto& consumer : m_cp_cb_table) {
+                if (consumer) { new_cp->m_contexts[idx] = std::move(consumer->on_switchover_cp(cur_cp, new_cp)); }
+                ++idx;
+            }
+
+            HS_PERIODIC_LOG(DEBUG, cp, "CP Attached completed, proceed to exit cp critical section");
+            cur_cp->m_done_cb = cb;
+            cur_cp->m_cp_status = cp_status_t::cp_flush_prepare;
+            new_cp->m_cp_status = cp_status_t::cp_io_ready;
+            rcu_xchg_pointer(&m_cur_cp, new_cp);
+            synchronize_rcu();
         }
-
-        HS_PERIODIC_LOG(DEBUG, cp, "CP Attached completed, proceed to exit cp critical section");
-        cur_cp->m_done_cb = cb;
-        cur_cp->m_cp_status = cp_status_t::cp_flush_prepare;
-        new_cp->m_cp_status = cp_status_t::cp_io_ready;
-        rcu_xchg_pointer(&m_cur_cp, new_cp);
-        synchronize_rcu();
+        // At this point we are sure that there is no thread working on prev_cp without incrementing the cp_enter cnt
     }
-    // At this point we are sure that there is no thread working on prev_cp without incrementing the cp_enter cnt
-
     HS_PERIODIC_LOG(DEBUG, cp, "CP critical section done, doing cp_io_exit");
-    cp_io_exit(cur_cp);
 }
 
 void CPManager::cp_start_flush(CP* cp) {
@@ -187,15 +197,17 @@ void CPManager::on_cp_flush_done(CP* cp) {
     delete cp;
 
     // Trigger CP in case there is one back to back CP
-    auto cur_cp = cp_io_enter();
-    if (!cur_cp) { return; }
-    m_wd_cp->set_cp(cur_cp);
-    if (cur_cp->m_cp_waiting_to_trigger) {
-        HS_PERIODIC_LOG(INFO, cp, "Triggering back to back CP");
-        COUNTER_INCREMENT(*m_metrics, back_to_back_cps, 1);
-        trigger_cp_flush();
+    {
+        auto cpg = cp_guard();
+        auto cur_cp = cpg.get();
+        if (!cur_cp) { return; }
+        m_wd_cp->set_cp(cur_cp);
+        if (cur_cp->m_cp_waiting_to_trigger) {
+            HS_PERIODIC_LOG(INFO, cp, "Triggering back to back CP");
+            COUNTER_INCREMENT(*m_metrics, back_to_back_cps, 1);
+            trigger_cp_flush();
+        }
     }
-    cp_io_exit(cur_cp);
 }
 
 void CPManager::cleanup_cp(CP* cp) {
@@ -203,6 +215,54 @@ void CPManager::cleanup_cp(CP* cp) {
     for (auto& consumer : m_cp_cb_table) {
         if (consumer) { consumer->cp_cleanup(cp); }
     }
+}
+
+//////////////////////////////////////// CP Guard class ////////////////////////////////////////////
+CPGuard::CPGuard(CPManager* mgr) {
+    if (t_cp_stack.empty()) {
+        // First CP in this thread stack.
+        m_cp = mgr->cp_io_enter();
+    } else {
+        // Nested CP sections
+        m_cp = t_cp_stack.top();
+        m_cp->m_cp_mgr->cp_ref(m_cp);
+    }
+    t_cp_stack.push(m_cp);
+    m_pushed = true; // m_pushed represented if this is added to current thread stack
+}
+
+CPGuard::~CPGuard() {
+    if (m_pushed && !t_cp_stack.empty()) {
+        HS_DBG_ASSERT_EQ((void*)m_cp, (void*)t_cp_stack.top(), "CPGuard mismatch of CP pointers");
+        t_cp_stack.pop();
+    }
+    if (m_cp) { m_cp->m_cp_mgr->cp_io_exit(m_cp); }
+}
+
+CPGuard::CPGuard(const CPGuard& other) {
+    m_cp = other.m_cp;
+    m_pushed = false;
+    m_cp->m_cp_mgr->cp_ref(m_cp);
+}
+
+CPGuard CPGuard::operator=(const CPGuard& other) {
+    m_cp = other.m_cp;
+    m_pushed = false;
+    m_cp->m_cp_mgr->cp_ref(m_cp);
+    return *this;
+}
+
+CP& CPGuard::operator*() { return *get(); }
+CP* CPGuard::operator->() { return get(); }
+
+CP* CPGuard::get() {
+    HS_DBG_ASSERT_NE((void*)m_cp, (void*)nullptr, "CPGuard get on empty CP pointer");
+    if (!m_pushed) {
+        // m_pushed is false in case cp guard is moved from one thread to other
+        t_cp_stack.push(m_cp);
+        m_pushed = true;
+    }
+    return m_cp;
 }
 
 //////////////////////////////////////// CP Watchdog class //////////////////////////////////////////

--- a/src/tests/test_common/range_scheduler.hpp
+++ b/src/tests/test_common/range_scheduler.hpp
@@ -1,0 +1,168 @@
+/*********************************************************************************
+ * Modifications Copyright 2017-2019 eBay Inc.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ *********************************************************************************/
+/*
+ * Homestore testing binaries shared common definitions, apis and data structures
+ *
+ */
+
+#pragma once
+
+#include <boost/icl/closed_interval.hpp>
+#include <boost/icl/interval_set.hpp>
+#include <boost/icl/separate_interval_set.hpp>
+#include <boost/icl/split_interval_set.hpp>
+#include <cassert>
+namespace homestore {
+using namespace boost::icl;
+typedef interval_set< uint32_t > set_t;
+typedef set_t::interval_type ival;
+
+class RangeScheduler {
+public:
+    void add_to_existing(uint32_t s) { add_to_existing(s, s); }
+
+    void add_to_working(uint32_t s) { add_to_working(s, s); }
+
+    void add_to_existing(uint32_t s, uint32_t e) { existing_keys += ival::closed(s, e); }
+
+    void add_to_working(uint32_t s, uint32_t e) { working_keys += ival::closed(s, e); }
+
+    void remove_from_existing(uint32_t s, uint32_t e) { existing_keys -= ival::closed(s, e); }
+
+    void remove_from_existing(uint32_t s) { remove_from_existing(s, s); }
+
+    void remove_from_working(uint32_t s) { remove_from_working(s, s); }
+
+    void remove_from_working(uint32_t s, uint32_t e) { working_keys -= ival::closed(s, e); }
+
+    bool is_working(uint32_t cur_key) { return working_keys.find(cur_key) != working_keys.end(); }
+
+    bool is_existing(uint32_t cur_key) { return existing_keys.find(cur_key) != existing_keys.end(); }
+
+    void lock() { set_lock.lock(); }
+
+    void unlock() { set_lock.unlock(); }
+
+    int pick_random_non_existing_keys(uint32_t n_keys = 1, uint32_t max_range = 0) {
+        uint32_t working_range = max_range <= 0 ? std::numeric_limits< uint32_t >::max() : max_range;
+        uint32_t num_retry = 0;
+
+        this->lock();
+        auto num_intervals = static_cast< uint32_t >(existing_keys.iterative_size());
+        std::uniform_int_distribution< uint32_t > s_rand_interval_generator{0, num_intervals - 1};
+        uint32_t start_key = std::numeric_limits< uint32_t >::max();
+
+        while (num_retry < max_retries) {
+            // find a random interval
+            uint32_t next_lower = working_range;
+            uint32_t previous_upper = 0;
+            auto it = existing_keys.begin();
+            // if the selected interval is the last ... check size between this one and the working_range, rand n keys
+            // in (previous_upper, working_range] = [previous_upper+1, working_range] choose the gap between this upper
+            // and the next begin. and check the size! rand nkeys in [previous_upper, next_lower]
+            if (num_intervals != 0) {
+                uint32_t cur_interval_idx = s_rand_interval_generator(g_re);
+                std::advance(it, cur_interval_idx);
+                previous_upper = last(*it) + 1; // to be inclusivelast
+                it++;
+                if (it != existing_keys.end()) { next_lower = first(*it) - 1; }
+            }
+            if ((next_lower + 1) < (n_keys + previous_upper)) { // check < or <=
+                num_retry++;
+                continue;
+            }
+
+            // choose randomly n keys in [previous_upper, next_lower]
+            std::uniform_int_distribution< uint32_t > rand_key_generator{
+                previous_upper, next_lower - n_keys + 1}; // n_keys or n_keys +- (1)
+            start_key = rand_key_generator(g_re);
+            auto found = (working_keys & ival::closed(start_key, start_key + n_keys - 1));
+            if (found.empty()) {
+                auto validate = existing_keys & ival::closed(start_key, start_key + n_keys - 1);
+                assert(validate.empty());
+                break;
+            }
+            num_retry++;
+            continue;
+        }
+        if (num_retry == max_retries) {
+            this->unlock();
+            return -1;
+        }
+        // add from working keys and return the start_key;
+        this->add_to_working(start_key, start_key + n_keys - 1);
+        assert(start_key + n_keys - 1 <= working_range);
+        this->unlock();
+        return static_cast< int >(start_key);
+    }
+
+    int pick_random_existing_keys(uint32_t n_keys = 1, uint32_t max_range = 0) {
+        uint32_t working_range = max_range <= 0 ? std::numeric_limits< uint32_t >::max() : max_range;
+        uint32_t num_retry = 0;
+
+        this->lock();
+        auto num_intervals = static_cast< uint32_t >(existing_keys.iterative_size());
+        // empty keys
+        if (num_intervals == 0) {
+            this->unlock();
+            return -1;
+        }
+        std::uniform_int_distribution< uint32_t > s_rand_interval_generator{0, num_intervals - 1};
+        uint32_t start_key = std::numeric_limits< uint32_t >::max();
+
+        while (num_retry < max_retries) {
+            // find a random interval
+            auto it = existing_keys.begin();
+            uint32_t cur_interval_idx = s_rand_interval_generator(g_re);
+            std::advance(it, cur_interval_idx);
+            uint32_t upper = last(*it);
+            uint32_t lower = first(*it);
+            if ((upper + 1) < (n_keys + lower)) { // check < or <=
+                num_retry++;
+                continue;
+            }
+            // choose randomly n keys in [lower, upper]
+            std::uniform_int_distribution< uint32_t > rand_key_generator{lower, upper - n_keys + 1};
+            start_key = rand_key_generator(g_re);
+            auto found = (working_keys & ival::closed(start_key, start_key + n_keys - 1));
+            if (found.empty()) {
+                auto validate = existing_keys & ival::closed(start_key, start_key + n_keys - 1);
+                assert(!validate.empty());
+                break;
+            }
+            num_retry++;
+            continue;
+        }
+        if (num_retry == max_retries) {
+            this->unlock();
+            return -1;
+        }
+        // add from working keys and return the start_key;
+        this->add_to_working(start_key, start_key + n_keys - 1);
+        assert(start_key + n_keys - 1 <= working_range);
+        this->unlock();
+        return static_cast< int >(start_key);
+    }
+
+private:
+    set_t existing_keys;
+    set_t working_keys;
+    std::mutex set_lock;
+    std::random_device g_rd{};
+    std::default_random_engine g_re{g_rd()};
+    uint32_t max_retries = 5;
+};
+}; // namespace homestore

--- a/src/tests/test_mem_btree.cpp
+++ b/src/tests/test_mem_btree.cpp
@@ -25,6 +25,7 @@
 #include <homestore/btree/detail/simple_node.hpp>
 #include <homestore/btree/detail/varlen_node.hpp>
 #include <homestore/btree/mem_btree.hpp>
+#include <ranges>
 #include "test_common/range_scheduler.hpp"
 
 static constexpr uint32_t g_node_size{4096};
@@ -34,9 +35,11 @@ SISL_LOGGING_INIT(btree)
 SISL_OPTIONS_ENABLE(logging, test_mem_btree)
 SISL_OPTION_GROUP(test_mem_btree,
                   (num_iters, "", "num_iters", "number of iterations for rand ops",
-                   ::cxxopts::value< uint32_t >()->default_value("1000"), "number"),
+                   ::cxxopts::value< uint32_t >()->default_value("100"), "number"),
                   (num_entries, "", "num_entries", "number of entries to test with",
                    ::cxxopts::value< uint32_t >()->default_value("10000"), "number"),
+                  (merge_activate, "", "merge_activate", "merge_activate",
+                   ::cxxopts::value< bool >()->default_value("0"), ""),
                   (n_threads, "", "n_threads", "number of threads", ::cxxopts::value< uint32_t >()->default_value("10"),
                    "number"),
                   (preload_size, "", "preload_size", "number of entries to preload tree with",
@@ -89,6 +92,7 @@ struct BtreeTest : public testing::Test {
     void SetUp() override {
         m_cfg.m_leaf_node_type = T::leaf_node_type;
         m_cfg.m_int_node_type = T::interior_node_type;
+        if (SISL_OPTIONS.count("merge_activate")) m_cfg.m_merge_turned_on = true;
         m_bt = std::make_unique< typename T::BtreeType >(m_cfg);
         m_bt->init(nullptr);
     }
@@ -152,9 +156,45 @@ struct BtreeTest : public testing::Test {
         }
     }
 
+    void range_remove(uint32_t start_key, uint32_t end_key) {
+
+        auto start_it = m_shadow_map.lower_bound(K{start_key});
+        auto end_it = m_shadow_map.lower_bound(K{end_key});
+        auto fount_it = m_shadow_map.find(K{end_key});
+        bool expected = (start_it != m_shadow_map.end()) && (std::distance(start_it, end_it) >= 0);
+        if (start_it == end_it && fount_it == m_shadow_map.end()) { expected = false; }
+        auto range = BtreeKeyRange< K >{K{start_key}, true, K{end_key}, true};
+        LOGINFO("range : {}", range.to_string());
+        auto mreq = BtreeRangeRemoveRequest< K >{std::move(range)};
+
+        size_t original_ts = get_tree_size();
+        size_t original_ms = m_shadow_map.size();
+
+        auto ret = m_bt->remove(mreq);
+        ASSERT_EQ(expected, ret == btree_status_t::success)
+            << " not a successful remove op for range " << range.to_string()
+            << "start_it!=m_shadow_map.end(): " << (start_it != m_shadow_map.end())
+            << " and std::distance(start_it,end_it) >= 0 : " << (std::distance(start_it, end_it) >= 0);
+
+        K out_key;
+        V out_value;
+        auto qret = get_num_elements_in_tree(start_key, end_key, out_key, out_value);
+        ASSERT_EQ(qret, btree_status_t::not_found)
+            << "  At least one element found! [" << out_key << "] = " << out_value;
+
+        if (expected) { m_shadow_map.erase(start_it, fount_it != m_shadow_map.end() ? ++end_it : end_it); }
+        size_t ms = m_shadow_map.size();
+        size_t ts = get_tree_size();
+        ASSERT_EQ(original_ms - ms, original_ts - ts) << " number of removed from map is " << original_ms - ms
+                                                      << " whereas number of existing keys is " << original_ts - ts;
+
+        ASSERT_EQ(ts, ms) << " size of tree is " << ts << " vs number of existing keys are " << ms;
+    }
+
     void query_all_validate() const {
         query_validate(0u, SISL_OPTIONS["num_entries"].as< uint32_t >() - 1, UINT32_MAX);
     }
+
     void query_all_paginate_validate(uint32_t batch_size) const {
         query_validate(0u, SISL_OPTIONS["num_entries"].as< uint32_t >() - 1, batch_size);
     }
@@ -234,6 +274,26 @@ struct BtreeTest : public testing::Test {
     }
 
     void print() const { m_bt->print_tree(); }
+
+    void print_keys() const { m_bt->print_tree_keys(); }
+
+    size_t get_tree_size() {
+        BtreeQueryRequest< K > qreq{
+            BtreeKeyRange< K >{K{0}, true, K{SISL_OPTIONS["num_entries"].as< uint32_t >()}, true},
+            BtreeQueryType::SWEEP_NON_INTRUSIVE_PAGINATION_QUERY, UINT32_MAX};
+        std::vector< std::pair< K, V > > out_vector;
+        auto const ret = m_bt->query(qreq, out_vector);
+        return out_vector.size();
+    }
+
+    btree_status_t get_num_elements_in_tree(uint32_t start_k, uint32_t end_k, K& out_key, V& out_value) const {
+        auto req = BtreeGetAnyRequest< K >{BtreeKeyRange< K >{K{start_k}, true, K{end_k}, true},
+                                           std::make_unique< K >(), std::make_unique< V >()};
+        auto ret = m_bt->get(req);
+        out_key = *((K*)req.m_outkey.get());
+        out_value = *((V*)req.m_outval.get());
+        return ret;
+    }
 
 private:
     void validate_data(const K& key, const V& btree_val) const {
@@ -348,6 +408,95 @@ TYPED_TEST(BtreeTest, RangeUpdate) {
     this->query_validate(0, num_entries, 75);
 }
 
+TYPED_TEST(BtreeTest, SimpleRemoveRange) {
+    // Forward sequential insert
+    const auto num_entries = 20;
+    LOGINFO("Step 1: Do Forward sequential insert for {} entries", num_entries);
+    for (uint32_t i{0}; i < num_entries; ++i) {
+        this->put(i, btree_put_type::INSERT_ONLY_IF_NOT_EXISTS);
+    }
+
+    //    this->print_keys(); // EXPECT size = 20 : 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
+    this->range_remove(5, 10);
+    //    this->print_keys(); // EXPECT size = 14 : 0 1 2 3 4 [5 6 7 8 9 10] 11 12 13 14 15 16 17 18 19
+    this->range_remove(0, 2);
+    //    this->print_keys(); // EXPECT size = 11 : [0 1 2] 3 4 11 12 13 14 15 16 17 18 19
+    this->range_remove(18, 19);
+    //    this->print_keys(); // EXPECT size = 9 : 3 4 11 12 13 14 15 16 17 [18 19]
+    this->range_remove(17, 17);
+    //    this->print_keys(); // EXPECT size = 8 : 3 4 11 12 13 14 15 16 [17]
+    this->range_remove(1, 5);
+    //    this->print_keys(); // EXPECT size = 6 : [3 4] 11 12 13 14 15 16
+    this->range_remove(1, 20);
+    //    this->print_keys(); // EXPECT size = 0 : [11 12 13 14 15 16]
+
+    this->query_all_validate();
+    //    this->query_validate(0, num_entries , 75);
+}
+
+TYPED_TEST(BtreeTest, removeAllEntriesReverse) {
+    // Forward sequential insert
+    const auto num_entries = 1000;
+    LOGINFO("Step 1: Do Forward sequential insert for {} entries", num_entries);
+    for (uint32_t i{0}; i < num_entries; ++i) {
+        this->put(i, btree_put_type::INSERT_ONLY_IF_NOT_EXISTS);
+    }
+    //    this->print_keys();
+    this->range_remove(681, 999);
+    //    this->print_keys();
+    this->range_remove(454, 680);
+    //    this->print_keys();
+    this->range_remove(227, 453);
+    //    this->print_keys();
+    this->range_remove(0, 226);
+    //    this->print_keys();
+    this->query_all_validate();
+}
+
+TYPED_TEST(BtreeTest, removeAllEntries) {
+    // Forward sequential insert
+    const auto num_entries = 1000;
+    LOGINFO("Step 1: Do Forward sequential insert for {} entries", num_entries);
+    for (uint32_t i{0}; i < num_entries; ++i) {
+        this->put(i, btree_put_type::INSERT_ONLY_IF_NOT_EXISTS);
+    }
+    //    this->print_keys();
+    this->range_remove(0, 226);
+    //    this->print_keys();
+    this->range_remove(227, 453);
+    //    this->print_keys();
+    this->range_remove(454, 680);
+    //    this->print_keys();
+    this->range_remove(681, 999);
+    //    this->print_keys();
+    this->query_all_validate();
+}
+
+TYPED_TEST(BtreeTest, RandomRemoveRange) {
+
+    // Forward sequential insert
+    const auto num_entries = SISL_OPTIONS["num_entries"].as< uint32_t >();
+    LOGINFO("Step 1: Do Forward sequential insert for {} entries", num_entries);
+    for (uint32_t i{0}; i < num_entries; ++i) {
+        this->put(i, btree_put_type::INSERT_ONLY_IF_NOT_EXISTS);
+    }
+
+    static std::uniform_int_distribution< uint32_t > s_rand_key_generator{0, 2 * num_entries};
+    //    this->print_keys();
+    for (uint32_t i{0}; i < SISL_OPTIONS["num_iters"].as< uint32_t >() && this->m_shadow_map.size() > 0; ++i) {
+        uint32_t key1 = s_rand_key_generator(g_re);
+        uint32_t key2 = s_rand_key_generator(g_re);
+        uint32_t start_key = std::min(key1, key2);
+        uint32_t end_key = std::max(key1, key2);
+
+        LOGINFO("Step 2 - {}: Do Range Remove of maximum [{},{}] keys ", i, start_key, end_key);
+        this->range_remove(std::min(key1, key2), std::max(key1, key2));
+        //        this->print_keys();
+    }
+
+    this->query_all_validate();
+}
+
 template < typename TestType >
 class BtreeConcurrentTest : public testing::Test {
     typedef void (BtreeConcurrentTest::*pt2func)(void);
@@ -356,39 +505,108 @@ class BtreeConcurrentTest : public testing::Test {
     using V = typename TestType::ValueType;
 
     std::unique_ptr< typename T::BtreeType > m_bt;
-    RangeScheduler range_scheduler;
-    std::vector< std::thread > threads;
-    uint32_t max_range_input = 10000;
+    struct ShadowMap {
+    public:
+        bool put(uint32_t key, std::string value, bool replace = false) {
+            auto it = data.find(key);
+            if ((it == data.end() && replace) || (it != data.end() && !replace)) { return false; }
+            data[key] = value;
+            return true;
+        }
+        bool range_put(uint32_t key, uint32_t nkeys, std::string value, bool replace = false) {
+            if (replace) {
+                if (!all_existed(key, nkeys)) { return false; }
+            } else {
+                if (!non_of_them_existed(key, nkeys)) { return false; }
+            }
+            for (auto cur = key; cur < key + nkeys; cur++)
+                data[cur] = value;
+            return true;
+        }
+
+        bool remove(uint32_t key) {
+            if (non_of_them_existed(key, 1)) return false;
+            auto it = data.find(key);
+            if (it == data.end()) return false;
+            data.erase(it);
+            return true;
+        }
+        bool remove(uint32_t key, std::string value) {
+            if (non_of_them_existed(key, 1)) return false;
+            auto it = data.find(key);
+            if (it == data.end()) return false;
+            if (it->second != value) return false;
+            data.erase(it);
+            return true;
+        }
+
+        bool range_remove(uint32_t key, uint32_t nkeys) {
+            if (non_of_them_existed(key, nkeys)) return false;
+            auto first_it = data.find(key);
+            auto last_it = data.upper_bound(key + nkeys - 1);
+            data.erase(first_it, last_it);
+            return true;
+        }
+        bool range_remove(uint32_t key, uint32_t nkeys, std::unordered_map< uint32_t, std::string > val_map) {
+            if (non_of_them_existed(key, nkeys)) return false;
+            for (auto cur = key; cur < key + nkeys; cur++)
+                if (data.find(cur) != data.end() && val_map[cur] != data[cur]) return false;
+            auto first_it = data.find(key);
+            auto last_it = data.upper_bound(key + nkeys - 1);
+            data.erase(first_it, last_it);
+            return true;
+        }
+
+        bool non_of_them_existed(uint32_t key, uint32_t nkeys) {
+            for (auto cur = key; cur < key + nkeys; cur++)
+                if (data.find(cur) != data.end()) return false;
+            return true;
+        }
+
+        bool all_existed(uint32_t key, uint32_t nkeys) {
+            for (auto cur = key; cur < key + nkeys; cur++)
+                if (data.find(cur) == data.end()) return false;
+            return true;
+        }
+
+    private:
+        std::map< uint32_t, std::string > data;
+    };
+    ShadowMap m_shadow_map;
+    RangeScheduler m_range_scheduler;
+    std::vector< std::thread > m_threads;
+    uint32_t m_max_range_input = 10000;
     BtreeConfig m_cfg{g_node_size};
-    std::map< std::string, pt2func > operations;
-    std::vector< std::string > op_list;
-    bool mock = false;
+    std::map< std::string, pt2func > m_operations;
+    std::vector< std::string > m_op_list;
+    bool m_mock = false;
 
     //    tree_ tree;
     void preload(uint32_t start, uint32_t end) {
         for (uint32_t i = start; i <= end; i++) {
-            if (!mock) { put(i, btree_put_type::INSERT_ONLY_IF_NOT_EXISTS); }
-            range_scheduler.add_to_existing(i);
+            auto value = V::generate_rand();
+            if (!m_mock) { put(i, btree_put_type::INSERT_ONLY_IF_NOT_EXISTS, value); }
+            m_range_scheduler.add_to_existing(i);
         }
         LOGINFO(" PRELOAD DONE FOR [{},{}]", start, end);
     }
     void RunInParallel(size_t n_threads = 10) {
         for (size_t i = 0; i < n_threads; ++i)
-            threads.push_back(std::thread(&BtreeConcurrentTest::doSomething, this));
-        for (auto& th : threads) {
+            m_threads.push_back(std::thread(&BtreeConcurrentTest::doSomething, this));
+        for (auto& th : m_threads) {
             th.join();
         }
     }
-    void set_operations(std::vector< std::string > op_list) { this->op_list = op_list; }
+    void set_operations(std::vector< std::string > op_list) { this->m_op_list = op_list; }
 
     void doSomething() {
         std::random_device g_rd{};
         std::default_random_engine g_re{g_rd()};
         const auto num_iters_per_thread = SISL_OPTIONS["num_iters"].as< uint32_t >();
-        std::uniform_int_distribution< uint32_t > s_rand_op_generator{0, static_cast< uint32_t >(op_list.size() - 1)};
+        std::uniform_int_distribution< uint32_t > s_rand_op_generator{0, static_cast< uint32_t >(m_op_list.size() - 1)};
         for (uint32_t i = 0; i < num_iters_per_thread; i++) {
             uint32_t operation = s_rand_op_generator(g_re);
-            run_one_iteration(op_list[operation]);
+            run_one_iteration(m_op_list[operation]);
         }
     }
     void SetUp() override {
@@ -396,71 +614,65 @@ class BtreeConcurrentTest : public testing::Test {
         m_cfg.m_int_node_type = T::interior_node_type;
         m_bt = std::make_unique< typename T::BtreeType >(m_cfg);
         m_bt->init(nullptr);
-        operations["put"] = &BtreeConcurrentTest::random_put;
-        operations["remove"] = &BtreeConcurrentTest::random_remove;
-        operations["range_put"] = &BtreeConcurrentTest::random_range_put;
-        operations["range_update"] = &BtreeConcurrentTest::random_range_update;
-        operations["range_remove"] = &BtreeConcurrentTest::random_range_remove;
+        m_operations["put"] = &BtreeConcurrentTest::random_put;
+        m_operations["remove"] = &BtreeConcurrentTest::random_remove;
+        m_operations["range_put"] = &BtreeConcurrentTest::random_range_put;
+        m_operations["range_update"] = &BtreeConcurrentTest::random_range_update;
+        m_operations["range_remove"] = &BtreeConcurrentTest::random_range_remove;
     }
     void run_one_iteration(std::string operation_name) {
-        auto op = operations[operation_name];
+        auto op = m_operations[operation_name];
         (*this.*op)();
     }
     void random_range_put() { random_range_put_update(false); }
     void random_range_update() { random_range_put_update(true); }
-    void put(uint32_t k, btree_put_type put_type) {
+    void put(uint32_t k, btree_put_type put_type, V value) {
         std::unique_ptr< V > existing_v = std::make_unique< V >();
 
-        auto sreq = BtreeSinglePutRequest{std::make_unique< K >(k), std::make_unique< V >(V::generate_rand()), put_type,
+        auto sreq = BtreeSinglePutRequest{std::make_unique< K >(k), std::make_unique< V >(value), put_type,
                                           std::move(existing_v)};
         bool done = (m_bt->put(sreq) == btree_status_t::success);
-        bool expected_done{true};
-        //        if (m_shadow_map.find(*sreq.m_k) != m_shadow_map.end()) {
-        //            expected_done = (put_type != btree_put_type::INSERT_ONLY_IF_NOT_EXISTS);
-        //        }
+        auto expected_done = m_shadow_map.put(k, value.to_string());
         ASSERT_EQ(done, expected_done) << "Expected put of key " << k << " of put_type " << enum_name(put_type)
                                        << " to be " << expected_done;
     }
-    void range_put(uint32_t start_key, uint32_t end_key, bool replace) {
-        auto val = std::make_unique< V >(V::generate_rand());
+    void range_put(uint32_t start_key, uint32_t end_key, V value, bool replace) {
         auto mreq = BtreeRangePutRequest< K >{BtreeKeyRange< K >{start_key, true, end_key, true},
                                               replace ? btree_put_type::REPLACE_ONLY_IF_EXISTS
                                                       : btree_put_type::INSERT_ONLY_IF_NOT_EXISTS,
-                                              std::move(val)};
-        ASSERT_EQ(m_bt->put(mreq), btree_status_t::success);
+                                              std::make_unique< V >(value)};
+        bool done = (m_bt->put(mreq) == btree_status_t::success);
+        auto expected_done = m_shadow_map.range_put(start_key, end_key - start_key + 1, value.to_string(), replace);
+        ASSERT_EQ(done, expected_done);
+        //        << "Expected put of key " << k << " of put_type " << enum_name(put_type)
+        //                                       << " to be " << expected_done;
     }
     void remove(uint32_t key) {
         std::unique_ptr< V > existing_v = std::make_unique< V >();
         auto rreq = BtreeSingleRemoveRequest{std::make_unique< K >(key), std::move(existing_v)};
         bool removed = (m_bt->remove(rreq) == btree_status_t::success);
-
-        bool expected_removed = true; //(m_shadow_map.find(rreq.key()) != m_shadow_map.end());
+        auto expected_removed = m_shadow_map.remove(key, ((const V&)rreq.value()).to_string());
         ASSERT_EQ(removed, expected_removed) << "Expected remove of key " << key << " to be " << expected_removed;
-
-        //        if (removed) {
-        //            validate_data(rreq.key(), (const V&)rreq.value());
-        //            m_shadow_map.erase(rreq.key());
-        //        }
     }
     void range_remove(uint32_t start_key, uint32_t end_key) {
-#if 0
         auto range = BtreeKeyRange< K >{K{start_key}, true, K{end_key}, true};
+        auto out_vector = query(start_key, end_key);
         auto mreq = BtreeRangeRemoveRequest< K >{std::move(range)};
-        auto ret = m_bt->remove(mreq);
-        ASSERT_EQ(ret, btree_status_t::success)
-            << " not a successful remove op for range " << range.to_string();
-#endif
+        bool removed = (m_bt->remove(mreq) == btree_status_t::success);
+        bool expected_removed = m_shadow_map.range_remove(start_key, end_key - start_key + 1, out_vector);
+        ASSERT_EQ(removed, expected_removed) << "not a successful remove op for range " << range.to_string();
     }
 
     void random_put() {
-        int key = range_scheduler.pick_random_non_existing_keys(1, max_range_input);
+        int key = m_range_scheduler.pick_random_non_existing_keys(1, m_max_range_input);
         if (key == -1) { return; }
         LOGINFO("Adding the new key {}", key);
-        if (!mock) { put(key, btree_put_type::INSERT_ONLY_IF_NOT_EXISTS); }
-        range_scheduler.lock();
-        range_scheduler.add_to_existing(static_cast< uint32_t >(key));
-        range_scheduler.remove_from_working(static_cast< uint32_t >(key));
-        range_scheduler.unlock();
+        auto value = V::generate_rand();
+        if (!m_mock) { put(key, btree_put_type::INSERT_ONLY_IF_NOT_EXISTS, value); }
+        m_range_scheduler.lock();
+        m_range_scheduler.add_to_existing(static_cast< uint32_t >(key));
+        m_range_scheduler.remove_from_working(static_cast< uint32_t >(key));
+        m_range_scheduler.unlock();
     }
 
     void random_range_put_update(bool replace = false) {
@@ -469,47 +681,64 @@ class BtreeConcurrentTest : public testing::Test {
         std::random_device g_re{};
         uint32_t nkeys = s_rand_range_generator(g_re);
         int key = -1;
+
         if (replace) {
-            key = range_scheduler.pick_random_existing_keys(nkeys, max_range_input);
+            key = m_range_scheduler.pick_random_existing_keys(nkeys, m_max_range_input);
         } else {
-            key = range_scheduler.pick_random_non_existing_keys(nkeys, max_range_input);
+            key = m_range_scheduler.pick_random_non_existing_keys(nkeys, m_max_range_input);
         }
 
         if (key == -1) { return; }
         LOGINFO("{} range keys [{},{}]", replace ? "RANGE_UPDATE existing" : "RANGE_PUT non-existing", key,
                 key + nkeys - 1);
-        if (!mock) { range_put(key, key + nkeys - 1, replace); }
-        range_scheduler.lock();
+        auto value = V::generate_rand();
+        if (!m_mock) { range_put(key, key + nkeys - 1, value, replace); }
+        m_range_scheduler.lock();
         if (!replace)
-            range_scheduler.add_to_existing(static_cast< uint32_t >(key), static_cast< uint32_t >(key + nkeys - 1));
-        range_scheduler.remove_from_working(static_cast< uint32_t >(key), static_cast< uint32_t >(key + nkeys - 1));
-        range_scheduler.unlock();
+            m_range_scheduler.add_to_existing(static_cast< uint32_t >(key), static_cast< uint32_t >(key + nkeys - 1));
+        m_range_scheduler.remove_from_working(static_cast< uint32_t >(key), static_cast< uint32_t >(key + nkeys - 1));
+        m_range_scheduler.unlock();
     }
 
     void random_remove() {
-        int key = range_scheduler.pick_random_existing_keys(1, max_range_input);
+        int key = m_range_scheduler.pick_random_existing_keys(1, m_max_range_input);
         if (key == -1) { return; }
         LOGINFO("Removing the key {}", key);
-        if (!mock) { remove(key); }
-        range_scheduler.lock();
-        range_scheduler.remove_from_existing(static_cast< uint32_t >(key));
-        range_scheduler.remove_from_working(static_cast< uint32_t >(key));
-        range_scheduler.unlock();
+        if (!m_mock) { remove(key); }
+        m_range_scheduler.lock();
+        m_range_scheduler.remove_from_existing(static_cast< uint32_t >(key));
+        m_range_scheduler.remove_from_working(static_cast< uint32_t >(key));
+        m_range_scheduler.unlock();
     }
 
     void random_range_remove() {
         static std::uniform_int_distribution< uint32_t > s_rand_range_generator{2, 5};
         std::random_device g_re{};
         uint32_t nkeys = s_rand_range_generator(g_re);
-        int key = range_scheduler.pick_random_existing_keys(nkeys, max_range_input);
+        int key = m_range_scheduler.pick_random_existing_keys(nkeys, m_max_range_input);
         if (key == -1) { return; }
         LOGINFO("RANGE_REMOVE range keys [{},{}]", key, key + nkeys - 1);
-        if (!mock) { range_remove(key, key + nkeys - 1); }
+        if (!m_mock) { range_remove(key, key + nkeys - 1); }
 
-        range_scheduler.lock();
-        range_scheduler.remove_from_existing(static_cast< uint32_t >(key), static_cast< uint32_t >(key + nkeys - 1));
-        range_scheduler.remove_from_working(static_cast< uint32_t >(key), static_cast< uint32_t >(key + nkeys - 1));
-        range_scheduler.unlock();
+        m_range_scheduler.lock();
+        m_range_scheduler.remove_from_existing(static_cast< uint32_t >(key), static_cast< uint32_t >(key + nkeys - 1));
+        m_range_scheduler.remove_from_working(static_cast< uint32_t >(key), static_cast< uint32_t >(key + nkeys - 1));
+        m_range_scheduler.unlock();
+    }
+    std::unordered_map< uint32_t, std::string > query(uint32_t start_k, uint32_t end_k) const {
+        std::vector< std::pair< K, V > > out_vector;
+        BtreeQueryRequest< K > qreq{BtreeKeyRange< K >{K{start_k}, true, K{end_k}, true},
+                                    BtreeQueryType::SWEEP_NON_INTRUSIVE_PAGINATION_QUERY, UINT32_MAX};
+        auto const ret = m_bt->query(qreq, out_vector);
+        std::unordered_map< uint32_t, std::string > result;
+        for (auto const& pair : out_vector) {
+            result[pair.first.key()] = pair.second.to_string();
+        }
+        //        std::vector< uint32_t , std::string > values;
+        //        std::transform(out_vector.begin(), out_vector.end(),
+        //                       std::back_inserter(values),
+        //                       [](auto const& pair){ return pair.second.to_string(); });
+        return result;
     }
 
 public:
@@ -517,7 +746,7 @@ public:
         const auto preload_size = SISL_OPTIONS["preload_size"].as< uint32_t >();
         const auto n_threads = SISL_OPTIONS["n_threads"].as< uint32_t >();
         set_operations(op_list);
-        this->mock = mock;
+        this->m_mock = mock;
         preload(0, preload_size);
         RunInParallel(n_threads);
     }
@@ -525,30 +754,58 @@ public:
 
 TYPED_TEST_SUITE(BtreeConcurrentTest, BtreeTypes);
 
-TYPED_TEST(BtreeConcurrentTest, put_no_tree) {
+TYPED_TEST(BtreeConcurrentTest, PutNoTree) {
     std::vector< std::string > ops = {"put"};
     this->execute(ops, true);
 }
 
-TYPED_TEST(BtreeConcurrentTest, remove_no_tree) {
+TYPED_TEST(BtreeConcurrentTest, RemoveNoTree) {
     std::vector< std::string > ops = {"remove"};
     this->execute(ops, true);
 }
 
-TYPED_TEST(BtreeConcurrentTest, put_remove_no_tree) {
+TYPED_TEST(BtreeConcurrentTest, PutRemoveNoTree) {
     std::vector< std::string > ops = {"put", "remove"};
     this->execute(ops, true);
 }
 
-TYPED_TEST(BtreeConcurrentTest, range_no_tree) {
+TYPED_TEST(BtreeConcurrentTest, RangeNoTree) {
     std::vector< std::string > ops = {"range_put", "range_update", "range_remove"};
     this->execute(ops, true);
 }
 
-TYPED_TEST(BtreeConcurrentTest, all_noTree) {
+TYPED_TEST(BtreeConcurrentTest, AllNoTree) {
     std::vector< std::string > ops = {"put", "remove", "range_put", "range_update", "range_remove"};
     this->execute(ops, true);
 }
+
+TYPED_TEST(BtreeConcurrentTest, PutTree) {
+    std::vector< std::string > ops = {"put"};
+    this->execute(ops, false);
+}
+
+TYPED_TEST(BtreeConcurrentTest, RemoveTree) {
+    std::vector< std::string > ops = {"remove"};
+    this->execute(ops, false);
+}
+
+TYPED_TEST(BtreeConcurrentTest, PutRemoveTree) {
+    std::vector< std::string > ops = {"put", "remove"};
+    this->execute(ops, false);
+}
+
+TYPED_TEST(BtreeConcurrentTest, RangeUpdateRemoveTree) {
+    // range put is not supported for non-extent keys
+    std::vector< std::string > ops = {"range_update", "range_remove"};
+    this->execute(ops, false);
+}
+
+TYPED_TEST(BtreeConcurrentTest, AllTree) {
+    // range put is not supported for non-extent keys
+    std::vector< std::string > ops = {"put", "remove", "range_update", "range_remove"};
+    this->execute(ops, false);
+}
+
 int main(int argc, char* argv[]) {
     ::testing::InitGoogleTest(&argc, argv);
     SISL_OPTIONS_LOAD(argc, argv, logging, test_mem_btree)


### PR DESCRIPTION
Adding range scheduler and unit tests when there is no btree involved. This class finds the free range randomly for put/range_put and a random available (non working) range for remove/range_remove/range_update