### PR TITLE
SDSTOR-11576 test_vdev is using same file name as test_data_service which cause it to fail 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ class HomestoreConan(ConanFile):
                 'shared': False,
                 'fPIC': True,
                 'coverage': False,
-                'sanitize': False,
+                'sanitize': True,
                 'testing': 'epoll_mode',
                 'skip_testing': False,
                 'sisl:prerelease': True,

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ class HomestoreConan(ConanFile):
                 'shared': False,
                 'fPIC': True,
                 'coverage': False,
-                'sanitize': True,
+                'sanitize': False,
                 'testing': 'epoll_mode',
                 'skip_testing': False,
                 'sisl:prerelease': True,

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.1.4"
+    version = "4.1.5"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -72,7 +72,7 @@ if (${io_tests})
     if(${epoll_tests})
         add_test(NAME LogStore-Epoll COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/test_log_store)
         add_test(NAME MetaBlkMgr-Epoll COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/test_meta_blk_mgr)
-        #add_test(NAME DataService-Epoll COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/test_data_service)
+        add_test(NAME DataService-Epoll COMMAND ${CMAKE_SOURCE_DIR}/test_wrap.sh ${CMAKE_BINARY_DIR}/bin/test_data_service)
     endif()
 
     can_build_spdk_io_tests(spdk_tests)

--- a/src/tests/test_vdev.cpp
+++ b/src/tests/test_vdev.cpp
@@ -71,7 +71,7 @@ public:
     virtual void SetUp() override {
         auto const ndevices = SISL_OPTIONS["num_devs"].as< uint32_t >();
         auto const dev_size = SISL_OPTIONS["dev_size_mb"].as< uint64_t >() * 1024 * 1024;
-        test_common::HSTestHelper::start_homestore("test_data_service", 15.0, 0, 0, 0, 0, nullptr);
+        test_common::HSTestHelper::start_homestore("test_vdev", 15.0, 0, 0, 0, 0, nullptr);
         m_vdev = std::make_unique< JournalVirtualDev >(hs()->device_mgr(), "test_vdev", PhysicalDevGroup::DATA,
                                                        (dev_size * ndevices * 60) / 100, 0 /* nmirror */,
                                                        true /* is_stripe */, 4096 /* blk_size */, nullptr, 0);


### PR DESCRIPTION
when test_vdev runs slower, the test_data_service runs into recovery mode by mistake, because same file name is used by test_vdev which is not intended.
