### PR TITLE
SDSTOR-xxxx turn off bitmap verification in release mode

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.5.18"
+    version = "3.5.19"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/homeblks/homeblks_config.fbs
+++ b/src/homeblks/homeblks_config.fbs
@@ -29,7 +29,7 @@ table GeneralConfig {
     // Frequency with which we need to check the success of shutdown
     shutdown_status_check_freq_ms: uint64 = 2000;
     // Consistency check on booting 
-    boot_consistency_check: bool = true;
+    boot_consistency_check: bool = false;
 
     // These fields should only be changed by agent through workflow
     boot_restricted_mode: bool = false;


### PR DESCRIPTION
1. in prereleas mode, boot_consistentcy_check is hard coded to be true (in existing code HomeBlks::init_done);
2. in release mode, we set default value as false which we want to turn it off in prod environment.

Testing:
======
1. local build test passed with debug build.
2. local build test of release mode and make sure verify bitmap is not triggered.