### PR TITLE
SDSTOR-11579 ChunkSelector and its default implementation 

### DIFF
--- a/src/include/homestore/chunk_selector.h
+++ b/src/include/homestore/chunk_selector.h
@@ -1,8 +1,8 @@
 #pragma once
 
-class PhysicalDevChunk;
-
 namespace homestore {
+
+class PhysicalDevChunk;
 
 class ChunkSelector {
 public:
@@ -17,4 +17,4 @@ public:
     virtual PhysicalDevChunk* select_chunk() = 0;
 };
 
-} // namespace homestore
+}

--- a/src/include/homestore/chunk_selector.h
+++ b/src/include/homestore/chunk_selector.h
@@ -1,0 +1,20 @@
+#pragma once
+
+class PhysicalDevChunk;
+
+namespace homestore {
+
+class ChunkSelector {
+public:
+    ChunkSelector();
+    virtual ~ChunkSelector() = default;
+    ChunkSelector(const ChunkSelector&) = delete;
+    ChunkSelector(ChunkSelector&&) noexcept = delete;
+    ChunkSelector& operator=(const ChunkSelector&) = delete;
+    ChunkSelector& operator=(ChunkSelector&&) noexcept = delete;
+
+    virtual void add_chunk(PhysicalDevChunk*) = 0;
+    virtual PhysicalDevChunk* select_chunk() = 0;
+};
+
+} // namespace homestore

--- a/src/include/homestore/homestore_decl.hpp
+++ b/src/include/homestore/homestore_decl.hpp
@@ -29,6 +29,8 @@
 #include <spdlog/fmt/fmt.h>
 #include <nlohmann/json.hpp>
 
+#include <homestore/chunk_selector.h>
+
 //
 // Note:
 // This file should only include stuffs that are needed by both service layer and internal homestore components;
@@ -138,11 +140,16 @@ public:
     io_flag data_open_flags{io_flag::DIRECT_IO}; // All data drives open flags
     io_flag fast_open_flags{io_flag::DIRECT_IO}; // All index drives open flags
 
+
     uint64_t app_mem_size{static_cast< uint64_t >(1024) * static_cast< uint64_t >(1024) *
                           static_cast< uint64_t >(1024)}; // memory available for the app (including cache)
     uint64_t hugepage_size{0};                            // memory available for the hugepage
     bool is_read_only{false};                             // Is read only
     bool auto_recovery{true};                             // Recovery of data is automatic or controlled by the caller
+    ChunkSelector* dataChunkSelector{nullptr};        // ChunkSelector for DataService
+    ChunkSelector* logChunkSelector{nullptr};          // ChunkSelector for LogService
+    ChunkSelector* IndexChunkSelector{nullptr};      // ChunkSelector for IndexService
+    ChunkSelector* metaChunkSelector{nullptr};        // ChunkSelector for MetaService
 
 #ifdef _PRERELEASE
     bool force_reinit{false};

--- a/src/lib/blkdata_svc/blkdata_service.cpp
+++ b/src/lib/blkdata_svc/blkdata_service.cpp
@@ -30,7 +30,8 @@ BlkDataService::~BlkDataService() = default;
 
 // recovery path
 void BlkDataService::open_vdev(vdev_info_block* vb) {
-    m_vdev = std::make_unique< VirtualDev >(hs()->device_mgr(), "DataVDev", vb, PhysicalDevGroup::DATA,
+    auto chunkSelector = HomeStoreStaticConfig::instance().input.dataChunkSelector;
+    m_vdev = std::make_unique< VirtualDev >(hs()->device_mgr(), chunkSelector, "DataVDev", vb, PhysicalDevGroup::DATA,
                                             blk_allocator_type_t::varsize, vb->is_failed(), true /* auto_recovery */);
 
     m_page_size = vb->blk_size;
@@ -46,7 +47,8 @@ void BlkDataService::create_vdev(uint64_t size) {
     struct blkstore_blob blob;
     blob.type = blkstore_type::DATA_STORE;
     m_page_size = hs()->device_mgr()->phys_page_size({PhysicalDevGroup::DATA});
-    m_vdev = std::make_unique< VirtualDev >(hs()->device_mgr(), "DataVDev", PhysicalDevGroup::DATA,
+    auto chunkSelector = HomeStoreStaticConfig::instance().input.dataChunkSelector;
+    m_vdev = std::make_unique< VirtualDev >(hs()->device_mgr(), chunkSelector, "DataVDev", PhysicalDevGroup::DATA,
                                             blk_allocator_type_t::varsize, size, 0, true /* is_stripe */, m_page_size,
                                             (char*)&blob, sizeof(blkstore_blob), true /* auto_recovery */);
 }

--- a/src/lib/device/journal_vdev.hpp
+++ b/src/lib/device/journal_vdev.hpp
@@ -49,17 +49,17 @@ private:
 
 public:
     /* Create a new virtual dev for these parameters */
-    JournalVirtualDev(DeviceManager* mgr, const char* name, PhysicalDevGroup pdev_group, uint64_t size_in,
+    JournalVirtualDev(DeviceManager* mgr, ChunkSelector* chunkSelector, const char* name, PhysicalDevGroup pdev_group, uint64_t size_in,
                       uint32_t nmirror, bool is_stripe, uint32_t blk_size, char* context, uint64_t context_size,
                       bool auto_recovery = false, vdev_high_watermark_cb_t hwm_cb = nullptr) :
-            VirtualDev{mgr,     name,         pdev_group,    blk_allocator_type_t::none,
+            VirtualDev{mgr,     chunkSelector, name,         pdev_group,    blk_allocator_type_t::none,
                        size_in, nmirror,      is_stripe,     blk_size,
                        context, context_size, auto_recovery, hwm_cb} {}
 
     /* Load the virtual dev from vdev_info_block and create a Virtual Dev. */
-    JournalVirtualDev(DeviceManager* mgr, const char* name, vdev_info_block* vb, PhysicalDevGroup pdev_group,
+    JournalVirtualDev(DeviceManager* mgr, ChunkSelector* chunkSelector, const char* name, vdev_info_block* vb, PhysicalDevGroup pdev_group,
                       bool recovery_init, bool auto_recovery = false, vdev_high_watermark_cb_t hwm_cb = nullptr) :
-            VirtualDev(mgr, name, vb, pdev_group, blk_allocator_type_t::none, recovery_init, auto_recovery, hwm_cb) {}
+            VirtualDev(mgr, chunkSelector, name, vb, pdev_group, blk_allocator_type_t::none, recovery_init, auto_recovery, hwm_cb) {}
 
     JournalVirtualDev(const JournalVirtualDev& other) = delete;
     JournalVirtualDev& operator=(const JournalVirtualDev& other) = delete;

--- a/src/lib/device/virtual_dev.hpp
+++ b/src/lib/device/virtual_dev.hpp
@@ -36,6 +36,7 @@
 
 #include "device.h"
 #include "device_selector.hpp"
+#include <homestore/chunk_selector.h>
 
 namespace iomgr {
 class DriveInterface;
@@ -136,6 +137,7 @@ class VirtualDev {
 protected:
     vdev_info_block* m_vb;   // This device block info
     DeviceManager* m_mgr;    // Device Manager back pointer
+    ChunkSelector* m_chunk_selector; //ChunkSelector
     std::string m_name;      // Name of the vdev
     uint64_t m_chunk_size;   // Chunk size that will be allocated in a physical device
     std::mutex m_mgmt_mutex; // Any mutex taken for management operations (like adding/removing chunks).
@@ -166,16 +168,16 @@ private:
     static uint32_t s_num_chunks_created; // vdev will not be created in parallel threads;
 
 public:
-    void init(DeviceManager* mgr, vdev_info_block* vb, uint32_t blk_size, bool auto_recovery,
+    void init(DeviceManager* mgr, ChunkSelector* chunkSelector, vdev_info_block* vb, uint32_t blk_size, bool auto_recovery,
               vdev_high_watermark_cb_t hwm_cb);
 
     // Create a new virtual dev for these parameters
-    VirtualDev(DeviceManager* mgr, const char* name, PhysicalDevGroup pdev_group, blk_allocator_type_t allocator_type,
+    VirtualDev(DeviceManager* mgr, ChunkSelector* chunkSelector, const char* name, PhysicalDevGroup pdev_group, blk_allocator_type_t allocator_type,
                uint64_t size_in, uint32_t nmirror, bool is_stripe, uint32_t blk_size, char* context,
                uint64_t context_size, bool auto_recovery = false, vdev_high_watermark_cb_t hwm_cb = nullptr);
 
     // Load the virtual dev from vdev_info_block and create a Virtual Dev instance
-    VirtualDev(DeviceManager* mgr, const char* name, vdev_info_block* vb, PhysicalDevGroup pdev_group,
+    VirtualDev(DeviceManager* mgr, ChunkSelector* chunkSelector, const char* name, vdev_info_block* vb, PhysicalDevGroup pdev_group,
                blk_allocator_type_t allocator_type, bool recovery_init, bool auto_recovery = false,
                vdev_high_watermark_cb_t hwm_cb = nullptr);
 

--- a/src/lib/index/index_service.cpp
+++ b/src/lib/index/index_service.cpp
@@ -39,14 +39,17 @@ void IndexService::create_vdev(uint64_t size) {
 
     struct blkstore_blob blob;
     blob.type = blkstore_type::INDEX_STORE;
+    auto chunkSelector = HomeStoreStaticConfig::instance().input.IndexChunkSelector;
     m_vdev =
-        std::make_shared< VirtualDev >(hs()->device_mgr(), "index", PhysicalDevGroup::FAST, blk_allocator_type_t::fixed,
-                                       size, 0, true, atomic_page_size, (char*)&blob, sizeof(blkstore_blob), true);
+        std::make_shared< VirtualDev >(hs()->device_mgr(), chunkSelector, "index", 
+        PhysicalDevGroup::FAST, blk_allocator_type_t::fixed, size, 0, true, atomic_page_size, 
+        (char*)&blob, sizeof(blkstore_blob), true);
 }
 
 void IndexService::open_vdev(vdev_info_block* vb) {
-    m_vdev = std::make_shared< VirtualDev >(hs()->device_mgr(), "index", vb, PhysicalDevGroup::FAST,
-                                            blk_allocator_type_t::fixed, vb->is_failed(), true);
+    auto chunkSelector = HomeStoreStaticConfig::instance().input.IndexChunkSelector;
+    m_vdev = std::make_shared< VirtualDev >(hs()->device_mgr(), chunkSelector, 
+    "index", vb, PhysicalDevGroup::FAST,blk_allocator_type_t::fixed, vb->is_failed(), true);
     if (vb->is_failed()) {
         LOGINFO("index vdev is in failed state");
         throw std::runtime_error("vdev in failed state");

--- a/src/lib/logstore/log_store_service.cpp
+++ b/src/lib/logstore/log_store_service.cpp
@@ -49,13 +49,13 @@ folly::Future< bool > LogStoreService::create_vdev(uint64_t size, logstore_famil
     if (family == DATA_LOG_FAMILY_IDX) {
         blob.type = blkstore_type::DATA_LOGDEV_STORE;
         m_data_logdev_vdev = std::make_unique< JournalVirtualDev >(
-            hs()->device_mgr(), logChunkSelector, "data_logdev", PhysicalDevGroup::FAST, size, 0 /* nmirror */, true /* is_stripe */,
+            hs()->device_mgr(), chunkSelector, "data_logdev", PhysicalDevGroup::FAST, size, 0 /* nmirror */, true /* is_stripe */,
             atomic_page_size /* blk_size */, (char*)&blob, sizeof(blkstore_blob), true /* auto_recovery */);
         return m_data_logdev_vdev->async_format();
     } else {
         blob.type = blkstore_type::CTRL_LOGDEV_STORE;
         m_ctrl_logdev_vdev = std::make_unique< JournalVirtualDev >(
-            hs()->device_mgr(), logChunkSelector, "ctrl_logdev", PhysicalDevGroup::FAST, size, 0 /* nmirror */, true /* is_stripe */,
+            hs()->device_mgr(), chunkSelector, "ctrl_logdev", PhysicalDevGroup::FAST, size, 0 /* nmirror */, true /* is_stripe */,
             atomic_page_size /* blk_size */, (char*)&blob, sizeof(blkstore_blob), true /* auto_recovery */);
         return m_ctrl_logdev_vdev->async_format();
     }

--- a/src/lib/meta/meta_blk_service.cpp
+++ b/src/lib/meta/meta_blk_service.cpp
@@ -48,13 +48,15 @@ void MetaBlkService::create_vdev(uint64_t size) {
 
     struct blkstore_blob blob;
     blob.type = blkstore_type::META_STORE;
-    m_sb_vdev = std::make_unique< VirtualDev >(hs()->device_mgr(), "meta", PhysicalDevGroup::META,
+    auto chunkSelector = HomeStoreStaticConfig::instance().input.metaChunkSelector;
+    m_sb_vdev = std::make_unique< VirtualDev >(hs()->device_mgr(), chunkSelector, "meta", PhysicalDevGroup::META,
                                                blk_allocator_type_t::varsize, size, 0, true, phys_page_size,
                                                (char*)&blob, sizeof(blkstore_blob), false);
 }
 
 void MetaBlkService::open_vdev(vdev_info_block* vb) {
-    m_sb_vdev = std::make_unique< VirtualDev >(hs()->device_mgr(), "meta", vb, PhysicalDevGroup::META,
+    auto chunkSelector = HomeStoreStaticConfig::instance().input.metaChunkSelector;
+    m_sb_vdev = std::make_unique< VirtualDev >(hs()->device_mgr(), chunkSelector, "meta", vb, PhysicalDevGroup::META,
                                                blk_allocator_type_t::varsize, vb->is_failed(), false);
     if (vb->is_failed()) {
         LOGINFO("metablk vdev is in failed state");

--- a/src/tests/test_vdev.cpp
+++ b/src/tests/test_vdev.cpp
@@ -72,7 +72,7 @@ public:
         auto const ndevices = SISL_OPTIONS["num_devs"].as< uint32_t >();
         auto const dev_size = SISL_OPTIONS["dev_size_mb"].as< uint64_t >() * 1024 * 1024;
         test_common::HSTestHelper::start_homestore("test_vdev", 15.0, 0, 0, 0, 0, nullptr);
-        m_vdev = std::make_unique< JournalVirtualDev >(hs()->device_mgr(), "test_vdev", PhysicalDevGroup::DATA,
+        m_vdev = std::make_unique< JournalVirtualDev >(hs()->device_mgr(), nullptr, "test_vdev", PhysicalDevGroup::DATA,
                                                        (dev_size * ndevices * 60) / 100, 0 /* nmirror */,
                                                        true /* is_stripe */, 4096 /* blk_size */, nullptr, 0);
     }


### PR DESCRIPTION
i am not quite sure whether it is appropriate to use `HomeStoreStaticConfig` for homeobject to pass the implementation of chunkselector to homeobject. this PR is used to finalize the interface of chunkselector between homeobject and homestore. the implementation of heapChunkSelector will be pushed to HomeObject repo after this pr is merged