### PR TITLE
Btree and index write back cache fixes

### DIFF
--- a/src/include/homestore/btree/btree.hpp
+++ b/src/include/homestore/btree/btree.hpp
@@ -97,11 +97,11 @@ public:
     // bool verify_tree(bool update_debug_bm) const;
     virtual std::pair< btree_status_t, uint64_t > destroy_btree(void* context);
     nlohmann::json get_status(int log_level) const;
-    void print_tree() const;
+    void print_tree(std::string file = "") const;
     nlohmann::json get_metrics_in_json(bool updated = true);
     bnodeid_t root_node_id() const;
     uint64_t root_link_version() const;
-    void set_root_node_info(const BtreeLinkInfo &info);
+    void set_root_node_info(const BtreeLinkInfo& info);
 
     // static void set_io_flip();
     // static void set_error_flip();
@@ -122,6 +122,7 @@ protected:
                                                 void* context) = 0;
 
     virtual std::string btree_store_type() const = 0;
+    virtual void update_new_root_info(bnodeid_t root_node, uint64_t version) = 0;
 
     /////////////////////////// Methods the application use case is expected to handle ///////////////////////////
 

--- a/src/include/homestore/btree/btree.ipp
+++ b/src/include/homestore/btree/btree.ipp
@@ -56,7 +56,7 @@ btree_status_t Btree< K, V >::init(void* op_context) {
 }
 
 template < typename K, typename V >
-void Btree< K, V >::set_root_node_info(const BtreeLinkInfo &info) {
+void Btree< K, V >::set_root_node_info(const BtreeLinkInfo& info) {
     m_root_node_info = info;
 }
 
@@ -321,13 +321,18 @@ nlohmann::json Btree< K, V >::get_status(int log_level) const {
 }
 
 template < typename K, typename V >
-void Btree< K, V >::print_tree() const {
+void Btree< K, V >::print_tree(std::string file) const {
     std::string buf;
     m_btree_lock.lock_shared();
     to_string(m_root_node_info.bnode_id(), buf);
     m_btree_lock.unlock_shared();
 
     BT_LOG(INFO, "Pre order traversal of tree:\n<{}>", buf);
+    if (!file.empty()) {
+        std::ofstream o(file);
+        o.write(buf.c_str(), buf.size());
+        o.flush();
+    }
 }
 
 template < typename K, typename V >

--- a/src/include/homestore/btree/detail/simple_node.hpp
+++ b/src/include/homestore/btree/detail/simple_node.hpp
@@ -18,6 +18,7 @@
 #include <homestore/btree/btree_kv.hpp>
 #include "btree_node.hpp"
 #include "btree_internal.hpp"
+#include "homestore/index/index_internal.hpp"
 
 using namespace std;
 using namespace boost;
@@ -242,10 +243,10 @@ public:
     }*/
 
     std::string to_string(bool print_friendly = false) const override {
-        auto str = fmt::format("{}id={} nEntries={} {} next_node={} ",
+        auto str = fmt::format("{}id={} level={} nEntries={} {} next_node={} ",
                                (print_friendly ? "------------------------------------------------------------\n" : ""),
-                               this->node_id(), this->total_entries(), (this->is_leaf() ? "LEAF" : "INTERIOR"),
-                               this->next_bnode());
+                               this->node_id(), this->level(), this->total_entries(),
+                               (this->is_leaf() ? "LEAF" : "INTERIOR"), this->next_bnode());
         if (!this->is_leaf() && (this->has_valid_edge())) {
             fmt::format_to(std::back_inserter(str), "edge_id={}.{}", this->edge_info().m_bnodeid,
                            this->edge_info().m_link_version);
@@ -260,6 +261,9 @@ public:
         return str;
     }
 
+    uint8_t* get_node_context() const {
+        return uintptr_cast(const_cast< SimpleNode* >(this)) + sizeof(SimpleNode< K, V >);
+    }
     uint8_t* get_node_context() override { return uintptr_cast(this) + sizeof(SimpleNode< K, V >); }
 
 #ifndef NDEBUG

--- a/src/include/homestore/btree/detail/varlen_node.hpp
+++ b/src/include/homestore/btree/detail/varlen_node.hpp
@@ -19,6 +19,7 @@
 #include <sisl/logging/logging.h>
 #include "btree_node.hpp"
 #include <homestore/btree/btree_kv.hpp>
+#include "homestore/index/index_internal.hpp"
 
 SISL_LOGGING_DECL(btree)
 
@@ -510,6 +511,10 @@ public:
                            get_nth_key< K >(i, false).to_string(), val.to_string());
         }
         return str;
+    }
+
+    uint8_t* get_node_context() const {
+        return uintptr_cast(const_cast< VariableNode* >(this)) + sizeof(VariableNode< K, V >);
     }
 
     uint8_t* get_node_context() override { return uintptr_cast(this) + sizeof(VariableNode< K, V >); }

--- a/src/include/homestore/btree/mem_btree.hpp
+++ b/src/include/homestore/btree/mem_btree.hpp
@@ -69,6 +69,8 @@ private:
         return btree_status_t::success;
     }
 
+    void update_new_root_info(bnodeid_t root_node, uint64_t version) override {}
+
 #if 0
     static void ref_node(MemBtreeNode* bn) {
         auto mbh = (mem_btree_node_header*)bn;

--- a/src/include/homestore/homestore_decl.hpp
+++ b/src/include/homestore/homestore_decl.hpp
@@ -178,6 +178,6 @@ struct cap_attrs {
 ////////////// Misc ///////////////////
 #define HOMESTORE_LOG_MODS                                                                                             \
     btree_structures, btree_nodes, btree_generics, btree, cache, device, blkalloc, vol_io_wd, volume, flip, cp, metablk, \
-        indx_mgr, logstore, replay, transient, IOMGR_LOG_MODS
+        indx_mgr, wbcache, logstore, replay, transient, IOMGR_LOG_MODS
 
 } // namespace homestore

--- a/src/include/homestore/index/wb_cache_base.hpp
+++ b/src/include/homestore/index/wb_cache_base.hpp
@@ -41,11 +41,6 @@ public:
     /// @param buf Buffer to reallocate
     virtual void realloc_buf(const IndexBufferPtr& buf) = 0;
 
-    /// @brief Write buffer
-    /// @param buf
-    /// @param context
-    virtual void write_buf(const BtreeNodePtr& node, const IndexBufferPtr& buf, CPContext* context) = 0;
-
     virtual void read_buf(bnodeid_t id, BtreeNodePtr& node, node_initializer_t&& node_initializer) = 0;
 
     /// @brief Start a chain of related btree buffers. Typically a chain is creating from second and third pairs and
@@ -56,12 +51,12 @@ public:
     /// @param third Thrid btree buffer in the chain. It will be updated to copy of third buffer if buffer already
     /// has dependencies.
     /// @return Returns if the buffer had to be copied
-    virtual bool create_chain(IndexBufferPtr& second, IndexBufferPtr& third) = 0;
+    virtual std::tuple< bool, bool > create_chain(IndexBufferPtr& second, IndexBufferPtr& third, CPContext* cp_ctx) = 0;
 
     /// @brief Prepend to the chain that was already created with second
     /// @param first
     /// @param second
-    virtual void prepend_to_chain(const IndexBufferPtr& first, const IndexBufferPtr& second) = 0;
+    virtual void prepend_to_chain(const IndexBufferGroupPtr& first, const IndexBufferGroupPtr& second) = 0;
 
     /// @brief Free the buffer allocated and remove it from wb cache
     /// @param buf

--- a/src/include/homestore/index_service.hpp
+++ b/src/include/homestore/index_service.hpp
@@ -31,6 +31,7 @@ class VirtualDev;
 
 class IndexServiceCallbacks {
 public:
+    virtual ~IndexServiceCallbacks() = default;
     virtual std::shared_ptr< IndexTableBase > on_index_table_found(const superblk< index_table_sb >& cb) = 0;
 };
 

--- a/src/lib/index/index_service.cpp
+++ b/src/lib/index/index_service.cpp
@@ -90,4 +90,6 @@ uint64_t IndexService::used_size() const {
 IndexBuffer::IndexBuffer(BlkId blkid, uint32_t buf_size, uint32_t align_size) :
         m_node_buf{hs_utils::iobuf_alloc(buf_size, sisl::buftag::btree_node, align_size)}, m_blkid{blkid} {}
 
+IndexBuffer::~IndexBuffer() { hs_utils::iobuf_free(m_node_buf, sisl::buftag::btree_node); }
+
 } // namespace homestore

--- a/src/lib/index/wb_cache.hpp
+++ b/src/lib/index/wb_cache.hpp
@@ -39,7 +39,7 @@ private:
     uint32_t m_node_size;
 
     // Dirty buffer list arranged in a dependent list fashion
-    std::unique_ptr< sisl::ThreadVector< IndexBufferPtr > > m_dirty_list[MAX_CP_COUNT];
+    std::unique_ptr< sisl::ThreadVector< IndexBufferGroupPtr > > m_dirty_list[MAX_CP_COUNT];
     std::unique_ptr< sisl::ThreadVector< BlkId > > m_free_blkid_list[MAX_CP_COUNT]; // Free'd btree blkids per cp
     std::vector< iomgr::io_fiber_t > m_cp_flush_fibers;
     std::mutex m_flush_mtx;
@@ -50,27 +50,32 @@ public:
 
     BtreeNodePtr alloc_buf(node_initializer_t&& node_initializer) override;
     void realloc_buf(const IndexBufferPtr& buf) override;
-    void write_buf(const BtreeNodePtr& node, const IndexBufferPtr& buf, CPContext* cp_ctx) override;
     void read_buf(bnodeid_t id, BtreeNodePtr& node, node_initializer_t&& node_initializer) override;
-    bool create_chain(IndexBufferPtr& second, IndexBufferPtr& third) override;
-    void prepend_to_chain(const IndexBufferPtr& first, const IndexBufferPtr& second) override;
+    std::tuple< bool, bool > create_chain(IndexBufferPtr& second, IndexBufferPtr& third, CPContext* cp_ctx) override;
+    void prepend_to_chain(const IndexBufferGroupPtr& first, const IndexBufferGroupPtr& second) override;
     void free_buf(const IndexBufferPtr& buf, CPContext* cp_ctx) override;
 
     //////////////////// CP Related API section /////////////////////////////////
     folly::Future< bool > async_cp_flush(CPContext* context);
     std::unique_ptr< CPContext > create_cp_context(cp_id_t cp_id);
+
     IndexBufferPtr copy_buffer(const IndexBufferPtr& cur_buf) const;
+    void write_buf_group(const IndexBufferGroupPtr& buf, CPContext* cp_ctx);
 
 private:
     void start_flush_threads();
-    void process_write_completion(IndexCPContext* cp_ctx, IndexBuffer* pbuf);
-    void do_flush_one_buf(IndexCPContext* cp_ctx, const IndexBufferPtr& buf, bool part_of_batch);
-    std::pair< IndexBufferPtr, bool > on_buf_flush_done(IndexCPContext* cp_ctx, IndexBuffer* buf);
-    std::pair< IndexBufferPtr, bool > on_buf_flush_done_internal(IndexCPContext* cp_ctx, IndexBuffer* buf);
 
-    void get_next_bufs(IndexCPContext* cp_ctx, uint32_t max_count, std::vector< IndexBufferPtr >& bufs);
-    void get_next_bufs_internal(IndexCPContext* cp_ctx, uint32_t max_count, IndexBuffer* prev_flushed_buf,
-                                std::vector< IndexBufferPtr >& bufs);
+    void process_write_completion(IndexCPContext* cp_ctx, IndexBufferGroupPtr buf_group);
+    void do_flush_one_buf_group(IndexCPContext* cp_ctx, const IndexBufferGroupPtr& buf, bool part_of_batch);
+    std::pair< IndexBufferGroupPtr, bool > on_buf_group_flush_done(IndexCPContext* cp_ctx,
+                                                                   IndexBufferGroupPtr buf_group);
+    std::pair< IndexBufferGroupPtr, bool > on_buf_group_flush_done_internal(IndexCPContext* cp_ctx,
+                                                                            IndexBufferGroupPtr buf_group);
+
+    void get_next_buf_groups(IndexCPContext* cp_ctx, uint32_t max_count, std::vector< IndexBufferGroupPtr >& bufs);
+    void get_next_buf_groups_internal(IndexCPContext* cp_ctx, uint32_t max_count,
+                                      IndexBufferGroupPtr prev_flushed_buf_group,
+                                      std::vector< IndexBufferGroupPtr >& bufs);
     void free_btree_blks_and_flush(IndexCPContext* cp_ctx);
 };
 } // namespace homestore

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ if (${build_nonio_tests})
 
     set(TEST_MEMBTREE_SOURCE_FILES test_mem_btree.cpp)
     add_executable(test_mem_btree ${TEST_MEMBTREE_SOURCE_FILES})
-    target_link_libraries(test_mem_btree ${COMMON_TEST_DEPS} GTest::gtest)
+    target_link_libraries(test_mem_btree homestore ${COMMON_TEST_DEPS} GTest::gtest)
     add_test(NAME MemBtree COMMAND test_mem_btree)
 
     add_executable(test_blk_read_tracker)

--- a/src/tests/test_mem_btree.cpp
+++ b/src/tests/test_mem_btree.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <gtest/gtest.h>
 
+#include <iomgr/io_environment.hpp>
 #include <sisl/options/options.h>
 #include <sisl/logging/logging.h>
 #include <sisl/utility/enum.hpp>
@@ -28,7 +29,7 @@
 
 static constexpr uint32_t g_node_size{4096};
 using namespace homestore;
-SISL_LOGGING_INIT(btree)
+SISL_LOGGING_INIT(HOMESTORE_LOG_MODS)
 
 SISL_OPTIONS_ENABLE(logging, test_mem_btree)
 SISL_OPTION_GROUP(test_mem_btree,
@@ -274,6 +275,7 @@ TYPED_TEST(BtreeTest, SequentialInsert) {
         this->put(i, btree_put_type::INSERT_ONLY_IF_NOT_EXISTS);
     }
     LOGINFO("Step 2: Query {} entries and validate with pagination of 75 entries", entries_iter1);
+    this->print();
     this->query_validate(0, entries_iter1, 75);
 
     // Reverse sequential insert


### PR DESCRIPTION
Add indexbuffergroup to flush multiple index buffers in order. Add dependency betweeen the groups. To handle cases for level greater than 3.