### PR TITLE
SDSTOR-10941 fix no space issue

### DIFF
--- a/src/test_scripts/vol_test.py
+++ b/src/test_scripts/vol_test.py
@@ -72,7 +72,7 @@ meta_flip_list = ["write_sb_abort", "write_with_ovf_abort", "remove_sb_abort", "
 vdev_flip_list = ["abort_before_update_eof_cur_chunk", "abort_after_update_eof_cur_chunk", "abort_after_update_eof_next_chunk"]
 
 def copy_vol_load():
-    cmd_opts = "--gtest_filter=VolTest.init_io_test  --run_time=600 --max_num_writes=999999 --enable_crash_handler=1 --remove_file_on_shutdown=0 --remove_file_on_start=1 --max_volume=1"
+    cmd_opts = "--gtest_filter=VolTest.init_io_test  --run_time=300 --max_num_writes=9999 --enable_crash_handler=1 --remove_file_on_shutdown=0 --remove_file_on_start=1 --max_volume=1"
     subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
 
     cmd_opts = "--max_volume=1 --gtest_filter=VolTest.recovery_boot_copy_vol_test --remove_file_on_shutdown=1"


### PR DESCRIPTION
Seeing no space left on root FS while running load test for copy vol on DesnSKU. 

Verified on pod that the copied vol file, plus the crc file is occupying 20GB, which is the total size of the mounted path for logs.

Change the script only occupying half of the root fs. 

Testing:
======
Manually tested on 85-01 and test case passed after the change which takes about 10GB of the total space.
