### PR TITLE
DataSvc Recovery

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.3.1"
+    version = "4.3.2"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/blk.h
+++ b/src/include/homestore/blk.h
@@ -35,6 +35,7 @@ using chunk_num_t = uint16_t;
 using blk_count_t = uint16_t;
 using blk_num_t = uint32_t;
 using blk_temp_t = uint16_t;
+using allocator_id_t = chunk_num_t;
 
 static constexpr size_t max_addressable_chunks() { return 1UL << (8 * sizeof(chunk_num_t)); }
 static constexpr size_t max_blks_per_chunk() { return 1UL << (8 * sizeof(blk_num_t)); }

--- a/src/lib/blkalloc/append_blk_allocator.h
+++ b/src/lib/blkalloc/append_blk_allocator.h
@@ -33,7 +33,7 @@ struct append_blkalloc_ctx {
     uint64_t magic{append_blkalloc_sb_magic};
     uint32_t version{append_blkalloc_sb_version};
     bool is_dirty; // this field is needed for cp_flush, but not necessarily needed for persistence;
-    uint64_t allocator_id;
+    allocator_id_t allocator_id;
     blk_num_t freeable_nblks;
     blk_num_t last_append_offset;
 };
@@ -67,7 +67,7 @@ public:
 //
 class AppendBlkAllocator : public BlkAllocator {
 public:
-    AppendBlkAllocator(const BlkAllocConfig& cfg, bool need_format, chunk_num_t id = 0);
+    AppendBlkAllocator(const BlkAllocConfig& cfg, bool need_format, allocator_id_t id = 0);
 
     AppendBlkAllocator(const AppendBlkAllocator&) = delete;
     AppendBlkAllocator(AppendBlkAllocator&&) noexcept = delete;


### PR DESCRIPTION
Add Data Service Recovery and its test case.

The recovery flow for data service is(most of the logic are already there):

load_vdev -> open_vdev
vdev->add_chunk(...) -> create_blk_allocator for each chunk, each blk allocator register meta_blk_found callback for every possible meta blks possibly written before recovery boot.
Start meta blk service
Each BlkAllocator instance receives meta blks from MetaSvc (via pre-registered callback), and load them into memory.
Recovery done.
Start serving I/O requests;
A new test case added with alloc/write/free/cp_flush, then recover, followed by another round of alloc/write/cp.

Test case added and passed.