### PR TITLE
Fix link version upgrade and enable it

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.5.5"
+    version = "4.5.6"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/btree/detail/btree_mutate_impl.ipp
+++ b/src/include/homestore/btree/detail/btree_mutate_impl.ipp
@@ -523,7 +523,7 @@ btree_status_t Btree< K, V >::split_node(const BtreeNodePtr& parent_node, const 
     }
     BT_NODE_LOG(TRACE, parent_node, "Available space for split entry={}", parent_node->available_size(m_bt_cfg));
 
-//    child_node1->inc_link_version();
+    child_node1->inc_link_version();
 
     // Update the existing parent node entry to point to second child ptr.
     parent_node->update(parent_ind, child_node2->link_info());

--- a/src/include/homestore/btree/detail/btree_node.hpp
+++ b/src/include/homestore/btree/detail/btree_node.hpp
@@ -398,7 +398,7 @@ public:
         return true;
     }
 
-    virtual BtreeLinkInfo get_edge_value() const { return BtreeLinkInfo{edge_id(), link_version()}; }
+    virtual BtreeLinkInfo get_edge_value() const { return BtreeLinkInfo{edge_id(), edge_link_version()}; }
 
     virtual void set_edge_value(const BtreeValue& v) {
         const auto b = v.serialize();
@@ -609,6 +609,10 @@ public:
 
     bnodeid_t edge_id() const { return get_persistent_header_const()->edge_info.m_bnodeid; }
     void set_edge_id(bnodeid_t edge) { get_persistent_header()->edge_info.m_bnodeid = edge; }
+    uint64_t edge_link_version() const { return get_persistent_header_const()->edge_info.m_link_version; }
+    void set_edge_link_version(uint64_t link_version) {
+        get_persistent_header()->edge_info.m_link_version = link_version;
+    }
 
     BtreeLinkInfo::bnode_link_info edge_info() const { return get_persistent_header_const()->edge_info; }
     void set_edge_info(const BtreeLinkInfo::bnode_link_info& info) { get_persistent_header()->edge_info = info; }

--- a/src/include/homestore/btree/detail/btree_node_mgr.ipp
+++ b/src/include/homestore/btree/detail/btree_node_mgr.ipp
@@ -69,13 +69,11 @@ btree_status_t Btree< K, V >::get_child_and_lock_node(const BtreeNodePtr& node, 
                                                       locktype_t int_lock_type, locktype_t leaf_lock_type,
                                                       void* context) const {
     if (index == node->total_entries()) {
-        const auto& edge_id{node->edge_id()};
-        child_info.set_bnode_id(edge_id);
-        // If bsearch points to last index, it means the search has not found entry unless it is an edge value.
-        if (!child_info.has_valid_bnode_id()) {
+        if (!node->has_valid_edge()) {
             BT_NODE_LOG_ASSERT(false, node, "Child index {} does not have valid bnode_id", index);
             return btree_status_t::not_found;
         }
+        child_info = node->get_edge_value();
     } else {
         BT_NODE_LOG_ASSERT_LT(index, node->total_entries(), node);
         node->get_nth_value(index, &child_info, false /* copy */);

--- a/src/include/homestore/btree/detail/simple_node.hpp
+++ b/src/include/homestore/btree/detail/simple_node.hpp
@@ -264,9 +264,9 @@ public:
     std::string to_string_keys(bool print_friendly = false) const override {
 #if 0
         std::string delimiter = print_friendly ? "\n" : "\t";
-        auto str = fmt::format("{}{} nEntries={} {} ",
+        auto str = fmt::format("{}{}.{} nEntries={} {} ",
                                print_friendly ? "------------------------------------------------------------\n" : "",
-                               this->node_id(), this->total_entries(), (this->is_leaf() ? "LEAF" : "INTERIOR"));
+                               this->node_id(), this->link_version(), this->total_entries(), (this->is_leaf() ? "LEAF" : "INTERIOR"));
         if (!this->is_leaf() && (this->has_valid_edge())) {
             fmt::format_to(std::back_inserter(str), "edge_id={}.{}", this->edge_info().m_bnodeid,
                            this->edge_info().m_link_version);
@@ -279,7 +279,9 @@ public:
             fmt::format_to(std::back_inserter(str), " [");
             for (uint32_t i{0}; i < this->total_entries(); ++i) {
                 uint32_t cur_key = get_nth_key< K >(i, false).key();
-                fmt::format_to(std::back_inserter(str), "{}{}", cur_key, i == this->total_entries() - 1 ? "" : ", ");
+                BtreeLinkInfo child_info;
+                get_nth_value(i, &child_info, false /* copy */);
+                fmt::format_to(std::back_inserter(str), "{}.{} {}", cur_key,  child_info.link_version(), i == this->total_entries() - 1 ? "" : ", ");
             }
             fmt::format_to(std::back_inserter(str), "]");
             return str;

--- a/src/include/homestore/btree/detail/varlen_node.hpp
+++ b/src/include/homestore/btree/detail/varlen_node.hpp
@@ -520,9 +520,9 @@ public:
     std::string to_string_keys(bool print_friendly = false) const override {
 #if 0
         std::string delimiter = print_friendly ? "\n" : "\t";
-        auto str = fmt::format("{}{} nEntries={} {} ",
+        auto str = fmt::format("{}{}.{} nEntries={} {} ",
                                print_friendly ? "------------------------------------------------------------\n" : "",
-                               this->node_id(), this->total_entries(), (this->is_leaf() ? "LEAF" : "INTERIOR"));
+                               this->node_id(), this->link_version(), this->total_entries(), (this->is_leaf() ? "LEAF" : "INTERIOR"));
         if (!this->is_leaf() && (this->has_valid_edge())) {
             fmt::format_to(std::back_inserter(str), "edge_id={}.{}", this->edge_info().m_bnodeid,
                            this->edge_info().m_link_version);
@@ -535,7 +535,9 @@ public:
             fmt::format_to(std::back_inserter(str), " [");
             for (uint32_t i{0}; i < this->total_entries(); ++i) {
                 uint32_t cur_key = get_nth_key< K >(i, false).key();
-                fmt::format_to(std::back_inserter(str), "{}{}", cur_key, i == this->total_entries() - 1 ? "" : ", ");
+                BtreeLinkInfo child_info;
+                get_nth_value(i, &child_info, false /* copy */);
+                fmt::format_to(std::back_inserter(str), "{}.{} {}", cur_key, child_info.link_version(), i == this->total_entries() - 1 ? "" : ", ");
             }
             fmt::format_to(std::back_inserter(str), "]");
             return str;


### PR DESCRIPTION
This pull request addresses an issue with link version inconsistency between a parent node and its children after a merge or split operation is performed. This change is necessary to ensure the stability and correctness of the btree during repair/recovery . This is achieved through the following changes:

1. The value of the link version for the edge is now properly populated and locked when accessed by a caller.
2. The` get_edge_value() `method now returns the correct value for the edge's link version.
3. The `inc_link_version` is now enabled in the merge and split methods.
4. A `BT_NODE_DBG_ASSERT_EQ` check has been added to validate the change made during merge (split, as it has a trivial algorithm, does not need this validation).

Overall, this pull request ensures that link version stays consistent between parent and children nodes, even after a merge or split operation is performed.

