### PR TITLE
SDSTOR-9859 : add http server port option for dense sku and expose recovery latency metrics

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.5.18"
+    version = "3.5.19"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/engine/meta/test_meta_blk_mgr.cpp
+++ b/src/engine/meta/test_meta_blk_mgr.cpp
@@ -124,7 +124,11 @@ static void start_homestore(const uint32_t ndevices, const uint64_t dev_size, co
     params.vol_state_change_cb = [](const VolumePtr& vol, vol_state old_state, vol_state new_state) {};
     params.vol_found_cb = [](boost::uuids::uuid uuid) -> bool { return true; };
 
-    test_common::set_random_http_port();
+    if (SISL_OPTIONS.count("http_port")) {
+        test_common::set_fixed_http_port(SISL_OPTIONS["http_port"].as< uint32_t >());
+    }else {
+        test_common::set_random_http_port();
+    }
     VolInterface::init(params);
 
     {
@@ -820,7 +824,9 @@ SISL_OPTION_GROUP(
     (per_write, "", "per_write", "write percentage", ::cxxopts::value< uint32_t >()->default_value("60"), "number"),
     (per_remove, "", "per_remove", "remove percentage", ::cxxopts::value< uint32_t >()->default_value("20"), "number"),
     (bitmap, "", "bitmap", "bitmap test", ::cxxopts::value< bool >()->default_value("false"), "true or false"),
-    (spdk, "", "spdk", "spdk", ::cxxopts::value< bool >()->default_value("false"), "true or false"));
+    (spdk, "", "spdk", "spdk", ::cxxopts::value< bool >()->default_value("false"), "true or false"),
+    (http_port, "", "http_port", "http_port", ::cxxopts::value< uint32_t >()->default_value("5000"),
+     "http server port"));
 
 int main(int argc, char* argv[]) {
     ::testing::GTEST_FLAG(filter) = "*random_load_test*";

--- a/src/homeblks/home_blks.cpp
+++ b/src/homeblks/home_blks.cpp
@@ -509,6 +509,11 @@ void HomeBlks::init_done() {
     status_mgr()->register_status_cb("Volumes", std::bind(&HomeBlks::get_status, this, std::placeholders::_1));
 
     m_recovery_stats->end();
+    GAUGE_UPDATE(*m_metrics, recovery_phase0_latency, m_recovery_stats->m_phase0_ms);
+    GAUGE_UPDATE(*m_metrics, recovery_phase1_latency, m_recovery_stats->m_phase1_ms);
+    GAUGE_UPDATE(*m_metrics, recovery_phase2_latency, m_recovery_stats->m_phase2_ms);
+    GAUGE_UPDATE(*m_metrics, recovery_log_store_latency, m_recovery_stats->m_log_store_ms);
+    GAUGE_UPDATE(*m_metrics, recovery_total_latency, m_recovery_stats->m_total_ms);
 
     // start the io watchdog;
     m_io_wd = std::make_unique< VolumeIOWatchDog >();

--- a/src/homeblks/home_blks.hpp
+++ b/src/homeblks/home_blks.hpp
@@ -106,6 +106,11 @@ public:
     explicit HomeBlksMetrics(const char* homeblks_name) : sisl::MetricsGroupWrapper("HomeBlks", homeblks_name) {
         REGISTER_HISTOGRAM(scan_volumes_latency, "Scan Volumes latency");
         REGISTER_COUNTER(boot_cnt, "boot cnt", sisl::_publish_as::publish_as_gauge);
+        REGISTER_GAUGE(recovery_phase0_latency, "recovery phase0 latency");
+        REGISTER_GAUGE(recovery_phase1_latency, "recovery phase1 latency");
+        REGISTER_GAUGE(recovery_phase2_latency, "recovery phase2 latency");
+        REGISTER_GAUGE(recovery_log_store_latency, "recovery logstore latency");
+        REGISTER_GAUGE(recovery_total_latency, "recovery total latency");
         REGISTER_GAUGE(unclean_shutdown, "unclean shutdown");
         register_me_to_farm();
     }
@@ -139,7 +144,7 @@ struct HomeBlksRecoveryStats {
     }
 
     std::string to_string() {
-        return fmt::format("Recovery Total (ms): {}, Recovery Total (ms): {},  Volume Phase-1 (ms): {}, Log Store "
+        return fmt::format("Recovery Total (ms): {}, Volume Phase-0 (ms): {},  Volume Phase-1 (ms): {}, Log Store "
                            "Recovery (ms): {}, Volume Phase-2 (ms): {}",
                            m_total_ms, m_phase0_ms, m_phase1_ms, m_log_store_ms, m_phase2_ms);
     }

--- a/src/homeblks/volume/tests/vol_gtest.cpp
+++ b/src/homeblks/volume/tests/vol_gtest.cpp
@@ -770,8 +770,11 @@ public:
         for (uint32_t i{0}; i < mod_tests.size(); ++i) {
             mod_tests[i]->try_init_iteration();
         }
-
-        test_common::set_random_http_port();
+        if (SISL_OPTIONS.count("http_port")) {
+            test_common::set_fixed_http_port(SISL_OPTIONS["http_port"].as< uint32_t >());
+        }else {
+            test_common::set_random_http_port();
+        }
         VolInterface::init(params);
 
         if (wait_for_init_done) { wait_homestore_init_done(); }
@@ -2356,6 +2359,8 @@ SISL_OPTION_GROUP(
      ::cxxopts::value< uint32_t >()->default_value("10"), "interval between create del in seconds"),
     (emulate_hdd_cnt, "", "emulate_hdd_cnt", "emulate_hdd_cnt", ::cxxopts::value< uint32_t >()->default_value("0"),
      "number of files or drives to be emulated as hdd"),
+    (http_port, "", "http_port", "http_port", ::cxxopts::value< uint32_t >()->default_value("5000"),
+     "http server port"),
     (emulate_hdd_stream_cnt, "", "emulate_hdd_stream_cnt", "emulate_hdd_stream_cnt",
      ::cxxopts::value< uint32_t >()->default_value("20"), "number of streams for each emulated hdd"),
     (p_vol_files_space, "", "p_vol_files_space",

--- a/src/homelogstore/tests/test_log_store.cpp
+++ b/src/homelogstore/tests/test_log_store.cpp
@@ -478,7 +478,11 @@ public:
         params.vol_state_change_cb = [](const VolumePtr& vol, vol_state old_state, vol_state new_state) {};
         params.vol_found_cb = [](boost::uuids::uuid uuid) -> bool { return true; };
 
-        test_common::set_random_http_port();
+        if (SISL_OPTIONS.count("http_port")) {
+            test_common::set_fixed_http_port(SISL_OPTIONS["http_port"].as< uint32_t >());
+        }else {
+            test_common::set_random_http_port();
+        }
         VolInterface::init(params, restart);
 
         {
@@ -1208,7 +1212,9 @@ SISL_OPTION_GROUP(test_log_store,
                    ::cxxopts::value< uint32_t >()->default_value("10000"), "number"),
                   (spdk, "", "spdk", "spdk", ::cxxopts::value< bool >()->default_value("false"), "true or false"),
                   (iterations, "", "iterations", "Iterations", ::cxxopts::value< uint32_t >()->default_value("1"),
-                   "the number of iterations to run each test"));
+                   "the number of iterations to run each test"),
+                  (http_port, "", "http_port", "http_port", ::cxxopts::value< uint32_t >()->default_value("5000"),
+                   "http server port"));
 
 #if 0
 void parse() {

--- a/src/test_common/homestore_test_common.hpp
+++ b/src/test_common/homestore_test_common.hpp
@@ -30,6 +30,13 @@ const std::string USER_WANT_DIRECT_IO{"USER_WANT_DIRECT_IO"};               // u
 
 namespace test_common {
 
+// Fix a port for http server
+inline static void set_fixed_http_port(uint32_t http_port){
+    IM_SETTINGS_FACTORY().modifiable_settings([http_port](auto& s) { s.io_env->http_port = http_port; });
+    IM_SETTINGS_FACTORY().save();
+    LOGINFO("http port = {}", http_port);
+}
+
 // generate random port for http server
 inline static void set_random_http_port() {
     static std::random_device dev;

--- a/src/test_scripts/vol_test.py
+++ b/src/test_scripts/vol_test.py
@@ -330,35 +330,35 @@ def vdev_nightly():
 def meta_blk_store_nightly():
     print("meta blk store test started")
     cmd_opts = "--gtest_filter=VMetaBlkMgrTest.CompressionBackoff"
-    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
+    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts + http_port, stderr=subprocess.STDOUT, shell=True)
     
     cmd_opts = "--gtest_filter=VMetaBlkMgrTest.RecoveryFromBadData"
-    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
+    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts + http_port, stderr=subprocess.STDOUT, shell=True)
 
     cmd_opts = "--gtest_filter=VMetaBlkMgrTest.min_drive_size_test"
-    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
+    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts + http_port, stderr=subprocess.STDOUT, shell=True)
 
     cmd_opts = "--gtest_filter=VMetaBlkMgrTest.single_read_test"
-    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
+    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts + http_port, stderr=subprocess.STDOUT, shell=True)
     
     cmd_opts = "--run_time=7200 --num_io=1000000"
-    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
+    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts + http_port, stderr=subprocess.STDOUT, shell=True)
     
     cmd_opts = "--min_write_size=65536 --max_write_size=2097152 --run_time=14400 --num_io=1000000"
-    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
+    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts + http_port, stderr=subprocess.STDOUT, shell=True)
     
     cmd_opts = "--min_write_size=10485760 --max_write_size=104857600 --bitmap=1"
-    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
+    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts + http_port, stderr=subprocess.STDOUT, shell=True)
     
     cmd_opts = "--gtest_filter=VMetaBlkMgrTest.write_to_full_test" # write to file instead of real disk to save time;
-    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
+    subprocess.check_call(dirpath + "test_meta_blk_mgr " + cmd_opts + http_port, stderr=subprocess.STDOUT, shell=True)
     print("meta blk store test completed")
 
 def logstore_nightly():
     print("log store test started")
 
     cmd_opts = "--iterations=10"
-    subprocess.check_call(dirpath + "test_log_store " + cmd_opts, stderr=subprocess.STDOUT, shell=True)
+    subprocess.check_call(dirpath + "test_log_store " + cmd_opts + http_port, stderr=subprocess.STDOUT, shell=True)
 
     print("log store test completed")
     

--- a/src/test_scripts/vol_test.py
+++ b/src/test_scripts/vol_test.py
@@ -13,12 +13,13 @@ import requests
 from threading import Thread
 
 
-opts,args = getopt.getopt(sys.argv[1:], 'tdlme:', ['test_suits=', 'dirpath=', 'dev_list=', 'log_mods=', 'emulate_hdd='] ) 
+opts,args = getopt.getopt(sys.argv[1:], 'tdlme:', ['test_suits=', 'dirpath=', 'dev_list=', 'log_mods=', 'emulate_hdd=', 'http_port='] )
 test_suits = ""
 dirpath = "./"
 dev_list = ""
 log_mods = ""
 emulate_hdd=""
+http_port = ""
 app_mem_size_in_gb=""
 skip_vol_verify_recovery=""
 
@@ -32,6 +33,9 @@ for opt,arg in opts:
     if opt in ('-l', '--dev_list'):
         dev_list = arg
         print(("device list (%s)") % (arg))
+    if opt in ('-p', '--http_port'):
+        http_port = " --http_port " + arg
+        print(("http_port (%s)") % (arg))
     if opt in ('-m', '--log_mods'):
         log_mods = arg
         print(("log_mods (%s)") % (arg))
@@ -59,7 +63,7 @@ if (test_suits == "nightly") :
     if (os.environ.get('USER_WANT_SPDK')) or ("--spdk" in addln_opts):
         app_mem_size_in_gb = ' --app_mem_size_in_gb=5' # set to 5GB for spdk mode;
 
-vol_addln_opts = addln_opts + emulate_hdd + app_mem_size_in_gb + skip_vol_verify_recovery
+vol_addln_opts = addln_opts + emulate_hdd + app_mem_size_in_gb + skip_vol_verify_recovery + http_port
 
 print("addln_opts: " + addln_opts)
 print("vol_addln_opts: " + vol_addln_opts)
@@ -477,7 +481,7 @@ def vdev_mod_abort():
 def http_sanity_routine():
     sleep(20)
     get_api_list = ['version', 'getObjLife', 'getLogLevel', 'verifyHS', 'mallocStats', 'getConfig', 'getStatus'""", 'verifyBitmap'"""]
-    endpoint = "127.0.0.1:12345"
+    endpoint = "127.0.0.1:5000"
     # homestore takes variable time to init. Retry brfore failing.
     retry_limit = 10
     for api in get_api_list:


### PR DESCRIPTION
Enabling the option `http_port` in `test_volume`, `test_log_store`, and `test_meta_blk_mgr` that one can specify the http port, o.w, a random port is picked. Furthermore, some gauges have been introduced in `homeblk` to expose the values of recovery latencies to Sherlock dashboard. 
The http port is set to 5000 in `nightly` test suit as it is required by Sherlock. 

### Testing
The changes have been manually tested on 137/sds-tess85-01. 
**script**: `python3 /usr/local/bin/vol_test.py --test_suits=nightly --dirpath=/usr/local/bin/ --dev_list=/dev/data1 --http_port=5000`
Accordingly a `Homestore-test` dashboard has been created to consume the introduced metrics in a plot named "recovery latency" ([link](https://console.sherlock.io/d/JcxkSlBVk/sds-homestore-test?orgId=1&from=1680120975081&to=1680130148152))