### PR TITLE
SDSTOR-10887 : update logstore

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.6.3"
+    version = "3.6.4"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/homeblks/homeblks_http_server.cpp
+++ b/src/homeblks/homeblks_http_server.cpp
@@ -77,6 +77,10 @@ void HomeBlksHttpServer::setup_routes() {
                                      Routes::bind(&HomeBlksHttpServer::get_status, this));
         http_server_ptr->setup_route(Http::Method::Get, "/api/v1/verifyBitmap",
                                      Routes::bind(&HomeBlksHttpServer::verify_bitmap, this), iomgr::url_t::localhost);
+        http_server_ptr->setup_route(Http::Method::Get, "/api/v1/logstore/:family/dump",
+                                     Routes::bind(&HomeBlksHttpServer::dump_logstore_family, this));
+        http_server_ptr->setup_route(Http::Method::Get, "/api/v1/logstore/:family/:logstore/dump",
+                                     Routes::bind(&HomeBlksHttpServer::dump_logstore_by_id, this));
         http_server_ptr->setup_route(Http::Method::Get, "/api/v1/dumpDiskMetaBlks",
                                      Routes::bind(&HomeBlksHttpServer::dump_disk_metablks, this));
         http_server_ptr->setup_route(Http::Method::Get, "/api/v1/verifyMetaBlkStore",
@@ -256,6 +260,55 @@ void HomeBlksHttpServer::dump_disk_metablks(const Pistache::Rest::Request& reque
         response.send(Pistache::Http::Code::Bad_Request,
                       "HomeBlks not in safe mode, not allowed to serve this request");
     }
+}
+
+void HomeBlksHttpServer::dump_logstore_family(const Pistache::Rest::Request& request,
+                                              Pistache::Http::ResponseWriter response) {
+    auto f_name = request.param(":family").as< std::string >();
+    homestore::log_dump_req dump_req{homestore::log_dump_req()};
+    auto family = HomeLogStoreMgrSI().get_family(f_name);
+    if (family == nullptr) {
+        response.send(Pistache::Http::Code::Bad_Request, "invalid log family");
+        return;
+    }
+    const auto start_seq_num_kv{request.query().get("start_seq_num")};
+    if (start_seq_num_kv) dump_req.start_seq_num = std::stoll(start_seq_num_kv.value());
+    const auto end_seq_num_kv{request.query().get("end_seq_num")};
+    if (end_seq_num_kv) dump_req.end_seq_num = std::stoll(end_seq_num_kv.value());
+
+    const auto content_kv{request.query().get("content")};
+    if (content_kv) dump_req.verbosity_level = log_dump_verbosity::CONTENT;
+
+    auto status_json = family->dump_log_store(dump_req);
+    response.send(Pistache::Http::Code::Ok, status_json.dump());
+}
+
+void HomeBlksHttpServer::dump_logstore_by_id(const Pistache::Rest::Request& request,
+                                             Pistache::Http::ResponseWriter response) {
+    auto f_name = request.param(":family").as< std::string >();
+    auto store_id = request.param(":logstore").as< int >();
+    homestore::log_dump_req dump_req{homestore::log_dump_req()};
+    auto family = HomeLogStoreMgrSI().get_family(f_name);
+    if (family == nullptr) {
+        response.send(Pistache::Http::Code::Bad_Request, "invalid log family");
+        return;
+    }
+    const auto start_seq_num_kv{request.query().get("start_seq_num")};
+    if (start_seq_num_kv) dump_req.start_seq_num = std::stoll(start_seq_num_kv.value());
+    const auto end_seq_num_kv{request.query().get("end_seq_num")};
+    if (end_seq_num_kv) dump_req.end_seq_num = std::stoll(end_seq_num_kv.value());
+
+    std::string failure_resp{""};
+    int verbosity_level{-1};
+    if (!verify_and_get_verbosity(request, failure_resp, verbosity_level)) {
+        response.send(Pistache::Http::Code::Bad_Request, failure_resp);
+        return;
+    }
+    dump_req.verbosity_level = static_cast<log_dump_verbosity> (verbosity_level);
+    auto logstore = family->find_logstore_by_id(store_id);
+    dump_req.log_store = logstore;
+    auto status_json = family->dump_log_store(dump_req);
+    response.send(Pistache::Http::Code::Ok, status_json.dump());
 }
 
 void HomeBlksHttpServer::get_status(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response) {

--- a/src/homeblks/homeblks_http_server.hpp
+++ b/src/homeblks/homeblks_http_server.hpp
@@ -51,6 +51,9 @@ public:
     void verify_metablk_store(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void wakeup_init(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void copy_vol(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
+    void dump_logstore_family(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
+    void dump_logstore_by_id(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
+
 #ifdef _PRERELEASE
     void set_safe_mode(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void unset_safe_mode(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);

--- a/src/homelogstore/log_store.hpp
+++ b/src/homelogstore/log_store.hpp
@@ -226,6 +226,7 @@ public:
 
     LogStoreFamily* data_log_family() { return m_logstore_families[DATA_LOG_FAMILY_IDX].get(); }
     LogStoreFamily* ctrl_log_family() { return m_logstore_families[CTRL_LOG_FAMILY_IDX].get(); }
+    LogStoreFamily* get_family(std::string family_name);
 
     static LogDev& data_logdev() { return HomeLogStoreMgr::instance().data_log_family()->logdev(); }
     static LogDev& ctrl_logdev() { return HomeLogStoreMgr::instance().ctrl_log_family()->logdev(); }

--- a/src/homelogstore/log_store_family.hpp
+++ b/src/homelogstore/log_store_family.hpp
@@ -70,6 +70,7 @@ public:
 
     [[nodiscard]] nlohmann::json dump_log_store(const log_dump_req& dum_req);
     std::string metablk_name() const { return m_metablk_name; }
+    std::shared_ptr< HomeLogStore > find_logstore_by_id(logstore_id_t store_id);
 
     LogDev& logdev() { return m_log_dev; }
 

--- a/src/homelogstore/log_store_mgr.cpp
+++ b/src/homelogstore/log_store_mgr.cpp
@@ -154,6 +154,13 @@ void HomeLogStoreMgr::start_threads() {
     }
 }
 
+LogStoreFamily* HomeLogStoreMgr::get_family(std::string family_name){
+    for (auto& l : m_logstore_families) {
+        if (l->get_name() == family_name) { return l.get(); }
+    }
+    return nullptr;
+}
+
 nlohmann::json HomeLogStoreMgr::dump_log_store(const log_dump_req& dump_req) {
     nlohmann::json json_dump{}; // create root object
     if (dump_req.log_store == nullptr) {


### PR DESCRIPTION
change:
	1- add dump_logstore_family API
	2- add dump_logstore_by_id API
	3- add range capability for getting status of LogStoreFamily

example:
curl 'localhost:5000/api/v1/getStatus?name=LogStore&type=module&min_logstore_id=4&max_logstore_id=8'
curl 'localhost:5000/api/v1/logstore/LogDevFamily0/dump' | jq .
curl 'localhost:5000/api/v1/logstore/LogDevFamily0/1/dump | jq.
curl 'localhost:5000/api/v1/logstore/LogDevFamily0/1/dump?start_seq_num=100000000&verbosity=0' | jq .