### PR TITLE
Add get_chunk_id to vchunk

### DIFF
--- a/src/include/homestore/vchunk.h
+++ b/src/include/homestore/vchunk.h
@@ -31,6 +31,7 @@ public:
     const uint8_t* get_user_private() const;
     blk_num_t available_blks() const;
     uint32_t get_pdev_id() const;
+    uint16_t get_chunk_id() const;
     cshared< Chunk > get_internal_chunk() const;
 
 private:

--- a/src/lib/device/vchunk.cpp
+++ b/src/lib/device/vchunk.cpp
@@ -27,5 +27,7 @@ blk_num_t VChunk::available_blks() const { return m_internal_chunk->blk_allocato
 
 uint32_t VChunk::get_pdev_id() const { return m_internal_chunk->physical_dev()->pdev_id(); }
 
+uint16_t VChunk::get_chunk_id() const { return m_internal_chunk->chunk_id(); }
+
 cshared< Chunk > VChunk::get_internal_chunk() const { return m_internal_chunk; }
 } // namespace homestore


### PR DESCRIPTION
This PR is created for Homeobject#heapChunkSelector and will be used by this https://github.com/eBay/HomeObject/pull/30

we need to maintain a chunkid -> chunk map, so we need to get chunk id from vchunk

https://github.com/eBay/HomeObject/blob/9ec3b9c730c6f61c80b9ce391c52618ab2908e05/src/lib/homestore/heap_chunk_selector.h#L50

other changes in this PR except the API  are caused by clang-format, not manually