### PR TITLE
Index write back cache fixes

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.1.5"
+    version = "4.1.6"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/btree/btree.hpp
+++ b/src/include/homestore/btree/btree.hpp
@@ -97,12 +97,14 @@ public:
     // bool verify_tree(bool update_debug_bm) const;
     virtual std::pair< btree_status_t, uint64_t > destroy_btree(void* context);
     nlohmann::json get_status(int log_level) const;
-    void print_tree() const;
+
+    void print_tree(const std::string& file = "") const;
     void print_tree_keys() const;
+
     nlohmann::json get_metrics_in_json(bool updated = true);
     bnodeid_t root_node_id() const;
     uint64_t root_link_version() const;
-    void set_root_node_info(const BtreeLinkInfo &info);
+    void set_root_node_info(const BtreeLinkInfo& info);
 
     // static void set_io_flip();
     // static void set_error_flip();
@@ -123,6 +125,7 @@ protected:
                                                 void* context) = 0;
 
     virtual std::string btree_store_type() const = 0;
+    virtual void update_new_root_info(bnodeid_t root_node, uint64_t version) = 0;
 
     /////////////////////////// Methods the application use case is expected to handle ///////////////////////////
 

--- a/src/include/homestore/btree/btree.ipp
+++ b/src/include/homestore/btree/btree.ipp
@@ -56,7 +56,7 @@ btree_status_t Btree< K, V >::init(void* op_context) {
 }
 
 template < typename K, typename V >
-void Btree< K, V >::set_root_node_info(const BtreeLinkInfo &info) {
+void Btree< K, V >::set_root_node_info(const BtreeLinkInfo& info) {
     m_root_node_info = info;
 }
 
@@ -321,13 +321,18 @@ nlohmann::json Btree< K, V >::get_status(int log_level) const {
 }
 
 template < typename K, typename V >
-void Btree< K, V >::print_tree() const {
+void Btree< K, V >::print_tree(const std::string& file) const {
     std::string buf;
     m_btree_lock.lock_shared();
     to_string(m_root_node_info.bnode_id(), buf);
     m_btree_lock.unlock_shared();
 
     BT_LOG(INFO, "Pre order traversal of tree:\n<{}>", buf);
+    if (!file.empty()) {
+        std::ofstream o(file);
+        o.write(buf.c_str(), buf.size());
+        o.flush();
+    }
 }
 
 template < typename K, typename V >

--- a/src/include/homestore/btree/detail/btree_mutate_impl.ipp
+++ b/src/include/homestore/btree/detail/btree_mutate_impl.ipp
@@ -103,6 +103,16 @@ retry:
         // If the child and child_info link in the parent mismatch, we need to do btree repair, it might have
         // encountered a crash in-between the split or merge and only partial commit happened.
         if (is_split_needed(child_node, m_bt_cfg, req) || is_repair_needed(child_node, child_info)) {
+
+            // TODO remove the split_node retry logic and use key max size.
+            if (!my_node->can_accomodate(m_bt_cfg, K::get_estimate_max_size(), BtreeLinkInfo::get_fixed_size())) {
+                // Mark the parent_node itself to be split upon next retry.
+                bt_thread_vars()->force_split_node = my_node;
+                unlock_node(child_node, child_cur_lock);
+                ret = btree_status_t::retry;
+                goto out;
+            }
+
             ret = upgrade_node_locks(my_node, child_node, curlock, child_cur_lock, req.m_op_context);
             if (ret != btree_status_t::success) {
                 BT_NODE_LOG(DEBUG, my_node, "Upgrade of node lock failed, retrying from root");
@@ -113,9 +123,12 @@ retry:
             curlock = child_cur_lock = locktype_t::WRITE;
 
             if (is_repair_needed(child_node, child_info)) {
+                BT_NODE_LOG(TRACE, child_node, "Node repair needed");
                 ret = repair_split(my_node, child_node, curr_idx, req.m_op_context);
+
             } else {
                 K split_key;
+                BT_NODE_LOG(TRACE, my_node, "Split node needed");
                 ret = split_node(my_node, child_node, curr_idx, &split_key, req.m_op_context);
             }
             unlock_node(child_node, locktype_t::WRITE);
@@ -135,10 +148,11 @@ retry:
             if (child_node->is_leaf()) {
                 // We get the trimmed range only for leaf because this is where we will be inserting keys. In
                 // interior nodes, keys are always propogated from the lower nodes.
-                bool is_inp_key_lesser;
-                req.trim_working_range(
-                    my_node->min_of(s_cast< const K& >(req.input_range().end_key()), curr_idx, is_inp_key_lesser),
-                    is_inp_key_lesser ? req.input_range().is_end_inclusive() : true);
+                bool is_inp_key_lesser = false;
+                K end_key =
+                    my_node->min_of(s_cast< const K& >(req.input_range().end_key()), curr_idx, is_inp_key_lesser);
+                bool end_incl = is_inp_key_lesser ? req.input_range().is_end_inclusive() : true;
+                req.trim_working_range(std::move(end_key), end_incl);
 
                 BT_NODE_LOG(DEBUG, my_node, "Subrange:idx=[{}-{}],c={},working={}", start_idx, end_idx, curr_idx,
                             req.working_range().to_string());
@@ -434,6 +448,14 @@ btree_status_t Btree< K, V >::check_split_root(ReqT& req) {
     root = std::move(new_root);
     BT_NODE_DBG_ASSERT_EQ(root->total_entries(), 0, root);
 
+    ret = prepare_node_txn(root, child_node, req.m_op_context);
+    if (ret != btree_status_t::success) {
+        free_node(root, locktype_t::WRITE, req.m_op_context);
+        root = std::move(child_node);
+        unlock_node(root, locktype_t::WRITE);
+        goto done;
+    }
+
     if (is_repair_needed(child_node, m_root_node_info)) {
         ret = repair_split(root, child_node, root->total_entries(), req.m_op_context);
     } else {
@@ -450,6 +472,7 @@ btree_status_t Btree< K, V >::check_split_root(ReqT& req) {
         m_root_node_info = BtreeLinkInfo{root->node_id(), root->link_version()};
         unlock_node(child_node, locktype_t::WRITE);
         COUNTER_INCREMENT(m_metrics, btree_depth, 1);
+        update_new_root_info(root->node_id(), root->link_version());
     }
 
 done:

--- a/src/include/homestore/btree/detail/btree_node.hpp
+++ b/src/include/homestore/btree/detail/btree_node.hpp
@@ -622,10 +622,8 @@ public:
 
     friend void intrusive_ptr_release(BtreeNode* node) {
         if (node->m_refcount.decrement_testz(1)) {
-            auto node_buffer = node->m_phys_node_buf;
             node->~BtreeNode();
             delete[] uintptr_cast(node);
-            delete[] node_buffer;
         }
     }
 };

--- a/src/include/homestore/btree/detail/btree_remove_impl.ipp
+++ b/src/include/homestore/btree/detail/btree_remove_impl.ipp
@@ -155,10 +155,10 @@ retry:
             if (child_node->is_leaf()) {
                 // We get the trimmed range only for leaf because this is where we will be removing keys. In interior
                 // nodes, keys are always propogated from the lower nodes.
-                bool is_inp_key_lesser;
-                req.trim_working_range(
-                    my_node->min_of(s_cast< const K& >(req.input_range().end_key()), curr_idx, is_inp_key_lesser),
-                    is_inp_key_lesser ? req.input_range().is_end_inclusive() : true);
+                bool is_inp_key_lesser = false;
+                K end_key = my_node->min_of(s_cast< const K& >(req.input_range().end_key()), curr_idx, is_inp_key_lesser);
+                bool end_incl = is_inp_key_lesser ? req.input_range().is_end_inclusive() : true;
+                req.trim_working_range(std::move(end_key), end_incl);
 
                 BT_NODE_LOG(DEBUG, my_node, "Subrange:idx=[{}-{}],c={},working={}", start_idx, end_idx, curr_idx,
                             req.working_range().to_string());

--- a/src/include/homestore/btree/detail/simple_node.hpp
+++ b/src/include/homestore/btree/detail/simple_node.hpp
@@ -18,6 +18,7 @@
 #include <homestore/btree/btree_kv.hpp>
 #include "btree_node.hpp"
 #include "btree_internal.hpp"
+#include "homestore/index/index_internal.hpp"
 
 using namespace std;
 using namespace boost;
@@ -242,10 +243,10 @@ public:
     }*/
 
     std::string to_string(bool print_friendly = false) const override {
-        auto str = fmt::format("{}id={} nEntries={} {} next_node={} ",
+        auto str = fmt::format("{}id={} level={} nEntries={} {} next_node={} ",
                                (print_friendly ? "------------------------------------------------------------\n" : ""),
-                               this->node_id(), this->total_entries(), (this->is_leaf() ? "LEAF" : "INTERIOR"),
-                               this->next_bnode());
+                               this->node_id(), this->level(), this->total_entries(),
+                               (this->is_leaf() ? "LEAF" : "INTERIOR"), this->next_bnode());
         if (!this->is_leaf() && (this->has_valid_edge())) {
             fmt::format_to(std::back_inserter(str), "edge_id={}.{}", this->edge_info().m_bnodeid,
                            this->edge_info().m_link_version);

--- a/src/include/homestore/btree/detail/varlen_node.hpp
+++ b/src/include/homestore/btree/detail/varlen_node.hpp
@@ -19,6 +19,7 @@
 #include <sisl/logging/logging.h>
 #include "btree_node.hpp"
 #include <homestore/btree/btree_kv.hpp>
+#include "homestore/index/index_internal.hpp"
 
 SISL_LOGGING_DECL(btree)
 

--- a/src/include/homestore/homestore_decl.hpp
+++ b/src/include/homestore/homestore_decl.hpp
@@ -178,6 +178,6 @@ struct cap_attrs {
 ////////////// Misc ///////////////////
 #define HOMESTORE_LOG_MODS                                                                                             \
     btree_structures, btree_nodes, btree_generics, btree, cache, device, blkalloc, vol_io_wd, volume, flip, cp, metablk, \
-        indx_mgr, logstore, replay, transient, IOMGR_LOG_MODS
+        indx_mgr, wbcache, logstore, replay, transient, IOMGR_LOG_MODS
 
 } // namespace homestore

--- a/src/include/homestore/index/wb_cache_base.hpp
+++ b/src/include/homestore/index/wb_cache_base.hpp
@@ -56,7 +56,7 @@ public:
     /// @param third Thrid btree buffer in the chain. It will be updated to copy of third buffer if buffer already
     /// has dependencies.
     /// @return Returns if the buffer had to be copied
-    virtual bool create_chain(IndexBufferPtr& second, IndexBufferPtr& third) = 0;
+    virtual std::tuple< bool, bool > create_chain(IndexBufferPtr& second, IndexBufferPtr& third, CPContext* cp_ctx) = 0;
 
     /// @brief Prepend to the chain that was already created with second
     /// @param first

--- a/src/include/homestore/index_service.hpp
+++ b/src/include/homestore/index_service.hpp
@@ -31,6 +31,7 @@ class VirtualDev;
 
 class IndexServiceCallbacks {
 public:
+    virtual ~IndexServiceCallbacks() = default;
     virtual std::shared_ptr< IndexTableBase > on_index_table_found(const superblk< index_table_sb >& cb) = 0;
 };
 

--- a/src/lib/index/index_service.cpp
+++ b/src/lib/index/index_service.cpp
@@ -90,4 +90,8 @@ uint64_t IndexService::used_size() const {
 IndexBuffer::IndexBuffer(BlkId blkid, uint32_t buf_size, uint32_t align_size) :
         m_node_buf{hs_utils::iobuf_alloc(buf_size, sisl::buftag::btree_node, align_size)}, m_blkid{blkid} {}
 
+IndexBuffer::~IndexBuffer() {
+    hs_utils::iobuf_free(m_node_buf, sisl::buftag::btree_node);
+}
+
 } // namespace homestore

--- a/src/lib/index/wb_cache.cpp
+++ b/src/lib/index/wb_cache.cpp
@@ -24,6 +24,8 @@
 #include "device/virtual_dev.hpp"
 #include "common/resource_mgr.hpp"
 
+SISL_LOGGING_DECL(wbcache)
+
 namespace homestore {
 
 IndexWBCache& wb_cache() { return index_service().wb_cache(); }
@@ -87,6 +89,7 @@ BtreeNodePtr IndexWBCache::alloc_buf(node_initializer_t&& node_initializer) {
     // Alloc buffer and initialize the node
     auto idx_buf = std::make_shared< IndexBuffer >(blkid, m_node_size, m_vdev->align_size());
     auto node = node_initializer(idx_buf);
+    LOGTRACEMOD(wbcache, "idx_buf {} blkid {}", static_cast< void* >(idx_buf.get()), blkid.to_integer());
 
     // Add the node to the cache
     bool done = m_cache.insert(node);
@@ -103,6 +106,14 @@ void IndexWBCache::write_buf(const BtreeNodePtr& node, const IndexBufferPtr& buf
     m_cache.upsert(node);
     r_cast< IndexCPContext* >(cp_ctx)->add_to_dirty_list(buf);
     resource_mgr().inc_dirty_buf_size(m_node_size);
+}
+
+IndexBufferPtr IndexWBCache::copy_buffer(const IndexBufferPtr& cur_buf) const {
+    auto new_buf = std::make_shared< IndexBuffer >(cur_buf->m_blkid, m_node_size, m_vdev->align_size());
+    std::memcpy(new_buf->raw_buffer(), cur_buf->raw_buffer(), m_node_size);
+    LOGTRACEMOD(wbcache, "new_buf {} cur_buf {} cur_buf_blkid {}", static_cast< void* >(new_buf.get()),
+                static_cast< void* >(cur_buf.get()), cur_buf->m_blkid.to_integer());
+    return new_buf;
 }
 
 void IndexWBCache::read_buf(bnodeid_t id, BtreeNodePtr& node, node_initializer_t&& node_initializer) {
@@ -129,35 +140,43 @@ retry:
     }
 }
 
-bool IndexWBCache::create_chain(IndexBufferPtr& second, IndexBufferPtr& third) {
-    bool copied{false};
-    if (second->m_next_buffer != nullptr) {
-        HS_DBG_ASSERT_EQ((void*)second->m_next_buffer.get(), (void*)third.get(),
-                         "Overwriting second (child node) with different third (parent node)");
-        HS_DBG_ASSERT_EQ((void*)second->m_next_buffer->m_next_buffer.get(), (void*)nullptr,
-                         "Third node buffer should be the last in the list");
+std::tuple< bool, bool > IndexWBCache::create_chain(IndexBufferPtr& second, IndexBufferPtr& third, CPContext* cp_ctx) {
+    bool second_copied{false}, third_copied{false};
 
-        // Second buf has already a next buffer, which means same node is in-place modified with structure change,
-        // we need to copy both this and next buffer.
+    if (!second->is_clean()) {
         auto new_second = copy_buffer(second);
-        auto new_third = copy_buffer(third);
-
-        third->m_next_buffer = new_second;
-        new_second->m_wait_for_leaders.increment(1);
-
+        LOGTRACEMOD(wbcache, "second copied blkid {} {} new_second {}", second->m_blkid.to_integer(),
+                    static_cast< void* >(second.get()), static_cast< void* >(new_second.get()));
         second = new_second;
-        third = new_third;
-        copied = true;
+        second_copied = true;
     }
-    second->m_next_buffer = third;
-    third->m_wait_for_leaders.increment(1);
+    if (!third->is_clean()) {
+        auto new_third = copy_buffer(third);
+        LOGTRACEMOD(wbcache, "third copied blkid {} {} new_third {}", third->m_blkid.to_integer(),
+                    static_cast< void* >(third.get()), static_cast< void* >(new_third.get()));
+        third = new_third;
+        third_copied = true;
+    }
 
-    return copied;
+    // Append parent(third) to the left child(second).
+    prepend_to_chain(second, third);
+
+    // TODO the index buffer are added to end of the chain, instead add to the dependency.
+    auto& last_in_chain = r_cast< IndexCPContext* >(cp_ctx)->m_last_in_chain;
+    if (last_in_chain) {
+        // Add this to the end of the chain.
+        last_in_chain->m_next_buffer = second;
+        second->m_wait_for_leaders.increment(1);
+    }
+
+    return {second_copied, third_copied};
 }
 
 void IndexWBCache::prepend_to_chain(const IndexBufferPtr& first, const IndexBufferPtr& second) {
+    assert(first->m_next_buffer.lock() == nullptr);
     first->m_next_buffer = second;
     second->m_wait_for_leaders.increment(1);
+    LOGTRACEMOD(wbcache, "first {} second {}", first->to_string(), second->to_string());
 }
 
 void IndexWBCache::free_buf(const IndexBufferPtr& buf, CPContext* cp_ctx) {
@@ -172,6 +191,7 @@ void IndexWBCache::free_buf(const IndexBufferPtr& buf, CPContext* cp_ctx) {
 //////////////////// CP Related API section /////////////////////////////////
 folly::Future< bool > IndexWBCache::async_cp_flush(CPContext* context) {
     IndexCPContext* cp_ctx = s_cast< IndexCPContext* >(context);
+    LOGTRACEMOD(wbcache, "cp_ctx {}", cp_ctx->to_string());
     if (!cp_ctx->any_dirty_buffers()) {
         CP_PERIODIC_LOG(DEBUG, cp_ctx->id(), "Btree does not have any dirty buffers to flush");
         return folly::makeFuture< bool >(true); // nothing to flush
@@ -200,13 +220,8 @@ std::unique_ptr< CPContext > IndexWBCache::create_cp_context(cp_id_t cp_id) {
                                               m_free_blkid_list[cp_id_slot].get());
 }
 
-IndexBufferPtr IndexWBCache::copy_buffer(const IndexBufferPtr& cur_buf) const {
-    auto new_buf = std::make_shared< IndexBuffer >(cur_buf->m_blkid, m_node_size, m_vdev->align_size());
-    std::memcpy(new_buf->raw_buffer(), cur_buf->raw_buffer(), m_node_size);
-    return new_buf;
-}
-
 void IndexWBCache::do_flush_one_buf(IndexCPContext* cp_ctx, const IndexBufferPtr& buf, bool part_of_batch) {
+    LOGTRACEMOD(wbcache, "buf {}", buf->to_string());
     buf->m_buf_state = index_buf_state_t::FLUSHING;
     m_vdev->async_write(r_cast< const char* >(buf->raw_buffer()), m_node_size, buf->m_blkid, part_of_batch)
         .thenValue([pbuf = buf.get(), cp_ctx](auto) {
@@ -218,6 +233,7 @@ void IndexWBCache::do_flush_one_buf(IndexCPContext* cp_ctx, const IndexBufferPtr
 }
 
 void IndexWBCache::process_write_completion(IndexCPContext* cp_ctx, IndexBuffer* pbuf) {
+    LOGTRACEMOD(wbcache, "buf {}", pbuf->to_string());
     resource_mgr().dec_dirty_buf_size(m_node_size);
     auto [next_buf, has_more] = on_buf_flush_done(cp_ctx, pbuf);
     if (next_buf) {
@@ -239,9 +255,9 @@ std::pair< IndexBufferPtr, bool > IndexWBCache::on_buf_flush_done(IndexCPContext
 
 std::pair< IndexBufferPtr, bool > IndexWBCache::on_buf_flush_done_internal(IndexCPContext* cp_ctx, IndexBuffer* buf) {
     static thread_local std::vector< IndexBufferPtr > t_buf_list;
-    t_buf_list.clear();
-
     buf->m_buf_state = index_buf_state_t::CLEAN;
+
+    t_buf_list.clear();
 
     if (cp_ctx->m_dirty_buf_count.decrement_testz()) {
         return std::make_pair(nullptr, false);
@@ -266,7 +282,7 @@ void IndexWBCache::get_next_bufs_internal(IndexCPContext* cp_ctx, uint32_t max_c
 
     // First attempt to execute any follower buffer flush
     if (prev_flushed_buf) {
-        auto& next_buffer = prev_flushed_buf->m_next_buffer;
+        auto next_buffer = prev_flushed_buf->m_next_buffer.lock();
         if (next_buffer && next_buffer->m_wait_for_leaders.decrement_testz()) {
             bufs.emplace_back(next_buffer);
             ++count;
@@ -295,6 +311,7 @@ void IndexWBCache::free_btree_blks_and_flush(IndexCPContext* cp_ctx) {
 
     // Pick a CP Manager blocking IO fiber to execute the cp flush of vdev
     iomanager.run_on_forget(hs()->cp_mgr().pick_blocking_io_fiber(), [this, cp_ctx]() {
+        LOGTRACEMOD(wbcache, "Initiating CP flush");
         m_vdev->cp_flush(); // This is a blocking io call
         cp_ctx->complete(true);
     });

--- a/src/lib/index/wb_cache.hpp
+++ b/src/lib/index/wb_cache.hpp
@@ -52,7 +52,7 @@ public:
     void realloc_buf(const IndexBufferPtr& buf) override;
     void write_buf(const BtreeNodePtr& node, const IndexBufferPtr& buf, CPContext* cp_ctx) override;
     void read_buf(bnodeid_t id, BtreeNodePtr& node, node_initializer_t&& node_initializer) override;
-    bool create_chain(IndexBufferPtr& second, IndexBufferPtr& third) override;
+    std::tuple< bool, bool > create_chain(IndexBufferPtr& second, IndexBufferPtr& third, CPContext* cp_ctx) override;
     void prepend_to_chain(const IndexBufferPtr& first, const IndexBufferPtr& second) override;
     void free_buf(const IndexBufferPtr& buf, CPContext* cp_ctx) override;
 
@@ -72,5 +72,6 @@ private:
     void get_next_bufs_internal(IndexCPContext* cp_ctx, uint32_t max_count, IndexBuffer* prev_flushed_buf,
                                 std::vector< IndexBufferPtr >& bufs);
     void free_btree_blks_and_flush(IndexCPContext* cp_ctx);
+
 };
 } // namespace homestore

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -49,7 +49,7 @@ if (${io_tests})
     set(TEST_INDEXBTREE_SOURCE_FILES test_index_btree.cpp)
     add_executable(test_index_btree ${TEST_INDEXBTREE_SOURCE_FILES})
     target_link_libraries(test_index_btree homestore ${COMMON_TEST_DEPS} GTest::gtest)
-    #add_test(NAME IndexBtree COMMAND test_index_btree)
+    add_test(NAME IndexBtree COMMAND test_index_btree)
 
     add_executable(test_data_service)
     target_sources(test_data_service PRIVATE test_data_service.cpp)

--- a/src/tests/btree_test_kvs.hpp
+++ b/src/tests/btree_test_kvs.hpp
@@ -185,7 +185,8 @@ public:
         assert(data == *idx_to_key(m_key));
     }
 
-    static uint32_t get_estimate_max_size() { return g_max_keysize; }
+    // Add 8 bytes for preamble.
+    static uint32_t get_estimate_max_size() { return g_max_keysize + 8; }
 
     int compare(const BtreeKey& o) const override {
         const TestVarLenKey& other = s_cast< const TestVarLenKey& >(o);


### PR DESCRIPTION
Add indexbuffergroup to flush multiple index buffers in order. Add dependency betweeen the groups. To handle cases for level greater than 3.
Add root in sb when root split.