### PR TITLE
fix solo repldev will be nullptr in map when homestore restart

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.5.4"
+    version = "4.5.5"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/service/repl_service_impl.cpp
+++ b/src/lib/replication/service/repl_service_impl.cpp
@@ -74,7 +74,7 @@ ReplicationServiceImpl::open_repl_dev(uuid_t group_id, std::unique_ptr< ReplDevL
     auto it = m_rd_map.find(group_id);
     if (it != m_rd_map.end()) {
         // We already loaded the ReplDev, just call the group_id and attach the listener
-        auto& repl_dev = it->second;
+        auto repl_dev = it->second;
         listener->set_repl_dev(repl_dev.get());
         repl_dev->attach_listener(std::move(listener));
         return make_async_success< shared< ReplDev > >(std::move(repl_dev));


### PR DESCRIPTION
This PR fix issue when HS restarts,  the Solo ReplDev in map will be set to nullptr. it is caused by an unexpected std::move() operation in src/lib/replication/service/repl_service_impl.cpp Line80