### PR TITLE
Fix Upgrade in LogstoreFamily

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.6.8"
+    version = "3.6.9"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/homelogstore/log_store_family.cpp
+++ b/src/homelogstore/log_store_family.cpp
@@ -32,7 +32,7 @@ SISL_LOGGING_DECL(logstore)
 
 LogStoreFamily::LogStoreFamily(const logstore_family_id_t f_id) :
         m_family_id{f_id},
-        m_metablk_name{std::string("LogStoreFamily") + std::to_string(f_id)},
+        m_metablk_name{std::string("LogDevFamily") + std::to_string(f_id)},
         m_log_dev{f_id, m_metablk_name} {
 }
 


### PR DESCRIPTION
**Maintaining Compatibility for different versions**
In previous versions of AM image, i.e., AM20, `m_metablk_name` was populated with **LogDevFamily**. In the recent, m_metablk_name had been changed to `LogStoreFamily` which results in broken recovery procedure from older versions. In this PR I revert it back that upgrading from AM -20 to AM21 will be possible. 