### PR TITLE
SDSTOR-10252 Copy Volume Out of HomeStore

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.6.1"
+    version = "3.6.2"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/api/vol_interface.hpp
+++ b/src/api/vol_interface.hpp
@@ -348,6 +348,8 @@ public:
     virtual void print_tree(const VolumePtr& vol, bool chksum = true) = 0;
     virtual bool verify_tree(const VolumePtr& vol) = 0;
 
+    virtual std::error_condition copy_vol(const boost::uuids::uuid& uuid, const std::string& path) = 0;
+
     /**
      * @brief : fix the btree which is in corrupted state;
      *

--- a/src/homeblks/home_blks.cpp
+++ b/src/homeblks/home_blks.cpp
@@ -1172,4 +1172,17 @@ iomgr::drive_type HomeBlks::data_drive_type() {
     }
 }
 
+std::error_condition HomeBlks::copy_vol(const boost::uuids::uuid& uuid, const std::string& file_path) {
+    // at this point, file_path is gaurnteened to be not existed yet by caller;
+    VolumePtr vol = nullptr;
+    {
+        std::lock_guard< std::recursive_mutex > lg(m_vol_lock);
+        auto it = m_volume_map.find(uuid);
+        if (it == m_volume_map.end()) { return std::make_error_condition(std::errc::no_such_device_or_address); }
+        vol = it->second;
+    }
+
+    return vol->copy_to(file_path);
+}
+
 bool HomeBlks::m_meta_blk_found = false;

--- a/src/homeblks/home_blks.hpp
+++ b/src/homeblks/home_blks.hpp
@@ -243,6 +243,9 @@ public:
     virtual cap_attrs get_system_capacity() override {
         return HomeStore< BLKSTORE_BUFFER_TYPE >::get_system_capacity();
     }
+
+    virtual std::error_condition copy_vol(const boost::uuids::uuid& uuid, const std::string& path) override;
+
     /**
      * @brief : fix corrupted mapping in volume
      *

--- a/src/homeblks/homeblks_http_server.cpp
+++ b/src/homeblks/homeblks_http_server.cpp
@@ -82,6 +82,8 @@ void HomeBlksHttpServer::setup_routes() {
                                      Routes::bind(&HomeBlksHttpServer::verify_metablk_store, this));
         http_server_ptr->setup_route(Http::Method::Post, "/api/v1/wakeupInit",
                                      Routes::bind(&HomeBlksHttpServer::wakeup_init, this));
+        http_server_ptr->setup_route(Http::Method::Post, "/api/v1/copy_vol",
+                                     Routes::bind(&HomeBlksHttpServer::copy_vol, this));
 #ifdef _PRERELEASE
         http_server_ptr->setup_route(Http::Method::Post, "/api/v1/crashSystem",
                                      Routes::bind(&HomeBlksHttpServer::crash_system, this));
@@ -284,6 +286,47 @@ void HomeBlksHttpServer::verify_bitmap(const Pistache::Rest::Request& request,
 void HomeBlksHttpServer::wakeup_init(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response) {
     m_hb->wakeup_init();
     response.send(Pistache::Http::Code::Ok, "completed");
+}
+
+void HomeBlksHttpServer::copy_vol(iomgr::HttpCallData cd) {
+    if (is_secure_zone() && !is_local_addr(cd->request()->conn->saddr)) {
+        ioenvironment.get_http_server()->respond_NOTOK(cd, EVHTP_RES_FORBIDDEN,
+                                                       "Access not allowed from external host");
+        return;
+    }
+    auto req = cd->request();
+
+    std::vector< std::string > vol_uuids;
+    auto vol_uuids_kv = evhtp_kvs_find_kv(req->uri->query, "uuid");
+    if (vol_uuids_kv) {
+        boost::algorithm::split(vol_uuids, vol_uuids_kv->val, boost::is_any_of(","), boost::token_compress_on);
+    }
+
+    std::vector< std::string > write_path;
+    auto write_path_kv = evhtp_kvs_find_kv(req->uri->query, "path");
+    if (write_path_kv) {
+        boost::algorithm::split(write_path, write_path_kv->val, boost::is_any_of(","), boost::token_compress_on);
+    }
+
+    std::string resp{"volume write to path: " + write_path[0] + " , file name: " + vol_uuids[0]};
+    auto hb = to_homeblks(cd);
+
+    //
+    // TODO: error condition:
+    // 0. only take one vol uuid and one write path;
+    // 1. return error if uuid file already exists;
+    // 2. vol uuid not recognized;
+    // 3. check disk free space before copying;
+    //
+    boost::uuids::string_generator gen;
+    boost::uuids::uuid uuid = gen(vol_uuids[0]);
+
+    // TODO: remove tailing / of write_path[0] if there is any;
+    const auto file_path = write_path[0] + "/" + vol_uuids[0];
+    const auto err = hb->copy_vol(uuid, file_path);
+
+    resp += (err == no_error ? " Successfully" : " Failed");
+    ioenvironment.get_http_server()->respond_OK(cd, EVHTP_RES_OK, resp);
 }
 
 #ifdef _PRERELEASE

--- a/src/homeblks/homeblks_http_server.cpp
+++ b/src/homeblks/homeblks_http_server.cpp
@@ -328,10 +328,15 @@ void HomeBlksHttpServer::copy_vol(const Pistache::Rest::Request& request, Pistac
         response.send(Pistache::Http::Code::Bad_Request, resp_fail);
     }
 
-    const auto err = m_hb->copy_vol(uuid, file_path);
+    // const auto err = m_hb->copy_vol(uuid, file_path);
 
-    std::string resp{"volume write to path: " + write_path[0] + " , file name: " + file_name};
-    resp += (err == no_error ? " Successfully" : (" Failed, error msg: " + err.message()));
+    auto sthread =
+        sisl::named_thread("copy_volume", [this, uuid, file_path]() mutable { m_hb->copy_vol(uuid, file_path); });
+    sthread.detach();
+
+    std::string resp{"Starting volume write to path: " + write_path[0] + " , file name: " + file_name +
+                     " Successfully"};
+    // resp += (err == no_error ? " Successfully" : (" Failed, error msg: " + err.message()));
 
     response.send(Pistache::Http::Code::Ok, resp);
 }

--- a/src/homeblks/homeblks_http_server.hpp
+++ b/src/homeblks/homeblks_http_server.hpp
@@ -50,6 +50,7 @@ public:
     void dump_disk_metablks(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void verify_metablk_store(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void wakeup_init(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
+    void copy_vol(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
 #ifdef _PRERELEASE
     void set_safe_mode(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void unset_safe_mode(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);

--- a/src/homeblks/volume/CMakeLists.txt
+++ b/src/homeblks/volume/CMakeLists.txt
@@ -56,13 +56,16 @@ if (${build_io_tests})
             SET_TESTS_PROPERTIES(TestHSForceReinit-Epoll PROPERTIES DEPENDS TestVol-Epoll)
         endif()
 
-        add_test(NAME TestVolRecovery-Epoll COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/scripts/vol_test.py --test_suits=recovery --dirpath=${CMAKE_BINARY_DIR}/bin/ --emulate_hdd=1 --)
+        add_test(NAME TestVolCopy-Epoll COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/scripts/vol_test.py --test_suits=copy_vol --dirpath=${CMAKE_BINARY_DIR}/bin/ --emulate_hdd=1 --)
         if (${PRERELEASE_ON})
-            SET_TESTS_PROPERTIES(TestVolRecovery-Epoll PROPERTIES DEPENDS TestHSForceReinit-Epoll)
+            SET_TESTS_PROPERTIES(TestVolCopy-Epoll PROPERTIES DEPENDS TestHSForceReinit-Epoll)
         else()
-            SET_TESTS_PROPERTIES(TestVolRecovery-Epoll PROPERTIES DEPENDS TestVol-Epoll)
+            SET_TESTS_PROPERTIES(TestVolCopy-Epoll PROPERTIES DEPENDS TestVol-Epoll)
         endif()
-    
+
+        add_test(NAME TestVolRecovery-Epoll COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/scripts/vol_test.py --test_suits=recovery --dirpath=${CMAKE_BINARY_DIR}/bin/ --emulate_hdd=1 --)
+        SET_TESTS_PROPERTIES(TestVolRecovery-Epoll PROPERTIES DEPENDS TestVolCopy-Epoll)
+            
         add_test(NAME TestVolRecoveryCrash-Epoll COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/scripts/vol_test.py --test_suits=recovery_crash --dirpath=${CMAKE_BINARY_DIR}/bin/ --emulate_hdd=1 --)
         SET_TESTS_PROPERTIES(TestVolRecoveryCrash-Epoll PROPERTIES DEPENDS TestVolRecovery-Epoll)
         add_test(NAME TestVolError-Epoll COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/test_volume --flip=2 --verify_type=2 --emulate_hdd_cnt=1)
@@ -89,13 +92,16 @@ if (${build_io_tests})
             SET_TESTS_PROPERTIES(TestHSForceReinit-Spdk PROPERTIES DEPENDS TestVol-Spdk)
         endif()
 
-        add_test(NAME TestVolRecovery-Spdk COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/scripts/vol_test.py --test_suits=recovery --dirpath=${CMAKE_BINARY_DIR}/bin/ -- --spdk true)
+        add_test(NAME TestVolCopy-Spdk COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/scripts/vol_test.py --test_suits=copy_vol --dirpath=${CMAKE_BINARY_DIR}/bin/ -- --spdk true)
         if (${PRERELEASE_ON})
-            SET_TESTS_PROPERTIES(TestVolRecovery-Spdk PROPERTIES DEPENDS TestHSForceReinit-Spdk)
+            SET_TESTS_PROPERTIES(TestVolCopy-Spdk PROPERTIES DEPENDS TestHSForceReinit-Spdk)
         else()
-            SET_TESTS_PROPERTIES(TestVolRecovery-Spdk PROPERTIES DEPENDS TestVol-Spdk)
+            SET_TESTS_PROPERTIES(TestVolCopy-Spdk PROPERTIES DEPENDS TestVol-Spdk)
         endif()
-    
+
+        add_test(NAME TestVolRecovery-Spdk COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/scripts/vol_test.py --test_suits=recovery --dirpath=${CMAKE_BINARY_DIR}/bin/ -- --spdk true)
+        SET_TESTS_PROPERTIES(TestVolRecovery-Spdk PROPERTIES DEPENDS TestVolCopy-Spdk)
+
         add_test(NAME TestVolRecoveryCrash-Spdk COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/scripts/vol_test.py --test_suits=recovery_crash --dirpath=${CMAKE_BINARY_DIR}/bin/ -- --spdk true)
         SET_TESTS_PROPERTIES(TestVolRecoveryCrash-Spdk PROPERTIES DEPENDS TestVolRecovery-Spdk)
         add_test(NAME TestVolError-Spdk COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/test_volume --spdk --flip=2 --verify_type=2)

--- a/src/homeblks/volume/tests/vol_gtest.cpp
+++ b/src/homeblks/volume/tests/vol_gtest.cpp
@@ -2213,6 +2213,35 @@ TEST_F(VolTest, recovery_io_test) {
     @brief  Tests which does recovery. End up with a clean shutdown
     This test doesn't do any io to volume;
  */
+TEST_F(VolTest, recovery_boot_test) {
+    const auto start_time(Clock::now());
+    tcfg.init = false;
+    this->start_homestore(false /* force_reinit */);
+
+    LOGINFO("recovery verify started");
+    std::unique_ptr< VolVerifyJob > verify_job;
+    if (tcfg.pre_init_verify || tcfg.verify_only) {
+        verify_job = std::make_unique< VolVerifyJob >(this);
+        this->start_job(verify_job.get(), wait_type::for_completion);
+        LOGINFO("recovery verify done");
+    } else {
+        LOGINFO("bypassing recovery verify");
+    }
+
+    while ((get_elapsed_time_sec(start_time) < tcfg.run_time)) {
+        std::this_thread::sleep_for(std::chrono::seconds{2});
+    }
+
+    if (tcfg.can_delete_volume) { this->delete_volumes(); }
+    this->shutdown();
+    if (tcfg.remove_file_on_shutdown) { this->remove_files(); }
+}
+
+/*!
+    @test   recovery_boot_copy_vol_test
+    @brief  Tests which does recovery. End up with a clean shutdown
+    This test doesn't do any io to volume;
+ */
 TEST_F(VolTest, recovery_boot_copy_vol_test) {
     const auto start_time(Clock::now());
     tcfg.init = false;

--- a/src/homeblks/volume/tests/vol_gtest.cpp
+++ b/src/homeblks/volume/tests/vol_gtest.cpp
@@ -1345,7 +1345,8 @@ public:
 
                 if (crc1 != zero_crc) {
                     std::memset(read_buf, 0, tcfg.vol_page_size);
-                    pread(fd, read_buf, tcfg.vol_page_size, crc_off * tcfg.vol_page_size);
+                    [[maybe_unused]] const auto ret =
+                        pread(fd, read_buf, tcfg.vol_page_size, crc_off * tcfg.vol_page_size);
                     const auto crc2 = crc16_t10dif(init_crc_16, read_buf, tcfg.vol_page_size);
                     HS_REL_ASSERT_EQ(crc1, crc2, "crc mismatch: origin crc: {}, copy vol crc: {}, offset: {}, len: {}",
                                      crc1, crc2, crc_off, tcfg.vol_page_size);
@@ -1377,7 +1378,7 @@ public:
         const std::string crc_file_name{VOL_PREFIX + std::to_string(0)};
         auto crc_fd = open(crc_file_name.c_str(), O_RDONLY);
         vol_file_hdr hdr;
-        pread(crc_fd, (char*)&hdr, VOL_FILE_HDR_SZ, 0 /* offset*/);
+        [[maybe_unused]] const auto rd_sz = pread(crc_fd, (char*)&hdr, VOL_FILE_HDR_SZ, 0 /* offset*/);
 
         // 1. verify uuid does match;
         HS_DBG_ASSERT_EQ(vol_uuid, boost::uuids::to_string(hdr.uuid));
@@ -1421,11 +1422,12 @@ public:
             for (pos = data; pos < hole;) {
                 // io size should be times of 4KB;
                 std::memset(buf, 0, tcfg.vol_page_size);
-                pread(fd, buf, tcfg.vol_page_size, pos);
+                [[maybe_unused]] const auto ret = pread(fd, buf, tcfg.vol_page_size, pos);
                 // calculate crc
                 const auto crc1 = crc16_t10dif(init_crc_16, buf, tcfg.vol_page_size);
                 uint16_t crc2 = 0;
-                pread(crc_fd, &crc2, sizeof(uint16_t), VOL_FILE_HDR_SZ + (pos / tcfg.vol_page_size) * sizeof(uint16_t));
+                [[maybe_unused]] const auto ret2 = pread(
+                    crc_fd, &crc2, sizeof(uint16_t), VOL_FILE_HDR_SZ + (pos / tcfg.vol_page_size) * sizeof(uint16_t));
                 HS_REL_ASSERT_EQ(crc1, crc2, "crc mismatch: copy vol crc: {}, origin crc: {}, offset: {}, len: {}",
                                  crc1, crc2, pos, tcfg.vol_page_size);
                 pos += tcfg.vol_page_size;

--- a/src/homeblks/volume/tests/vol_gtest.cpp
+++ b/src/homeblks/volume/tests/vol_gtest.cpp
@@ -173,6 +173,7 @@ struct TestCfg {
     uint32_t create_del_ops_interval;
     uint32_t p_vol_files_space;
     std::string flip_name;
+    std::string vol_copy_file_path;
 
     bool verify_csum() { return verify_type == verify_type_t::csum; }
     bool verify_data() { return verify_type == verify_type_t::data; }
@@ -1310,6 +1311,76 @@ private:
         }
     }
 
+    // vol data is copied to "vol_copy_file_path",
+    // 1. read data out, calculate crc and compare it with vol file saved under test_files/vol[1...x]
+    // 2. this is only valid when --verify_type is set to 0, which is default value;
+    void verify_vol_copy(std::string& vol_copy_file_path) {
+        // vol_copy_file_path: the file dumped with copied volume data
+        // crc_file_name: the file stored with crc when volume is being written in io job;
+        const auto vol_uuid = fs::path(vol_copy_file_path).filename();
+        const std::string crc_file_name{VOL_PREFIX + std::to_string(0)};
+        auto crc_fd = open(crc_file_name.c_str(), O_RDONLY);
+        const auto hdr_offset = sizeof(vol_file_hdr);
+        vol_file_hdr hdr;
+        pread(crc_fd, (char*)&hdr, hdr_offset, 0 /* offset*/);
+
+        // 1. verify uuid does match;
+        HS_DBG_ASSERT_EQ(vol_uuid.string(), boost::uuids::to_string(hdr.uuid));
+
+        // 2. read vol_copy_rf (sparse file) and compare with vol_file (dense file);
+        //    make sure everything written in vol_copy is also written in vol_file;
+        auto fd = open(vol_copy_file_path.c_str(), O_RDONLY);
+
+        // std::vector< uint16_t > crc_vec;
+        off_t hole, data, pos, len;
+        auto buf = iomanager.iobuf_alloc(512 /* alignment */,
+                                         tcfg.vol_page_size); // replace with data blkstore get_align_size();
+        for (hole = 0;; data = hole) {
+            if ((data = lseek(fd, hole, SEEK_DATA)) == -1) {
+                if (errno == ENXIO) {
+                    LOGINFO("no more data on seek + data.");
+                    break;
+                }
+            }
+
+            if ((hole = lseek(0, data, SEEK_HOLE)) == -1) {
+                if (errno == ENXIO) {
+                    LOGINFO("no more data on seek + data.");
+                    break;
+                }
+            }
+
+            HS_DBG_ASSERT_EQ(data % tcfg.vol_page_size, 0, "Unexpected data offset: {}", data);
+            HS_DBG_ASSERT_EQ(hole % tcfg.vol_page_size, 0, "Unexpected hole offset: {}", hole);
+
+            const auto data_len = hole - data;
+            LOGINFO("data len: {}", data_len);
+
+            for (pos = data; pos < hole;) {
+                // io size should be times of 4KB;
+                const auto len = tcfg.vol_page_size;
+                pread(fd, buf, len, pos);
+                // calculate crc
+                const auto crc1 = crc16_t10dif(init_crc_16, buf, len);
+                uint16_t crc2 = 0;
+                pread(crc_fd, &crc2, sizeof(uint16_t), hdr_offset + (data / tcfg.vol_page_size) * sizeof(uint16_t));
+                HS_DBG_ASSERT_EQ(crc1, crc2, "crc mismatch: copy vol crc: {}, origin crc: {}, offset: {}, len: {}",
+                                 crc1, crc2, pos, len);
+                // crc_vec.push_back(crc);
+                pos += len;
+            }
+
+            HS_DBG_ASSERT_EQ(pos, hole, "pos: {}, hole: {}", pos, hole);
+        }
+
+        iomanager.iobuf_free(buf);
+        close(fd);
+
+        // 3. read vol_file, skip all zero crc, and compare it with vol_copy_rf
+        //   cross compare, making sure vol_copy_rf is not missing any data written in vol_file;
+        close(crc_fd);
+    }
+
 public:
     void force_reinit(const std::vector< dev_info >& data_devices, const io_flag data_oflags,
                       const io_flag fast_oflags) {
@@ -1689,9 +1760,10 @@ protected:
         ++m_outstanding_ios;
         vinfo->ref_cnt.increment(1);
         const auto ret_io{VolInterface::get_instance()->write(vol, vreq)};
-        LOGDEBUG("Wrote lba: {}, nlbas: {} outstanding_ios={}, iovec(s)={}, cache={}", lba, nlbas,
-                 m_outstanding_ios.load(), (tcfg.write_iovec != 0 ? true : false),
-                 (tcfg.write_cache != 0 ? true : false));
+        // LOGDEBUG("Wrote lba: {}, nlbas: {} outstanding_ios={}, iovec(s)={}, cache={}", lba, nlbas,
+        LOGINFO("Wrote lba: {}, nlbas: {} outstanding_ios={}, iovec(s)={}, cache={}", lba, nlbas,
+                m_outstanding_ios.load(), (tcfg.write_iovec != 0 ? true : false),
+                (tcfg.write_cache != 0 ? true : false));
         if (ret_io != no_error) { return false; }
         return true;
     }
@@ -2104,6 +2176,11 @@ TEST_F(VolTest, recovery_boot_test) {
 
     output.print("recovery_boot_test");
 
+    LOGINFO("Starting to verify dumpped files with saved vol file with crc checksum");
+
+    // TODO: send curl http command to dump volume file in this test case and use file name to call verify;
+    verify_vol_copy(tcfg.vol_copy_file_path);
+
     if (tcfg.can_delete_volume) { this->delete_volumes(); }
     this->shutdown();
     if (tcfg.remove_file_on_shutdown) { this->remove_files(); }
@@ -2410,6 +2487,8 @@ SISL_OPTION_GROUP(
     (max_io_size, "", "max_io_size", "max io size", ::cxxopts::value< uint64_t >()->default_value("4096"),
      "max_io_size"),
     (io_size, "", "io_size", "io size in KB", ::cxxopts::value< uint32_t >()->default_value("4"), "io_size"),
+    (vol_copy_file_path, "", "vol_copy_file_path", "file path for copied volume",
+     ::cxxopts::value< std::string >()->default_value(""), "path [...]"),
     (unmap_frequency, "", "unmap_frequency", "do unmap for every N",
      ::cxxopts::value< uint64_t >()->default_value("100"), "unmap_frequency"))
 
@@ -2484,6 +2563,7 @@ int main(int argc, char* argv[]) {
     gcfg.emulate_hdd_stream_cnt = SISL_OPTIONS["emulate_hdd_stream_cnt"].as< uint32_t >();
     gcfg.p_vol_files_space = SISL_OPTIONS["p_vol_files_space"].as< uint32_t >();
     gcfg.app_mem_size_in_gb = SISL_OPTIONS["app_mem_size_in_gb"].as< uint32_t >();
+    gcfg.vol_copy_file_path = SISL_OPTIONS["vol_copy_file_path"].as< std::string >();
     const auto io_size_in_kb = SISL_OPTIONS["io_size"].as< uint32_t >();
     gcfg.io_size = io_size_in_kb * 1024;
 

--- a/src/homeblks/volume/tests/vol_gtest.cpp
+++ b/src/homeblks/volume/tests/vol_gtest.cpp
@@ -773,7 +773,7 @@ public:
         }
         if (SISL_OPTIONS.count("http_port")) {
             test_common::set_fixed_http_port(SISL_OPTIONS["http_port"].as< uint32_t >());
-        }else {
+        } else {
             test_common::set_random_http_port();
         }
         VolInterface::init(params);
@@ -2068,6 +2068,41 @@ TEST_F(VolTest, recovery_io_test) {
     output.print("recovery_io_test");
 
     if (tcfg.create_del_with_io || tcfg.delete_with_io) { cdjob->wait_for_completion(); }
+
+    if (tcfg.can_delete_volume) { this->delete_volumes(); }
+    this->shutdown();
+    if (tcfg.remove_file_on_shutdown) { this->remove_files(); }
+}
+
+/*!
+    @test   recovery_boot_test
+    @brief  Tests which does recovery. End up with a clean shutdown
+    This test doesn't do any io to volume;
+ */
+TEST_F(VolTest, recovery_boot_test) {
+    const auto start_time(Clock::now());
+    tcfg.init = false;
+    this->start_homestore(false /* force_reinit */);
+
+    LOGINFO("recovery verify started");
+    std::unique_ptr< VolVerifyJob > verify_job;
+    if (tcfg.pre_init_verify || tcfg.verify_only) {
+        verify_job = std::make_unique< VolVerifyJob >(this);
+        this->start_job(verify_job.get(), wait_type::for_completion);
+        LOGINFO("recovery verify done");
+    } else {
+        LOGINFO("bypassing recovery verify");
+    }
+
+#if 0
+    this->start_io_job();
+#endif
+
+    while (get_elapsed_time_sec(start_time) < tcfg.run_time) {
+        std::this_thread::sleep_for(std::chrono::seconds{10});
+    }
+
+    output.print("recovery_boot_test");
 
     if (tcfg.can_delete_volume) { this->delete_volumes(); }
     this->shutdown();

--- a/src/homeblks/volume/tests/vol_gtest.cpp
+++ b/src/homeblks/volume/tests/vol_gtest.cpp
@@ -1358,6 +1358,9 @@ public:
         }
         // end of file
 
+        iomanager.iobuf_free(read_buf);
+        close(crc_fd);
+        close(fd);
         LOGINFO("Successfully reverse verified crc.");
     }
 

--- a/src/homeblks/volume/volume.cpp
+++ b/src/homeblks/volume/volume.cpp
@@ -1172,7 +1172,7 @@ void VolumeMetrics::on_gather() {
 //
 std::error_condition Volume::copy_to(const std::string& file_path) {
     // open file;
-    auto fd = open(file_path.c_str(), O_RDWR | O_CREAT | O_DIRECT);
+    auto fd = ::open(file_path.c_str(), O_RDWR | O_CREAT | O_DIRECT, 0666);
     if (fd == -1) {
         LOGERROR("open file failed: errno: {}, msg: {}", errno, std::strerror(errno));
         return std::make_error_condition(std::errc::invalid_argument);

--- a/src/homeblks/volume/volume.hpp
+++ b/src/homeblks/volume/volume.hpp
@@ -613,6 +613,8 @@ public:
     }
 
     void inc_ref_cnt();
+
+    std::error_condition copy_to(const std::string& file_path);
 };
 
 /* Note :- Any member inside this structure is not lock protected. Its caller responsibility to call it under lock

--- a/src/test_scripts/vol_test.py
+++ b/src/test_scripts/vol_test.py
@@ -71,6 +71,22 @@ print("vol_addln_opts: " + vol_addln_opts)
 meta_flip_list = ["write_sb_abort", "write_with_ovf_abort", "remove_sb_abort", "update_sb_abort", "abort_before_recover_cb_sent", "abort_after_recover_cb_sent"]
 vdev_flip_list = ["abort_before_update_eof_cur_chunk", "abort_after_update_eof_cur_chunk", "abort_after_update_eof_next_chunk"]
 
+def copy_vol_load():
+    cmd_opts = "--gtest_filter=VolTest.init_io_test  --run_time=600 --max_num_writes=999999 --enable_crash_handler=1 --remove_file_on_shutdown=0 --remove_file_on_start=1 --max_volume=1"
+    subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
+
+    cmd_opts = "--max_volume=1 --gtest_filter=VolTest.recovery_boot_copy_vol_test --remove_file_on_shutdown=1"
+    subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
+    print("copy volume and verify load test passed")
+
+def copy_vol():
+    cmd_opts = "--gtest_filter=VolTest.init_io_test  --run_time=100 --max_num_writes=1000 --enable_crash_handler=1 --remove_file_on_shutdown=0 --remove_file_on_start=1 --max_volume=1"
+    subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
+
+    cmd_opts = "--max_volume=1 --gtest_filter=VolTest.recovery_boot_copy_vol_test --remove_file_on_shutdown=1"
+    subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
+    print("copy volume and verify passed")
+
 def recovery():
     cmd_opts = "--gtest_filter=VolTest.init_io_test --run_time=30 --enable_crash_handler=1 --remove_file_on_shutdown=0 --remove_file_on_start=1"
     subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
@@ -540,6 +556,9 @@ def nightly():
     sleep(5)
 
     #load()
+    sleep(5)
+
+    copy_vol_load();
     sleep(5)
 
     vol_create_delete_test()


### PR DESCRIPTION
Design notes: 
======================
https://docs.google.com/document/d/1MfXIWfk7IJIqvxBME6FJjn26s1Z6LwLwzrVzcsZZsUY/edit#

This http command - copy volume should not crash (no release assert) on IO errors, space full, file already exists, etc. 
It should torrent/expect the error and return corresponding error to http response. 

Example:
========
curl -X PUT "http://localhost:5000/api/v1/copy_vol?uuid=80fcb0aa-e2c0-4aaf-9533-d49b21336bbc&part_info=137_sds_tess86_01_am02&path=./test_files/"

Test:
==============
1. Populate a volume with size 20G, during writing to this volume, write is random and each write will calculate the crc of the data (per page size) being written to volume and saved to another file, the position crc being written is based on the data’s LBA, this way by reading the crc out of the crc file, we know the data corresponding LBA.

2. After Volume is randomly populated with some number (configurable) or some run_time (configurable) of writes, trigger http command to copy the volume to a file based on the write path being passed to http command. 

3. After copy operation is finished, read the file by skipping the holes in the file and calculate crc being read (per page size) and compare the data crc with the one saved on crc file based on data’s LBA (data’s crc location on the crc file can be calculated in order to serve the read).

This step makes sure everything written in the copied volume file does exist and data is correct. E.g. we are not writing/coping any wrong data to the volume file;

4. Do a reverse check by reading the crc file and calculating its data LBA and read on the copied vol file to make sure their crc does match. 

This step makes sure the copied file doesn’t miss any data that exists in the original volume, but not copied to vol file. E.g. we are not missing any volume data. 

5. Also tested starting volume in recovery mode in manual mode and run curl command to verify copy_volume request is served by another thread (http server not blocked) and verified logs that thread exists after copy_vol task is finished.

6.  Also single gdb and verify thread is not there after copy_vol is finished.
