### PR TITLE
DataService Recovery and its test case.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.3.0"
+    version = "4.3.1"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/conanfile.py
+++ b/conanfile.py
@@ -55,7 +55,7 @@ class HomestoreConan(ConanFile):
         self.build_requires("gtest/1.14.0")
 
     def requirements(self):
-        self.requires("iomgr/[~=10, include_prerelease=True]@oss/master")
+        self.requires("iomgr/10.0.1@yakuang/master")
         self.requires("sisl/[~=10, include_prerelease=True]@oss/master")
 
         self.requires("farmhash/cci.20190513@")

--- a/conanfile.py
+++ b/conanfile.py
@@ -55,7 +55,7 @@ class HomestoreConan(ConanFile):
         self.build_requires("gtest/1.14.0")
 
     def requirements(self):
-        self.requires("iomgr/10.0.1@yakuang/master")
+        self.requires("iomgr/[~=10, include_prerelease=True]@oss/master")
         self.requires("sisl/[~=10, include_prerelease=True]@oss/master")
 
         self.requires("farmhash/cci.20190513@")

--- a/src/include/homestore/blk.h
+++ b/src/include/homestore/blk.h
@@ -35,6 +35,7 @@ using chunk_num_t = uint16_t;
 using blk_count_t = uint16_t;
 using blk_num_t = uint32_t;
 using blk_temp_t = uint16_t;
+using allocator_id_t = chunk_num_t;
 
 static constexpr size_t max_addressable_chunks() { return 1UL << (8 * sizeof(chunk_num_t)); }
 static constexpr size_t max_blks_per_chunk() { return 1UL << (8 * sizeof(blk_num_t)); }

--- a/src/include/homestore/checkpoint/cp_mgr.hpp
+++ b/src/include/homestore/checkpoint/cp_mgr.hpp
@@ -140,6 +140,7 @@ public:
     CPGuard(const CPGuard& other);
     CPGuard operator=(const CPGuard& other);
 
+    CPContext* context(cp_consumer_t consumer);
     CP& operator*();
     CP* operator->();
     CP* get();

--- a/src/include/homestore/index/index_table.hpp
+++ b/src/include/homestore/index/index_table.hpp
@@ -22,8 +22,7 @@
 #include <homestore/superblk_handler.hpp>
 #include <homestore/index_service.hpp>
 #include <homestore/checkpoint/cp_mgr.hpp>
-#include "checkpoint/cp.hpp"
-#include "index/wb_cache.hpp"
+#include <homestore/index/wb_cache_base.hpp>
 
 SISL_LOGGING_DECL(wbcache)
 
@@ -56,7 +55,7 @@ public:
 
     btree_status_t init() {
         auto cp = hs()->cp_mgr().cp_guard();
-        auto ret = Btree< K, V >::init((void*)cp->context(cp_consumer_t::INDEX_SVC));
+        auto ret = Btree< K, V >::init((void*)cp.context(cp_consumer_t::INDEX_SVC));
         update_new_root_info(Btree< K, V >::root_node_id(), Btree< K, V >::root_link_version());
         return ret;
     }
@@ -77,14 +76,14 @@ public:
     template < typename ReqT >
     btree_status_t put(ReqT& put_req) {
         auto cpg = hs()->cp_mgr().cp_guard();
-        put_req.m_op_context = (void*)cpg->context(cp_consumer_t::INDEX_SVC);
+        put_req.m_op_context = (void*)cpg.context(cp_consumer_t::INDEX_SVC);
         return Btree< K, V >::put(put_req);
     }
 
     template < typename ReqT >
     btree_status_t remove(ReqT& remove_req) {
         auto cpg = hs()->cp_mgr().cp_guard();
-        remove_req.m_op_context = (void*)cpg->context(cp_consumer_t::INDEX_SVC);
+        remove_req.m_op_context = (void*)cpg.context(cp_consumer_t::INDEX_SVC);
         return Btree< K, V >::remove(remove_req);
     }
 

--- a/src/include/homestore/index_service.hpp
+++ b/src/include/homestore/index_service.hpp
@@ -25,7 +25,7 @@
 
 namespace homestore {
 
-class IndexWBCache;
+class IndexWBCacheBase;
 class IndexTableBase;
 class VirtualDev;
 
@@ -38,7 +38,7 @@ public:
 class IndexService {
 private:
     std::unique_ptr< IndexServiceCallbacks > m_svc_cbs;
-    std::unique_ptr< IndexWBCache > m_wb_cache;
+    std::unique_ptr< IndexWBCacheBase > m_wb_cache;
     std::shared_ptr< VirtualDev > m_vdev;
 
     mutable std::mutex m_index_map_mtx;
@@ -63,13 +63,13 @@ public:
     uint64_t used_size() const;
     uint32_t node_size() const;
 
-    IndexWBCache& wb_cache() { return *m_wb_cache; }
+    IndexWBCacheBase& wb_cache() { return *m_wb_cache; }
 
 private:
     void meta_blk_found(const sisl::byte_view& buf, void* meta_cookie);
 };
 
 extern IndexService& index_service();
-extern IndexWBCache& wb_cache();
+extern IndexWBCacheBase& wb_cache();
 
 } // namespace homestore

--- a/src/include/homestore/vchunk.h
+++ b/src/include/homestore/vchunk.h
@@ -31,6 +31,7 @@ public:
     const uint8_t* get_user_private() const;
     blk_num_t available_blks() const;
     uint32_t get_pdev_id() const;
+    uint16_t get_chunk_id() const;
     cshared< Chunk > get_internal_chunk() const;
 
 private:

--- a/src/lib/blkalloc/append_blk_allocator.cpp
+++ b/src/lib/blkalloc/append_blk_allocator.cpp
@@ -21,7 +21,7 @@
 
 namespace homestore {
 
-AppendBlkAllocator::AppendBlkAllocator(const BlkAllocConfig& cfg, bool need_format, chunk_num_t id) :
+AppendBlkAllocator::AppendBlkAllocator(const BlkAllocConfig& cfg, bool need_format, allocator_id_t id) :
         BlkAllocator{cfg, id}, m_metrics{get_name().c_str()} {
     // TODO: try to make all append_blk_allocator instances use same client type to reduce metablk's cache footprint;
     meta_service().register_handler(
@@ -47,13 +47,12 @@ AppendBlkAllocator::AppendBlkAllocator(const BlkAllocConfig& cfg, bool need_form
 }
 
 void AppendBlkAllocator::on_meta_blk_found(const sisl::byte_view& buf, void* meta_cookie) {
-    // TODO: also needs to initialize base class blkallocator for recovery path;
     // load all dirty buffer from the same starting point;
-    m_sb[0].load(buf, meta_cookie);
-    for (uint8_t i = 1; i < m_sb.size(); ++i) {
+    for (uint8_t i = 0; i < m_sb.size(); ++i) {
         m_sb[i].load(buf, meta_cookie);
     }
 
+    // recover in-memory counter/offset from metablk;
     m_last_append_offset = m_sb[0]->last_append_offset;
     m_freeable_nblks = m_sb[0]->freeable_nblks;
 
@@ -125,11 +124,11 @@ BlkAllocStatus AppendBlkAllocator::alloc(blk_count_t nblks, const blk_alloc_hint
 // cp_flush should not block alloc/free;
 //
 void AppendBlkAllocator::cp_flush(CP* cp) {
-    const auto idx = cp->id();
+    const auto idx = cp->id() % MAX_CP_COUNT;
     // check if current cp's context has dirty buffer already
     if (m_sb[idx]->is_dirty) {
         // write to metablk;
-        m_sb[cp->id()].write();
+        m_sb[idx].write();
 
         // clear this dirty buff's dirty flag;
         clear_dirty_offset(idx);

--- a/src/lib/blkalloc/append_blk_allocator.cpp
+++ b/src/lib/blkalloc/append_blk_allocator.cpp
@@ -32,18 +32,19 @@ AppendBlkAllocator::AppendBlkAllocator(const BlkAllocConfig& cfg, bool need_form
     if (need_format) {
         m_freeable_nblks = available_blks();
         m_last_append_offset = 0;
-
-        for (uint8_t i = 0; i < m_sb.size(); ++i) {
-            m_sb[i].set_name(get_name());
-            m_sb[i].create(sizeof(append_blkalloc_ctx));
-            m_sb[i]->is_dirty = false;
-            m_sb[i]->allocator_id = id;
-            m_sb[i]->last_append_offset = 0;
-            m_sb[i]->freeable_nblks = m_freeable_nblks;
-        }
     }
 
-    // for recovery boot, fields should be recovered from metablks;
+    // for both fresh start and recovery, firstly init m_sb fields;
+    for (uint8_t i = 0; i < m_sb.size(); ++i) {
+        m_sb[i].set_name(get_name());
+        m_sb[i].create(sizeof(append_blkalloc_ctx));
+        m_sb[i]->is_dirty = false;
+        m_sb[i]->allocator_id = id;
+        m_sb[i]->last_append_offset = 0;
+        m_sb[i]->freeable_nblks = m_freeable_nblks;
+    }
+
+    // for recovery boot, fields will also be recovered from metablks;
 }
 
 void AppendBlkAllocator::on_meta_blk_found(const sisl::byte_view& buf, void* meta_cookie) {

--- a/src/lib/blkalloc/append_blk_allocator.h
+++ b/src/lib/blkalloc/append_blk_allocator.h
@@ -33,7 +33,7 @@ struct append_blkalloc_ctx {
     uint64_t magic{append_blkalloc_sb_magic};
     uint32_t version{append_blkalloc_sb_version};
     bool is_dirty; // this field is needed for cp_flush, but not necessarily needed for persistence;
-    uint64_t allocator_id;
+    allocator_id_t allocator_id;
     blk_num_t freeable_nblks;
     blk_num_t last_append_offset;
 };
@@ -67,7 +67,7 @@ public:
 //
 class AppendBlkAllocator : public BlkAllocator {
 public:
-    AppendBlkAllocator(const BlkAllocConfig& cfg, bool need_format, chunk_num_t id = 0);
+    AppendBlkAllocator(const BlkAllocConfig& cfg, bool need_format, allocator_id_t id = 0);
 
     AppendBlkAllocator(const AppendBlkAllocator&) = delete;
     AppendBlkAllocator(AppendBlkAllocator&&) noexcept = delete;

--- a/src/lib/checkpoint/cp_mgr.cpp
+++ b/src/lib/checkpoint/cp_mgr.cpp
@@ -296,6 +296,7 @@ CPGuard CPGuard::operator=(const CPGuard& other) {
 
 CP& CPGuard::operator*() { return *get(); }
 CP* CPGuard::operator->() { return get(); }
+CPContext* CPGuard::context(cp_consumer_t consumer) { return get()->context(consumer); }
 
 CP* CPGuard::get() {
     HS_DBG_ASSERT_NE((void*)m_cp, (void*)nullptr, "CPGuard get on empty CP pointer");

--- a/src/lib/device/vchunk.cpp
+++ b/src/lib/device/vchunk.cpp
@@ -27,5 +27,7 @@ blk_num_t VChunk::available_blks() const { return m_internal_chunk->blk_allocato
 
 uint32_t VChunk::get_pdev_id() const { return m_internal_chunk->physical_dev()->pdev_id(); }
 
+uint16_t VChunk::get_chunk_id() const { return m_internal_chunk->chunk_id(); }
+
 cshared< Chunk > VChunk::get_internal_chunk() const { return m_internal_chunk; }
 } // namespace homestore

--- a/src/lib/device/virtual_dev.cpp
+++ b/src/lib/device/virtual_dev.cpp
@@ -228,8 +228,6 @@ BlkAllocStatus VirtualDev::alloc_blks(blk_count_t nblks, blk_alloc_hints const& 
     blk_count_t nblks_remain = nblks;
     BlkAllocStatus status;
 
-    HS_REL_ASSERT(h.chunk_id_hint, "Not expecting to received targetd chunk allocation in this function. ");
-
     do {
         out_blkids.emplace_back(); // Put an empty MultiBlkId and use that for allocating them
         BlkId& out_bid = out_blkids.back();

--- a/src/lib/device/virtual_dev.cpp
+++ b/src/lib/device/virtual_dev.cpp
@@ -187,7 +187,7 @@ BlkAllocStatus VirtualDev::alloc_blks(blk_count_t nblks, blk_alloc_hints const& 
         if (hints.chunk_id_hint) {
             // this is a target-chunk allocation;
             chunk = m_dmgr.get_chunk_mutable(*(hints.chunk_id_hint));
-            status = alloc_blk_from_chunk(nblks, hints, out_blkid, chunk);
+            status = alloc_blks_from_chunk(nblks, hints, out_blkid, chunk);
             // don't look for other chunks because user wants allocation on chunk_id_hint only;
         } else {
             do {
@@ -205,7 +205,7 @@ BlkAllocStatus VirtualDev::alloc_blks(blk_count_t nblks, blk_alloc_hints const& 
             } while (++attempt < m_all_chunks.size());
         }
 
-        if ((status != BlkAllocStatus::SUCCESS) && !((status == BlkAllocStatus::PARTIAL) && hints.partial_alloc_ok) {
+        if ((status != BlkAllocStatus::SUCCESS) && !((status == BlkAllocStatus::PARTIAL) && hints.partial_alloc_ok)) {
             LOGERROR("nblks={} failed to alloc after trying to alloc on every chunks {} and devices {}.", nblks);
             COUNTER_INCREMENT(m_metrics, vdev_num_alloc_failure, 1);
         }

--- a/src/lib/index/wb_cache.cpp
+++ b/src/lib/index/wb_cache.cpp
@@ -29,7 +29,7 @@ SISL_LOGGING_DECL(wbcache)
 
 namespace homestore {
 
-IndexWBCache& wb_cache() { return index_service().wb_cache(); }
+IndexWBCacheBase& wb_cache() { return index_service().wb_cache(); }
 
 IndexWBCache::IndexWBCache(const std::shared_ptr< VirtualDev >& vdev, const std::shared_ptr< sisl::Evictor >& evictor,
                            uint32_t node_size) :

--- a/src/tests/test_append_blkalloc.cpp
+++ b/src/tests/test_append_blkalloc.cpp
@@ -70,6 +70,18 @@ public:
     virtual void SetUp() override {
         test_common::HSTestHelper::set_data_svc_allocator(homestore::blk_allocator_type_t::append);
         test_common::HSTestHelper::set_data_svc_chunk_selector(homestore::chunk_selector_type_t::HEAP);
+
+        test_common::HSTestHelper::start_homestore("test_append_blkalloc", 5.0 /* meta */, 0 /* data_log */,
+                                                   0 /* ctrl_log */, 80.0 /* data */, 0 /* index */, nullptr,
+                                                   false /* recovery */, nullptr, false /* default ds type */);
+    }
+
+    virtual void TearDown() override { test_common::HSTestHelper::shutdown_homestore(); }
+
+    void restart_homestore() {
+        test_common::HSTestHelper::start_homestore("test_append_blkalloc", 5.0, 0, 0, 80.0, 0,
+                                                   nullptr /* before_svc_start_cb */, true /* restart */,
+                                                   nullptr /* indx_svc_cb */, false /* default ds type */);
     }
 
     void finish_and_notify() {
@@ -188,11 +200,6 @@ private:
 };
 
 TEST_F(AppendBlkAllocatorTest, TestBasicWrite) {
-    LOGINFO("Step 0: Starting homestore.");
-    test_common::HSTestHelper::start_homestore("test_append_blkalloc", 5.0 /* meta */, 0 /* data_log */,
-                                               0 /* ctrl_log */, 80.0 /* data */, 0 /* index */, nullptr,
-                                               false /* recovery */, nullptr, false /* default ds type */);
-
     // start io in worker thread;
     const auto io_size = 4 * Ki;
     LOGINFO("Step 1: run on worker thread to schedule write for {} Bytes.", io_size);
@@ -202,14 +209,9 @@ TEST_F(AppendBlkAllocatorTest, TestBasicWrite) {
     wait_for_all_io_complete();
 
     LOGINFO("Step 3: I/O completed, do shutdown.");
-    test_common::HSTestHelper::shutdown_homestore();
 }
 
 TEST_F(AppendBlkAllocatorTest, TestWriteThenReadVerify) {
-    LOGINFO("Step 0: Starting homestore.");
-    test_common::HSTestHelper::start_homestore("test_append_blkalloc", 5.0, 0, 0, 80.0, 0, nullptr, false, nullptr,
-                                               false /* default ds type */);
-
     // start io in worker thread;
     auto io_size = 4 * Ki;
     LOGINFO("Step 1: run on worker thread to schedule write for {} Bytes.", io_size);
@@ -219,14 +221,9 @@ TEST_F(AppendBlkAllocatorTest, TestWriteThenReadVerify) {
     wait_for_all_io_complete();
 
     LOGINFO("Step 3: I/O completed, do shutdown.");
-    test_common::HSTestHelper::shutdown_homestore();
 }
 
 TEST_F(AppendBlkAllocatorTest, TestWriteThenFreeBlk) {
-    LOGINFO("Step 0: Starting homestore.");
-    test_common::HSTestHelper::start_homestore("test_append_blkalloc", 5.0, 0, 0, 80.0, 0, nullptr, false, nullptr,
-                                               false /* default ds type */);
-
     // start io in worker thread;
     auto io_size = 4 * Mi;
     LOGINFO("Step 1: run on worker thread to schedule write for {} Bytes, then free blk.", io_size);
@@ -237,13 +234,9 @@ TEST_F(AppendBlkAllocatorTest, TestWriteThenFreeBlk) {
     wait_for_all_io_complete();
 
     LOGINFO("Step 3: I/O completed, do shutdown.");
-    test_common::HSTestHelper::shutdown_homestore();
 }
 
 TEST_F(AppendBlkAllocatorTest, TestCPFlush) {
-    LOGINFO("Step 0: Starting homestore.");
-    test_common::HSTestHelper::start_homestore("test_append_blkalloc", 5.0, 0, 0, 80.0, 0, nullptr, false, nullptr,
-                                               false /* default ds type */);
     const auto io_size = 4 * Ki;
     LOGINFO("Step 1: run on worker thread to schedule write for {} Bytes.", io_size);
     iomanager.run_on_forget(iomgr::reactor_regex::random_worker, [this, io_size]() { this->write_io(io_size); });
@@ -255,14 +248,9 @@ TEST_F(AppendBlkAllocatorTest, TestCPFlush) {
     test_common::HSTestHelper::trigger_cp(true /* wait */);
 
     LOGINFO("Step 4: cp completed, do shutdown.");
-    test_common::HSTestHelper::shutdown_homestore();
 }
 
 TEST_F(AppendBlkAllocatorTest, TestWriteThenRecovey) {
-    LOGINFO("Step 0: Starting homestore.");
-    test_common::HSTestHelper::start_homestore("test_append_blkalloc", 5.0, 0, 0, 80.0, 0, nullptr, false, nullptr,
-                                               false /* default ds type */);
-
     // start io in worker thread;
     auto io_size = 4 * Mi;
     LOGINFO("Step 1: run on worker thread to schedule write for {} Bytes, then free blk.", io_size);
@@ -276,9 +264,7 @@ TEST_F(AppendBlkAllocatorTest, TestWriteThenRecovey) {
     test_common::HSTestHelper::trigger_cp(true /* wait */);
 
     LOGINFO("Step 4: cp completed, restart homestore.");
-    test_common::HSTestHelper::start_homestore("test_append_blkalloc", 5.0, 0, 0, 80.0, 0,
-                                               nullptr /* before_svc_start_cb */, true /* restart */,
-                                               nullptr /* indx_svc_cb */, false /* default ds type */);
+    this->restart_homestore();
 
     std::this_thread::sleep_for(std::chrono::seconds{3});
     LOGINFO("Step 5: Restarted homestore with data service recovered");
@@ -295,7 +281,6 @@ TEST_F(AppendBlkAllocatorTest, TestWriteThenRecovey) {
     test_common::HSTestHelper::trigger_cp(true /* wait */);
 
     LOGINFO("Step 9: do shutdown. ");
-    test_common::HSTestHelper::shutdown_homestore();
 }
 
 SISL_OPTION_GROUP(test_append_blkalloc,

--- a/src/tests/test_index_btree.cpp
+++ b/src/tests/test_index_btree.cpp
@@ -298,7 +298,7 @@ struct BtreeTest : public testing::Test {
 
     void destroy_btree() {
         auto cpg = hs()->cp_mgr().cp_guard();
-        auto op_context = (void*)cpg->context(cp_consumer_t::INDEX_SVC);
+        auto op_context = (void*)cpg.context(cp_consumer_t::INDEX_SVC);
         const auto [ret, free_node_cnt] = m_bt->destroy_btree(op_context);
         ASSERT_EQ(ret, btree_status_t::success) << "btree destroy failed";
         m_bt.reset();


### PR DESCRIPTION
Add Data Service Recovery and its test case.

The recovery flow for data service is(most of the logic are already there):

1. load_vdev -> open_vdev
2. vdev->add_chunk(...) -> create_blk_allocator for each chunk, each blk allocator register meta_blk_found callback for every possible meta blks possibly written before recovery boot.
3. Start meta blk service
4. Each BlkAllocator instance receives meta blks from MetaSvc (via pre-registered callback), and load them into memory.
5. Recovery done.
6. Start serving I/O requests;

A new test case added with alloc/write/free/cp_flush, then recover, followed by another round of alloc/write/cp.

Test case added and passed.