### PR TITLE
Fix for vol create with same uuid vol that is pending on destroying.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.6.9"
+    version = "3.6.10"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/test_scripts/vol_test.py
+++ b/src/test_scripts/vol_test.py
@@ -157,25 +157,6 @@ def del_create_same_vol_uuid_test():
     subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
     print("del_create_same_vol_uuid_test completed")
 
-def normal_unmap(num_secs="1500"):
-    print("normal unmap test started")
-    i = 1
-    while i < 5:
-        cmd_opts = "--run_time=" + num_secs + " --max_num_writes=5000000 --gtest_filter=VolTest.init_io_test --remove_file_on_shutdown=0 --remove_file_on_start=1 --flip=1 --verify_type=2 --unmap_enable=1 --remove_file_on_shutdown=1 --delete_volume=1"
-        subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
-    
-        cmd_opts = "--gtest_filter=VolTest.recovery_io_test --run_time=800 --enable_crash_handler=1 --pre_init_verify=false --abort=0 --flip=1 --remove_file_on_shutdown=0 --verify_type=2"
-        subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, shell=True)
-        s = "normal unmap iteration" + repr(i) + "passed"
-        print(s)
-        i += 1
-
-    print("normal unmap test completed")
-
-## @test load
-#  @brief Test using load generator
-def load():
-    print("load test started")
 ## @test normal
 #  @brief Normal IO test
 def normal(num_secs="20000"):

--- a/src/test_scripts/vol_test.py
+++ b/src/test_scripts/vol_test.py
@@ -151,10 +151,34 @@ def sequential_write_and_recovery():
     subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
     print("recovery on sequential write test completed")
 
+def del_create_same_vol_uuid_test():
+    print("del_create_same_vol_uuid_test started")
+    cmd_opts = "--gtest_filter=VolTest.del_and_create_same_uuid_vol --max_volume=3 --remove_file_on_shutdown=1 --remove_file_on_start=1"
+    subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
+    print("del_create_same_vol_uuid_test completed")
+
+def normal_unmap(num_secs="1500"):
+    print("normal unmap test started")
+    i = 1
+    while i < 5:
+        cmd_opts = "--run_time=" + num_secs + " --max_num_writes=5000000 --gtest_filter=VolTest.init_io_test --remove_file_on_shutdown=0 --remove_file_on_start=1 --flip=1 --verify_type=2 --unmap_enable=1 --remove_file_on_shutdown=1 --delete_volume=1"
+        subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
+    
+        cmd_opts = "--gtest_filter=VolTest.recovery_io_test --run_time=800 --enable_crash_handler=1 --pre_init_verify=false --abort=0 --flip=1 --remove_file_on_shutdown=0 --verify_type=2"
+        subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, shell=True)
+        s = "normal unmap iteration" + repr(i) + "passed"
+        print(s)
+        i += 1
+
+    print("normal unmap test completed")
+
+## @test load
+#  @brief Test using load generator
+def load():
+    print("load test started")
 ## @test normal
 #  @brief Normal IO test
 def normal(num_secs="20000"):
-
     print("normal test started")
     cmd_opts = "--run_time=" + num_secs + " --max_num_writes=5000000 --gtest_filter=VolTest.init_io_test --remove_file_on_shutdown=0 --remove_file_on_start=1 --flip=1"
     subprocess.check_call(dirpath + "test_volume " + cmd_opts + vol_addln_opts, stderr=subprocess.STDOUT, shell=True)
@@ -567,6 +591,9 @@ def nightly():
     sleep(5)
 
     copy_vol_load();
+    sleep(5)
+
+    del_create_same_vol_uuid_test()
     sleep(5)
 
     vol_create_delete_test()


### PR DESCRIPTION
Changes:
========
1. fix for vol create with same uuid vol that is pending on destroying.
2. add test case to create volumes, then delete a volume and before destroy completes, create a volume with same uuid, the creation should fail as expected and later the destroy of the uuid should succeed as expected.
3. Test passed with verified logs below.

Test results:
==========
Logs showing a creation of same vol uuid is failed because previous vol is still in destroying state.
Later volume destroyed successfully of the previous destroy command;
[08/08/23 11:35:46.429522] [E] [5774] [home_blks.cpp:336:create_volume] Can't serve this create_volume: vol uuid: 2b5f5459-005e-4e10-a69e-8c601d3d2e17 already exists, state: DESTROYING
[08/08/23 11:35:46.429535] [I] [5774] [vol_gtest.cpp:1085:delete_and_create_same_uuid_vol] Create vol with same uuid: 2b5f5459-005e-4e10-a69e-8c601d3d2e17 failed as expected!
...
[08/08/23 11:35:52.434132] [I] [5794] [volume.cpp:308] [vol=test_files/vol0] volume destroyed