### PR TITLE
issue #184: threaded test for readblktracker

### DIFF
--- a/src/lib/blkdata_svc/blk_read_tracker.cpp
+++ b/src/lib/blkdata_svc/blk_read_tracker.cpp
@@ -61,7 +61,8 @@ void BlkReadTracker::merge(const BlkId& blkid, int64_t new_ref_count,
                 waiter_rescheduled = true;
             });
         }
-        cur_base_blk_num += 1;
+
+        cur_base_blk_num += entries_per_record();
     }
 
 #ifdef _PRERELEASE

--- a/src/lib/blkdata_svc/blk_read_tracker.cpp
+++ b/src/lib/blkdata_svc/blk_read_tracker.cpp
@@ -61,7 +61,7 @@ void BlkReadTracker::merge(const BlkId& blkid, int64_t new_ref_count,
                 waiter_rescheduled = true;
             });
         }
-        cur_base_blk_num += entries_per_record();
+        cur_base_blk_num += 1;
     }
 
 #ifdef _PRERELEASE

--- a/src/lib/blkdata_svc/blk_read_tracker.cpp
+++ b/src/lib/blkdata_svc/blk_read_tracker.cpp
@@ -47,11 +47,13 @@ void BlkReadTracker::merge(const BlkId& blkid, int64_t new_ref_count,
                                                  });
         } else if (new_ref_count < 0) {
             // This is a remove operation
-            m_pending_reads_map.upsert_or_delete(base_blkid, [new_ref_count](BlkTrackRecord& rec, bool existing) {
-                HS_DBG_ASSERT_EQ(existing, true, "Decrement a ref count which does not exist in map");
-                rec.m_ref_cnt += new_ref_count;
-                return (rec.m_ref_cnt == 0);
-            });
+            m_pending_reads_map.upsert_or_delete(
+                base_blkid, [new_ref_count, &base_blkid](BlkTrackRecord& rec, bool existing) {
+                    HS_DBG_ASSERT_EQ(existing, true, "Decrement a ref count (blk: {}) which does not exist in map",
+                                     base_blkid.to_string());
+                    rec.m_ref_cnt += new_ref_count;
+                    return (rec.m_ref_cnt == 0);
+                });
         } else {
             // this is wait_on operation
             m_pending_reads_map.update(base_blkid, [&waiter_rescheduled, &waiter](BlkTrackRecord& rec) {

--- a/src/tests/test_blk_read_tracker.cpp
+++ b/src/tests/test_blk_read_tracker.cpp
@@ -408,7 +408,7 @@ TEST_F(BlkReadTrackerTest, TestThreadedInsertWaitonThenRemove) {
                 LOGINFO("wait_on called on blkid: {};", bids[i].to_string());
             });
         });
-        t.detach();
+        op_threads.push_back(std::move(t));
     }
 
     LOGINFO("Step 3: threaded wait_on issued on all bids.");

--- a/src/tests/test_blk_read_tracker.cpp
+++ b/src/tests/test_blk_read_tracker.cpp
@@ -403,7 +403,7 @@ TEST_F(BlkReadTrackerTest, TestThreadedInsertWaitonThenRemove) {
         std::thread t([this, &bids, i, &mtx, &called]() {
             get_inst()->wait_on(bids[i], [i, &bids, &mtx, &called]() {
                 std::unique_lock lk(mtx);
-                assert(!called[i]); // callback shouldn't be called more than once;
+                LOGMSG_ASSERT(called[i] == false, "not expecting callback to be called more than once!");
                 called[i] = true;
                 LOGINFO("wait_on called on blkid: {};", bids[i].to_string());
             });
@@ -427,8 +427,8 @@ TEST_F(BlkReadTrackerTest, TestThreadedInsertWaitonThenRemove) {
 
     LOGINFO("Step 4: all threads joined.");
 
-    for (const auto x : called) {
-        assert(x); // all callbacks should be called;
+    for (auto i = 0ul; i < called.size(); ++i) {
+        LOGMSG_ASSERT(called[i] == true, "expecting all waiters to be called");
     }
 
     LOGINFO("Step 5: all bids wait_on cb called.");

--- a/src/tests/test_blk_read_tracker.cpp
+++ b/src/tests/test_blk_read_tracker.cpp
@@ -374,9 +374,9 @@ TEST_F(BlkReadTrackerTest, TestThreadedInsertAndRemove) {
     LOGINFO("Step 3: threaded insert joined.");
     op_threads.clear();
 
-    for (auto i = 0ul; i < bids.size(); ++i) {
+    for (const auto& b : bids) {
         for (auto j = 0ul; j < repeat; ++j) {
-            std::thread t([this, &bids, i]() { get_inst()->remove(bids[i]); });
+            std::thread t([this, &b]() { get_inst()->remove(b); });
             op_threads.push_back(std::move(t));
         }
     }
@@ -397,10 +397,10 @@ TEST_F(BlkReadTrackerTest, TestThreadedInsertWaitonThenRemove) {
     std::vector< BlkId > bids{{12, 6, 0}, {18, 5, 0}, {25, 8, 0}, {36, 16, 0}, {57, 4, 0}, {66, 18, 0}, {92, 14, 0}};
     const auto repeat = 100ul;
     std::vector< std::thread > op_threads;
-    for (auto i = 0ul; i < bids.size(); ++i) {
-        std::thread t([this, &bids, i]() {
+    for (const auto& b : bids) {
+        std::thread t([this, &b]() {
             for (auto j = 0ul; j < repeat; ++j) {
-                get_inst()->insert(bids[i]);
+                get_inst()->insert(b);
             }
         });
         op_threads.push_back(std::move(t));
@@ -431,9 +431,9 @@ TEST_F(BlkReadTrackerTest, TestThreadedInsertWaitonThenRemove) {
 
     LOGINFO("Step 3: threaded wait_on issued on all bids.");
 
-    for (auto i = 0ul; i < bids.size(); ++i) {
+    for (const auto& b : bids) {
         for (auto j = 0ul; j < repeat; ++j) {
-            std::thread t([this, &bids, i]() { get_inst()->remove(bids[i]); });
+            std::thread t([this, &b]() { get_inst()->remove(b); });
             op_threads.push_back(std::move(t));
         }
     }
@@ -445,8 +445,8 @@ TEST_F(BlkReadTrackerTest, TestThreadedInsertWaitonThenRemove) {
 
     LOGINFO("Step 4: all threads joined.");
 
-    for (auto i = 0ul; i < called.size(); ++i) {
-        LOGMSG_ASSERT(called[i] == true, "expecting all waiters to be called");
+    for (const auto x : called) {
+        LOGMSG_ASSERT(x == true, "expecting all waiters to be called");
     }
 
     LOGINFO("Step 5: all bids wait_on cb called.");

--- a/src/tests/test_blk_read_tracker.cpp
+++ b/src/tests/test_blk_read_tracker.cpp
@@ -13,7 +13,12 @@
  * specific language governing permissions and limitations under the License.
  *
  *********************************************************************************/
-
+#include <memory>
+#include <mutex>
+#include <random>
+#include <string>
+#include <vector>
+#include <list>
 #include <gtest/gtest.h>
 
 #include "blkdata_svc/blk_read_tracker.hpp"
@@ -23,6 +28,7 @@ using namespace homestore;
 SISL_LOGGING_INIT(test_blk_read_tracker, iomgr, flip, io_wd)
 SISL_OPTIONS_ENABLE(logging, test_blk_read_tracker)
 
+VENUM(op_type_t, uint8_t, insert = 0, remove = 1, wait_on = 2, max_op = 3);
 class BlkReadTrackerTest : public testing::Test {
 public:
     virtual void SetUp() override {
@@ -32,6 +38,24 @@ public:
 
     void init() { m_blk_read_tracker = std::make_unique< BlkReadTracker >(); }
     std::shared_ptr< BlkReadTracker > get_inst() { return m_blk_read_tracker; }
+
+    op_type_t get_rand_op_type() {
+        return static_cast< op_type_t >(rand() % static_cast< uint8_t >(op_type_t::max_op));
+    }
+
+    void gen_random_blkids(std::vector< BlkId >& out_bids, blk_count_t nblks) {
+        for (auto i = 0ul; i < nblks; ++i) {
+            out_bids.emplace_back(gen_random_blkid());
+        }
+    }
+
+    BlkId gen_random_blkid() {
+        static thread_local std::random_device rd;
+        static thread_local std::default_random_engine re{rd()};
+        std::uniform_int_distribution< blk_num_t > blk_num{0, 1000};
+        std::uniform_int_distribution< blk_count_t > nblks{0, 64};
+        return BlkId{blk_num(re), nblks(re), static_cast< chunk_num_t >(0ul) /* chunk_num */};
+    }
 
 private:
     std::shared_ptr< BlkReadTracker > m_blk_read_tracker;
@@ -342,7 +366,6 @@ TEST_F(BlkReadTrackerTest, TestInsRmWithWaiterOverlapMultiReads2) {
  * 1. do insert with a few threads -- (can also be done in massive threads, but not necessary)
  * 2. do remove in massive threads (must be same amount of inserts);
  * */
-VENUM(op_type_t, uint8_t, insert = 1, remove = 2, wait_on = 3, no_op = 4);
 TEST_F(BlkReadTrackerTest, TestThreadedInsertAndRemove) {
     auto align = 8ul;
     LOGINFO("Step 1: set entries per record to {}.", align);
@@ -450,6 +473,81 @@ TEST_F(BlkReadTrackerTest, TestThreadedInsertWaitonThenRemove) {
     }
 
     LOGINFO("Step 5: all bids wait_on cb called.");
+}
+
+/*
+ * Purpose of this test:
+ * 1. Concurrent random insert/remove/wait_on operations in different threads.
+ *
+ * */
+TEST_F(BlkReadTrackerTest, TestThreadedInsertRemoveAndWait2) {
+    auto align = 8ul;
+    LOGINFO("Step 1: set entries per record to {}.", align);
+    get_inst()->set_entries_per_record(align);
+
+    std::mutex mtx;
+    std::list< BlkId > inserted_bids;
+
+    std::atomic< uint32_t > outstanding_wait_bids_cnt = 0ul;
+
+    LOGINFO("Step 2: randome threaded insert/remove/wait_on operation:");
+    std::list< std::thread > op_threads;
+    auto nitr = 0ul;
+    while (nitr++ < 200ul || inserted_bids.empty() == false) {
+        std::thread t([this, &outstanding_wait_bids_cnt, &nitr, &inserted_bids, &mtx]() {
+            auto op = get_rand_op_type();
+            if (nitr >= 200) {
+                // reached maximum iterations, let's do remove only so that we can exit the while loop;
+                op = op_type_t::remove;
+            }
+
+            if (op == op_type_t::insert) {
+                BlkId b = gen_random_blkid();
+                get_inst()->insert(b);
+                {
+                    std::unique_lock lg(mtx);
+                    inserted_bids.push_front(b);
+                }
+            } else if (op == op_type_t::remove) {
+                BlkId rm_b;
+                {
+                    std::unique_lock lg(mtx);
+                    if (inserted_bids.size() == 0) {
+                        // remove come ahead of insert, nothing to do;
+                        return;
+                    }
+                    rm_b = inserted_bids.back();
+                    inserted_bids.pop_back();
+                }
+
+                get_inst()->remove(rm_b);
+            } else if (op == op_type_t::wait_on) {
+                BlkId wait_b;
+                {
+                    std::unique_lock lg(mtx);
+                    if (inserted_bids.size() == 0) {
+                        // remove come ahead of insert, nothing to do;
+                        return;
+                    }
+                    wait_b = inserted_bids.back();
+                }
+
+                outstanding_wait_bids_cnt.fetch_add(1);
+                get_inst()->wait_on(wait_b, [&outstanding_wait_bids_cnt]() { outstanding_wait_bids_cnt.fetch_sub(1); });
+            }
+        });
+        op_threads.push_back(std::move(t));
+    }
+
+    for (auto& t : op_threads) {
+        t.join();
+    }
+
+    LOGINFO("Step 3: all threads joined.");
+
+    LOGMSG_ASSERT(outstanding_wait_bids_cnt.load() == 0, "expecting callback to be called for all waited bids!");
+
+    LOGINFO("Step 4: Test Passed.");
 }
 
 SISL_OPTION_GROUP(test_blk_read_tracker,

--- a/src/tests/test_blk_read_tracker.cpp
+++ b/src/tests/test_blk_read_tracker.cpp
@@ -353,10 +353,10 @@ TEST_F(BlkReadTrackerTest, TestThreadedInsertAndRemove) {
     const auto repeat = 100ul;
     std::vector< std::thread > op_threads;
 
-    for (auto i = 0ul; i < bids.size(); ++i) {
-        std::thread t([this, &bids, i]() {
+    for (const auto& b : bids) {
+        std::thread t([this, &b]() {
             for (auto j = 0ul; j < repeat; ++j) {
-                get_inst()->insert(bids[i]);
+                get_inst()->insert(b);
             }
         });
         op_threads.push_back(std::move(t));

--- a/src/tests/test_blk_read_tracker.cpp
+++ b/src/tests/test_blk_read_tracker.cpp
@@ -352,6 +352,7 @@ TEST_F(BlkReadTrackerTest, TestThreadedInsertAndRemove) {
 
     const auto repeat = 100ul;
     std::vector< std::thread > op_threads;
+
     for (auto i = 0ul; i < bids.size(); ++i) {
         std::thread t([this, &bids, i]() {
             for (auto j = 0ul; j < repeat; ++j) {


### PR DESCRIPTION
Added three new test cases:
========================
1. concurrent insert and concurrent remove.   // >>>>> to expose race window for concurrent get element, update element and then put back to map, same thing for remove.
2. concurrent insert, then concurrent wait, then concurrent remove. //  >>>> similar as "1", but add wait on operations.
3. concurrent insert/wait/remove.  // >>>>> this is pure concurrent operations close to real life concurrency.
All test passed.