### PR TITLE
SDSTOR-11755. Make VChunk CopyAssignable and CopyConstructible

### DIFF
--- a/src/include/homestore/vchunk.h
+++ b/src/include/homestore/vchunk.h
@@ -34,6 +34,6 @@ public:
     cshared< Chunk > get_internal_chunk() const;
 
 private:
-    shared< Chunk > internalChunk;
+    shared< Chunk > m_internal_chunk;
 };
 } // namespace homestore

--- a/src/include/homestore/vchunk.h
+++ b/src/include/homestore/vchunk.h
@@ -24,7 +24,7 @@ class Chunk;
 class VChunk {
 public:
     VChunk(cshared< Chunk > const&);
-    
+
     ~VChunk() = default;
 
     void set_user_private(const sisl::blob& data);
@@ -34,6 +34,6 @@ public:
     cshared< Chunk > get_internal_chunk() const;
 
 private:
-    cshared< Chunk > internalChunk;
+    shared< Chunk > internalChunk;
 };
-}// namespace homestore
+} // namespace homestore

--- a/src/lib/device/vchunk.cpp
+++ b/src/lib/device/vchunk.cpp
@@ -17,23 +17,15 @@
 #include "device/chunk.h"
 
 namespace homestore {
-    VChunk::VChunk(cshared< Chunk >& chunk) : internalChunk(chunk){}
+VChunk::VChunk(cshared< Chunk >& chunk) : m_internal_chunk(chunk) {}
 
-    void VChunk::set_user_private(const sisl::blob& data){
-        internalChunk->set_user_private(data);
-    }
+void VChunk::set_user_private(const sisl::blob& data) { m_internal_chunk->set_user_private(data); }
 
-    const uint8_t* VChunk::get_user_private() const {
-        return internalChunk->user_private();
-    };
+const uint8_t* VChunk::get_user_private() const { return m_internal_chunk->user_private(); };
 
-    blk_cap_t VChunk::available_blks() const {
-        return internalChunk->blk_allocator()->available_blks();
-    }
+blk_cap_t VChunk::available_blks() const { return m_internal_chunk->blk_allocator()->available_blks(); }
 
-    uint32_t VChunk::get_pdev_id() const {
-        return internalChunk->physical_dev()->pdev_id();
-    }
+uint32_t VChunk::get_pdev_id() const { return m_internal_chunk->physical_dev()->pdev_id(); }
 
-    cshared< Chunk > VChunk::get_internal_chunk() const {return internalChunk;}
-}// namespace homestore
+cshared< Chunk > VChunk::get_internal_chunk() const { return m_internal_chunk; }
+} // namespace homestore


### PR DESCRIPTION
In HeapChunkSelector, we use a priority_queue as the heap, which will take std::vector or std:deque as the internal container to do the heap sort. well,  a type T in std::vector or std:deque must meet the requirements of [CopyAssignable](https://en.cppreference.com/w/cpp/named_req/CopyAssignable) and [CopyConstructible](https://en.cppreference.com/w/cpp/named_req/CopyConstructible). so we need to make VChunk meeting this requirements.

actually, the complier will generate default copy constructor and copy assign operator if necessary, the default action of the above two is just copy all the member of the class one by one. now , in Vchunk the only member is `cshard<chunk>`, which can not be assigned a new value, so we need to change this to a non-const `shard_ptr`