### PR TITLE
ReplDev context type safety and blkread tracker race condition fix

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.4.0"
+    version = "4.5.0"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/homestore.hpp
+++ b/src/include/homestore/homestore.hpp
@@ -44,9 +44,8 @@ class MetaBlkService;
 class LogStoreService;
 class BlkDataService;
 class IndexService;
-class ReplicationServiceImpl;
+class ReplicationService;
 class IndexServiceCallbacks;
-class ReplServiceCallbacks;
 struct vdev_info;
 class HomeStore;
 class CPManager;
@@ -114,7 +113,7 @@ private:
     std::unique_ptr< MetaBlkService > m_meta_service;
     std::unique_ptr< LogStoreService > m_log_service;
     std::unique_ptr< IndexService > m_index_service;
-    std::unique_ptr< ReplicationServiceImpl > m_repl_service;
+    std::unique_ptr< ReplicationService > m_repl_service;
 
     std::unique_ptr< DeviceManager > m_dev_mgr;
     shared< sisl::logging::logger_t > m_periodic_logger;
@@ -144,7 +143,7 @@ public:
     HomeStore& with_data_service(cshared< ChunkSelector >& custom_chunk_selector = nullptr);
     HomeStore& with_log_service();
     HomeStore& with_index_service(std::unique_ptr< IndexServiceCallbacks > cbs);
-    HomeStore& with_repl_data_service(repl_impl_type repl_type, std::unique_ptr< ReplServiceCallbacks > cbs,
+    HomeStore& with_repl_data_service(repl_impl_type repl_type,
                                       cshared< ChunkSelector >& custom_chunk_selector = nullptr);
 
     bool start(const hs_input_params& input, hs_before_services_starting_cb_t svcs_starting_cb = nullptr);
@@ -165,7 +164,7 @@ public:
     MetaBlkService& meta_service() { return *m_meta_service; }
     LogStoreService& logstore_service() { return *m_log_service; }
     IndexService& index_service() { return *m_index_service; }
-    ReplicationServiceImpl& repl_service() { return *m_repl_service; }
+    ReplicationService& repl_service() { return *m_repl_service; }
     DeviceManager* device_mgr() { return m_dev_mgr.get(); }
     ResourceMgr& resource_mgr() { return *m_resource_mgr.get(); }
     CPManager& cp_mgr() { return *m_cp_mgr.get(); }

--- a/src/include/homestore/homestore_decl.hpp
+++ b/src/include/homestore/homestore_decl.hpp
@@ -55,6 +55,9 @@ using unique = std::unique_ptr< T >;
 template < typename T >
 using intrusive = boost::intrusive_ptr< T >;
 
+template < typename T >
+using cintrusive = const boost::intrusive_ptr< T >;
+
 ////////////// All Size Limits ///////////////////
 constexpr uint32_t BLK_NUM_BITS{32};
 constexpr uint32_t NBLKS_BITS{8};

--- a/src/include/homestore/index/wb_cache_base.hpp
+++ b/src/include/homestore/index/wb_cache_base.hpp
@@ -31,6 +31,8 @@ struct CPContext;
 
 class IndexWBCacheBase {
 public:
+    virtual ~IndexWBCacheBase() = default;
+
     /// @brief Allocate the buffer and initialize the btree node. It adds the node to the wb cache.
     /// @tparam K Key type of the Index
     /// @param node_initializer Callback to be called upon which buffer is turned into btree node

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -36,7 +36,7 @@ template < typename V, typename E >
 using Result = folly::Expected< V, E >;
 
 template < class V, class E >
-using AsyncResult = folly::SemiFuture< Result< V, E > >;
+using AsyncResult = folly::Future< Result< V, E > >;
 
 template < class V >
 using ReplResult = Result< V, ReplServiceError >;
@@ -44,26 +44,45 @@ using ReplResult = Result< V, ReplServiceError >;
 template < class V >
 using AsyncReplResult = AsyncResult< V, ReplServiceError >;
 
-class ReplServiceCallbacks {
-public:
-    virtual ~ReplServiceCallbacks() = default;
-    virtual std::unique_ptr< ReplDevListener > on_repl_dev_init(cshared< ReplDev >& rs) = 0;
-};
-
 class ReplicationService {
 public:
     ReplicationService() = default;
     virtual ~ReplicationService() = default;
 
-    /// Sync APIs
-    virtual ReplResult< shared< ReplDev > > get_replica_dev(uuid_t group_id) const = 0;
-    virtual void iterate_replica_devs(std::function< void(cshared< ReplDev >&) > const& cb) = 0;
+    /// @brief Creates the Repl Device to which eventually user can read locally and write to the quorom of the members
+    /// @param group_id Unique ID indicating the group. This is the key for several lookup structures
+    /// @param members List of members to form this group
+    /// @param listener state machine listener of all the events happening on the repl_dev (commit, precommit etc)
+    /// @return A Future ReplDev on success or Future ReplServiceError upon error
+    virtual AsyncReplResult< shared< ReplDev > > create_repl_dev(uuid_t group_id,
+                                                                 std::set< std::string, std::less<> >&& members,
+                                                                 std::unique_ptr< ReplDevListener > listener) = 0;
 
-    /// Async APIs
-    virtual AsyncReplResult< shared< ReplDev > > create_replica_dev(uuid_t group_id,
-                                                                    std::set< std::string, std::less<> >&& members) = 0;
+    /// @brief Opens the Repl Device for a given group id. It is expected that the repl dev is already created and used
+    /// this method for recovering. It is possible that repl_dev is not ready and in that case it will provide Repl
+    /// Device after it is ready and thus returns a Future.
+    ///
+    /// NOTE 1: If callers does an open for a repl device which was not created before, then at the end of
+    /// initialization an error is returned saying ReplServiceError::SERVER_NOT_FOUND
+    ///
+    /// NOTE 2: If the open repl device is called after Replication service is started, then it returns an error
+    /// ReplServiceError::BAD_REQUEST
+    /// @param group_id Group id to open the repl device with
+    /// @param listener state machine listener of all the events happening on the repl_dev (commit, precommit etc)
+    /// @return A Future ReplDev on successful open of ReplDev or Future ReplServiceError upon error
+    virtual AsyncReplResult< shared< ReplDev > > open_repl_dev(uuid_t group_id,
+                                                               std::unique_ptr< ReplDevListener > listener) = 0;
 
-    virtual folly::SemiFuture< ReplServiceError > replace_member(uuid_t group_id, std::string const& member_out,
-                                                                 std::string const& member_in) const = 0;
+    virtual folly::Future< ReplServiceError > replace_member(uuid_t group_id, std::string const& member_out,
+                                                             std::string const& member_in) const = 0;
+
+    /// @brief Get the repl dev for a given group id if it is already created or opened
+    /// @param group_id Group id interested in
+    /// @return ReplDev is opened or ReplServiceError::SERVER_NOT_FOUND if it doesn't exist
+    virtual ReplResult< shared< ReplDev > > get_repl_dev(uuid_t group_id) const = 0;
+
+    /// @brief Iterate over all repl devs and then call the callback provided
+    /// @param cb Callback with repl dev
+    virtual void iterate_repl_devs(std::function< void(cshared< ReplDev >&) > const& cb) = 0;
 };
 } // namespace homestore

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -5,7 +5,8 @@
 #include "replication/repl_dev/solo_repl_dev.h"
 
 namespace homestore {
-SoloReplDev::SoloReplDev(superblk< repl_dev_superblk > const& rd_sb, bool load_existing) : m_rd_sb{rd_sb} {
+SoloReplDev::SoloReplDev(superblk< repl_dev_superblk > const& rd_sb, bool load_existing) :
+        m_rd_sb{rd_sb}, m_group_id{m_rd_sb->gid} {
     if (load_existing) {
         logstore_service().open_log_store(LogStoreService::DATA_LOG_FAMILY_IDX, m_rd_sb->data_journal_id, true,
                                           bind_this(SoloReplDev::on_data_journal_created, 1));
@@ -23,18 +24,17 @@ void SoloReplDev::on_data_journal_created(shared< HomeLogStore > log_store) {
 }
 
 void SoloReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& key, sisl::sg_list const& value,
-                                    void* user_ctx) {
-    auto rreq = intrusive< repl_req >(new repl_req{});
+                                    intrusive< repl_req_ctx > rreq) {
+    if (!rreq) { auto rreq = intrusive< repl_req_ctx >(new repl_req_ctx{}); }
     rreq->header = header;
     rreq->key = key;
     rreq->value = std::move(value);
-    rreq->user_ctx = user_ctx;
 
     // If it is header only entry, directly write to the journal
     if (rreq->value.size) {
         // Step 1: Alloc Blkid
-        auto status = data_service().alloc_blks(
-            uint32_cast(rreq->value.size), m_listener->get_blk_alloc_hints(rreq->header, user_ctx), rreq->local_blkid);
+        auto status = data_service().alloc_blks(uint32_cast(rreq->value.size),
+                                                m_listener->get_blk_alloc_hints(rreq->header, rreq), rreq->local_blkid);
         HS_REL_ASSERT_EQ(status, BlkAllocStatus::SUCCESS);
 
         // Write the data
@@ -49,9 +49,9 @@ void SoloReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& 
     }
 }
 
-void SoloReplDev::write_journal(intrusive< repl_req > rreq) {
-    uint32_t entry_size =
-        sizeof(repl_journal_entry) + rreq->header.size + rreq->key.size + rreq->local_blkid.serialized_size();
+void SoloReplDev::write_journal(intrusive< repl_req_ctx > rreq) {
+    uint32_t entry_size = sizeof(repl_journal_entry) + rreq->header.size + rreq->key.size +
+        (rreq->value.size ? rreq->local_blkid.serialized_size() : 0);
     rreq->alloc_journal_entry(entry_size);
     rreq->journal_entry->code = journal_type_t::HS_DATA;
     rreq->journal_entry->user_header_size = rreq->header.size;
@@ -74,17 +74,17 @@ void SoloReplDev::write_journal(intrusive< repl_req > rreq) {
         raw_ptr += b.size;
     }
 
-    m_data_journal->append_async(
-        sisl::io_blob{rreq->journal_buf.get(), entry_size, false /* is_aligned */}, nullptr /* cookie */,
-        [this, rreq](int64_t lsn, sisl::io_blob&, homestore::logdev_key, void*) {
-            rreq->lsn = lsn;
-            m_listener->on_pre_commit(rreq->lsn, rreq->header, rreq->key, rreq->user_ctx);
+    m_data_journal->append_async(sisl::io_blob{rreq->journal_buf.get(), entry_size, false /* is_aligned */},
+                                 nullptr /* cookie */,
+                                 [this, rreq](int64_t lsn, sisl::io_blob&, homestore::logdev_key, void*) mutable {
+                                     rreq->lsn = lsn;
+                                     m_listener->on_pre_commit(rreq->lsn, rreq->header, rreq->key, rreq);
 
-            auto cur_lsn = m_commit_upto.load();
-            if (cur_lsn < lsn) { m_commit_upto.compare_exchange_strong(cur_lsn, lsn); }
+                                     auto cur_lsn = m_commit_upto.load();
+                                     if (cur_lsn < lsn) { m_commit_upto.compare_exchange_strong(cur_lsn, lsn); }
 
-            m_listener->on_commit(rreq->lsn, rreq->header, rreq->key, rreq->local_blkid, rreq->user_ctx);
-        });
+                                     m_listener->on_commit(rreq->lsn, rreq->header, rreq->key, rreq->local_blkid, rreq);
+                                 });
 }
 
 void SoloReplDev::on_log_found(logstore_seq_num_t lsn, log_buffer buf, void* ctx) {
@@ -133,4 +133,12 @@ void SoloReplDev::cp_flush(CP*) {
 
 void SoloReplDev::cp_cleanup(CP*) { m_data_journal->truncate(m_rd_sb->checkpoint_lsn); }
 
+void repl_req_ctx::alloc_journal_entry(uint32_t size) {
+    journal_buf = std::unique_ptr< uint8_t[] >(new uint8_t[size]);
+    journal_entry = new (journal_buf.get()) repl_journal_entry();
+}
+
+repl_req_ctx::~repl_req_ctx() {
+    if (journal_entry) { journal_entry->~repl_journal_entry(); }
+}
 } // namespace homestore

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -97,7 +97,6 @@ public:
         uint32_t blk_size{0};
         shared< ChunkSelector > custom_chunk_selector{nullptr};
         IndexServiceCallbacks* index_svc_cbs{nullptr};
-        ReplServiceCallbacks* repl_svc_cbs{nullptr};
         repl_impl_type repl_impl{repl_impl_type::solo};
     };
 
@@ -170,8 +169,7 @@ public:
             } else if ((svc == HS_SERVICE::LOG_REPLICATED) || (svc == HS_SERVICE::LOG_LOCAL)) {
                 hsi->with_log_service();
             } else if (svc == HS_SERVICE::REPLICATION) {
-                hsi->with_repl_data_service(tp.repl_impl, std::unique_ptr< ReplServiceCallbacks >(tp.repl_svc_cbs),
-                                            tp.custom_chunk_selector);
+                hsi->with_repl_data_service(tp.repl_impl, tp.custom_chunk_selector);
             }
         }
         bool need_format =


### PR DESCRIPTION
* Consumer passes some context as part of ReplDev requests, which are then passed back during callback. This was a type unsafe void* pointer. This resulted in either caller allocating a surrounding request structure then pass as a void* or worse caller pass a stack context. Latter is dangerous since callback can be done as part of different thread at different time. Former is safe, but it involves type unsafety and another allocation, since homestore repl layer also has to create a structure to capture its status. Hence this commit opens up a repl_ctx as intrusive pointer and exposes as the context for upper layer, providing type safety and reduce allocations. Using intrusive instead of shared_ptr is because intrusive size is 8 bytes and avoid another allocation during lambda capture, since most of the std::function implementation will capture upto 32 bytes inline and better to keep them always inline.

* Allow consumer to veto pre_commit on callback

* Without this fix, BlkReadTracker gets the blk_track_record and then makes decision to update or delete.  When this happens on multiple threads, each thread makes update or delete independently and step on each other resulting in either callback never happens or ref_count goes below 0. Fixed this by calling SimpleHashMap new api to get/update/delete atomically