### PR TITLE
SDSTOR-11578 add user data(private area) support in homestore chunk

### DIFF
--- a/src/lib/device/device.h
+++ b/src/lib/device/device.h
@@ -138,6 +138,7 @@ public:
     void update_vb_context(uint32_t vdev_id, const sisl::blob& ctx_data);
     void get_vb_context(uint32_t vdev_id, const sisl::blob& ctx_data) const;
     void update_end_of_chunk(PhysicalDevChunk* chunk, off_t offset);
+    void update_chunk_user_data(PhysicalDevChunk* chunk, uint8_t* user_data, uint8_t user_data_size);
     void init_done();
     void close_devices();
     bool is_first_time_boot() const { return m_first_time_boot; }

--- a/src/lib/device/device_manager.cpp
+++ b/src/lib/device/device_manager.cpp
@@ -219,6 +219,13 @@ void DeviceManager::update_end_of_chunk(PhysicalDevChunk* chunk, off_t offset) {
     write_info_blocks();
 }
 
+void DeviceManager::update_chunk_user_data(PhysicalDevChunk* chunk, uint8_t* user_data, uint8_t user_data_size) {
+    std::lock_guard< decltype(m_dev_mutex) > lock{m_dev_mutex};
+    HS_LOG_ASSERT_LE(user_data_size, MAX_USER_DATA_SIZE_IN_CHUNK);
+    chunk->set_user_data(user_data, user_data_size);
+    write_info_blocks();
+}
+
 void DeviceManager::get_vb_context(uint32_t vdev_id, const sisl::blob& ctx_data) const {
     std::lock_guard< decltype(m_dev_mutex) > lock{m_dev_mutex};
     HS_LOG_ASSERT_LE(ctx_data.size, vdev_info_block::max_context_size());


### PR DESCRIPTION
homestore chunk will setup a user data area which allow upper layer(such as homeobject) to store some customize data, these data can be  homestore unawared.