### PR TITLE
Index write back cache fixes.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.8.1"
+    version = "4.8.2"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/btree/detail/btree_node_mgr.ipp
+++ b/src/include/homestore/btree/detail/btree_node_mgr.ipp
@@ -305,7 +305,7 @@ BtreeNode* Btree< K, V >::init_node(uint8_t* node_buf, uint32_t node_ctx_size, b
 /* Note:- This function assumes that access of this node is thread safe. */
 template < typename K, typename V >
 void Btree< K, V >::free_node(const BtreeNodePtr& node, locktype_t cur_lock, void* context) {
-    BT_NODE_LOG(DEBUG, node, "Freeing node");
+    BT_NODE_LOG(TRACE, node, "Freeing node");
 
     COUNTER_DECREMENT_IF_ELSE(m_metrics, node->is_leaf(), btree_leaf_node_count, btree_int_node_count, 1);
     if (cur_lock != locktype_t::NONE) {

--- a/src/include/homestore/index/wb_cache_base.hpp
+++ b/src/include/homestore/index/wb_cache_base.hpp
@@ -52,13 +52,13 @@ public:
 
     /// @brief Start a chain of related btree buffers. Typically a chain is creating from second and third pairs and
     /// then first is prepended to the chain. In case the second buffer is already with the WB cache, it will create a
-    /// new buffer for both second and third.
+    /// new buffer for both second and third. We append the buffers to a list in dependency chain.
     /// @param second Second btree buffer in the chain. It will be updated to copy of second buffer if buffer already
     /// has dependencies.
     /// @param third Thrid btree buffer in the chain. It will be updated to copy of third buffer if buffer already
     /// has dependencies.
     /// @return Returns if the buffer had to be copied
-    virtual std::tuple< bool, bool > create_chain(IndexBufferPtr& second, IndexBufferPtr& third, CPContext* cp_ctx) = 0;
+    virtual std::pair< bool, bool > create_chain(IndexBufferPtr& second, IndexBufferPtr& third, CPContext* cp_ctx) = 0;
 
     /// @brief Prepend to the chain that was already created with second
     /// @param first
@@ -73,7 +73,7 @@ public:
     /// @brief Copy buffer
     /// @param cur_buf
     /// @return
-    virtual IndexBufferPtr copy_buffer(const IndexBufferPtr& cur_buf) const = 0;
+    virtual IndexBufferPtr copy_buffer(const IndexBufferPtr& cur_buf, const CPContext* context) const = 0;
 };
 
 } // namespace homestore

--- a/src/include/homestore/index_service.hpp
+++ b/src/include/homestore/index_service.hpp
@@ -22,7 +22,7 @@
 #include <homestore/homestore_decl.hpp>
 #include <homestore/index/index_internal.hpp>
 #include <homestore/superblk_handler.hpp>
-
+#include <homestore/index/wb_cache_base.hpp>
 namespace homestore {
 
 class IndexWBCacheBase;

--- a/src/lib/checkpoint/cp.hpp
+++ b/src/lib/checkpoint/cp.hpp
@@ -21,7 +21,7 @@
 
 #include <sisl/logging/logging.h>
 #include <iomgr/iomgr.hpp>
-
+#include <folly/futures/SharedPromise.h>
 #include "common/homestore_assert.hpp"
 
 /*
@@ -73,7 +73,7 @@ struct CP {
     bool m_cp_waiting_to_trigger{false}; // it is waiting for previous cp to complete
     cp_id_t m_cp_id;
     std::array< std::unique_ptr< CPContext >, (size_t)cp_consumer_t::SENTINEL > m_contexts;
-    folly::Promise< bool > m_comp_promise;
+    folly::SharedPromise< bool > m_comp_promise;
 
 public:
     CP(CPManager* mgr) : m_cp_mgr{mgr} {}

--- a/src/lib/index/index_cp.hpp
+++ b/src/lib/index/index_cp.hpp
@@ -18,6 +18,7 @@
 #include <sisl/fds/concurrent_insert_vector.hpp>
 #include <homestore/blk.h>
 #include <homestore/index/index_internal.hpp>
+#include <homestore/index_service.hpp>
 #include <homestore/checkpoint/cp_mgr.hpp>
 
 #include "checkpoint/cp.hpp"
@@ -32,20 +33,18 @@ public:
     std::atomic< uint64_t > m_num_nodes_removed{0};
     sisl::ConcurrentInsertVector< IndexBufferPtr > m_dirty_buf_list;
     sisl::atomic_counter< int64_t > m_dirty_buf_count{0};
-    IndexBufferPtr m_last_in_chain;
     std::mutex m_flush_buffer_mtx;
     sisl::ConcurrentInsertVector< IndexBufferPtr >::iterator m_dirty_buf_it;
 
 public:
+
     IndexCPContext(CP* cp) : VDevCPContext(cp) {}
     virtual ~IndexCPContext() = default;
 
     void add_to_dirty_list(const IndexBufferPtr& buf) {
-        buf->m_buf_state = index_buf_state_t::DIRTY;
         m_dirty_buf_list.push_back(buf);
+        buf->set_state(index_buf_state_t::DIRTY);
         m_dirty_buf_count.increment(1);
-        m_last_in_chain = buf;
-        LOGTRACEMOD(wbcache, "{}", buf->to_string());
     }
 
     bool any_dirty_buffers() const { return !m_dirty_buf_count.testz(); }
@@ -59,14 +58,101 @@ public:
         return ret;
     }
 
-    std::string to_string() const {
+    std::string to_string() {
         std::string str{fmt::format("IndexCPContext cpid={} dirty_buf_count={} dirty_buf_list_size={}", m_cp->id(),
                                     m_dirty_buf_count.get(), m_dirty_buf_list.size())};
 
-        // TODO dump all index buffers.
+        // Mapping from a node to all its parents in the graph.
+        // Display all buffers and its dependencies and state.
+        std::unordered_map< IndexBuffer*, std::vector< IndexBuffer* > > parents;
+
+        auto it = m_dirty_buf_list.begin();
+        while (it != m_dirty_buf_list.end()) {
+            // Add this buf to his children.
+            IndexBufferPtr buf = *it;
+            parents[buf->m_next_buffer.lock().get()].emplace_back(buf.get());
+            ++it;
+        }
+
+        it = m_dirty_buf_list.begin();
+        while (it != m_dirty_buf_list.end()) {
+            IndexBufferPtr buf = *it;
+            fmt::format_to(std::back_inserter(str), "{}", buf->to_string());
+            auto first = true;
+            for (const auto& p : parents[buf.get()]) {
+                if (first) {
+                    fmt::format_to(std::back_inserter(str), "\nDepends:");
+                    first = false;
+                }
+                fmt::format_to(std::back_inserter(str), " {}({})", r_cast< void* >(p), s_cast< int >(p->state()));
+            }
+            fmt::format_to(std::back_inserter(str), "\n");
+            ++it;
+        }
+
         return str;
     }
+
+    void check_cycle() {
+        // Use dfs to find if the graph is cycle
+        auto it = m_dirty_buf_list.begin();
+        while (it != m_dirty_buf_list.end()) {
+            IndexBufferPtr buf = *it;;
+            std::set< IndexBuffer* > visited;
+            check_cycle_recurse(buf, visited);
+            ++it;
+        }
+    }
+
+    void check_cycle_recurse(IndexBufferPtr buf, std::set< IndexBuffer* >& visited) const {
+        if (visited.count(buf.get()) != 0) {
+            LOGERROR("Cycle found for {}", buf->to_string());
+            for (auto& x : visited) {
+                LOGERROR("Path : {}", x->to_string());
+            }
+            return;
+        }
+
+        visited.insert(buf.get());
+        if (buf->m_next_buffer.lock()) { check_cycle_recurse(buf->m_next_buffer.lock(), visited); }
+    }
+
+    void check_wait_for_leaders() {
+        // Use the next buffer as indegree to find if wait_for_leaders is invalid.
+        std::unordered_map< IndexBuffer*, int > wait_for_leaders;
+        IndexBufferPtr buf;
+
+        // Store the wait for leader count for each buffer.
+        auto it = m_dirty_buf_list.begin();
+        while (it != m_dirty_buf_list.end()) {
+            buf = *it;
+            wait_for_leaders[buf.get()] = buf->m_wait_for_leaders.get();
+            ++it;
+        }
+
+        // Decrement the count using the next buffer.
+        it = m_dirty_buf_list.begin();
+        while (it != m_dirty_buf_list.end()) {
+            buf = *it;
+            auto next_buf = buf->m_next_buffer.lock();
+            if (next_buf.get() == nullptr) continue;
+            wait_for_leaders[next_buf.get()]--;
+            ++it;
+        }
+
+        bool issue = false;
+        for (const auto& [buf, waits] : wait_for_leaders) {
+            // Any value other than zero means the dependency graph is invalid.
+            if (waits != 0) {
+                issue = true;
+                LOGERROR("Leaders wait not zero cp {} buf {} waits {}", id(), buf->to_string(), waits);
+            }
+        }
+
+        RELEASE_ASSERT_EQ(issue, false, "Found issue with wait_for_leaders");
+    }
 };
+
 
 class IndexWBCache;
 class IndexCPCallbacks : public CPCallbacks {

--- a/src/lib/index/wb_cache.hpp
+++ b/src/lib/index/wb_cache.hpp
@@ -49,23 +49,23 @@ public:
     void realloc_buf(const IndexBufferPtr& buf) override;
     void write_buf(const BtreeNodePtr& node, const IndexBufferPtr& buf, CPContext* cp_ctx) override;
     void read_buf(bnodeid_t id, BtreeNodePtr& node, node_initializer_t&& node_initializer) override;
-    std::tuple< bool, bool > create_chain(IndexBufferPtr& second, IndexBufferPtr& third, CPContext* cp_ctx) override;
+    std::pair< bool, bool > create_chain(IndexBufferPtr& second, IndexBufferPtr& third, CPContext* cp_ctx) override;
     void prepend_to_chain(const IndexBufferPtr& first, const IndexBufferPtr& second) override;
     void free_buf(const IndexBufferPtr& buf, CPContext* cp_ctx) override;
 
     //////////////////// CP Related API section /////////////////////////////////
     folly::Future< bool > async_cp_flush(IndexCPContext* context);
-    IndexBufferPtr copy_buffer(const IndexBufferPtr& cur_buf) const;
+    IndexBufferPtr copy_buffer(const IndexBufferPtr& cur_buf, const CPContext *cp_ctx) const;
 
 private:
     void start_flush_threads();
-    void process_write_completion(IndexCPContext* cp_ctx, IndexBuffer* pbuf);
-    void do_flush_one_buf(IndexCPContext* cp_ctx, const IndexBufferPtr& buf, bool part_of_batch);
-    std::pair< IndexBufferPtr, bool > on_buf_flush_done(IndexCPContext* cp_ctx, IndexBuffer* buf);
-    std::pair< IndexBufferPtr, bool > on_buf_flush_done_internal(IndexCPContext* cp_ctx, IndexBuffer* buf);
+    void process_write_completion(IndexCPContext* cp_ctx, IndexBufferPtr pbuf);
+    void do_flush_one_buf(IndexCPContext* cp_ctx, const IndexBufferPtr buf, bool part_of_batch);
+    std::pair< IndexBufferPtr, bool > on_buf_flush_done(IndexCPContext* cp_ctx, IndexBufferPtr& buf);
+    std::pair< IndexBufferPtr, bool > on_buf_flush_done_internal(IndexCPContext* cp_ctx, IndexBufferPtr& buf);
 
     void get_next_bufs(IndexCPContext* cp_ctx, uint32_t max_count, std::vector< IndexBufferPtr >& bufs);
-    void get_next_bufs_internal(IndexCPContext* cp_ctx, uint32_t max_count, IndexBuffer* prev_flushed_buf,
+    void get_next_bufs_internal(IndexCPContext* cp_ctx, uint32_t max_count, IndexBufferPtr prev_flushed_buf,
                                 std::vector< IndexBufferPtr >& bufs);
 };
 } // namespace homestore

--- a/src/tests/btree_helpers/shadow_map.hpp
+++ b/src/tests/btree_helpers/shadow_map.hpp
@@ -7,26 +7,36 @@ template < typename K, typename V >
 class ShadowMap {
 private:
     std::map< K, V > m_map;
+    RangeScheduler m_range_scheduler;
+    using mutex = iomgr::FiberManagerLib::shared_mutex;
+    mutex m_mutex;
 
 public:
+    ShadowMap(uint32_t num_keys) : m_range_scheduler(num_keys) {}
+
     void put_and_check(const K& key, const V& val, const V& old_val, bool expected_success) {
+        std::lock_guard lock{m_mutex};
         auto const [it, happened] = m_map.insert(std::make_pair(key, val));
         ASSERT_EQ(happened, expected_success) << "Testcase issue, expected inserted slots to be in shadow map";
         if (!happened) {
             ASSERT_EQ(old_val, it->second) << "Put: Existing value doesn't return correct data for key: " << it->first;
         }
+        m_range_scheduler.put_key(key.key());
     }
 
     void range_upsert(uint64_t start_k, uint32_t count, const V& val) {
+        std::lock_guard lock{m_mutex};
         for (uint32_t i{0}; i < count; ++i) {
             K key{start_k + i};
             V range_value{val};
             if constexpr (std::is_same_v< V, TestIntervalValue >) { range_value.shift(i); }
             m_map.insert_or_assign(key, range_value);
         }
+        m_range_scheduler.put_keys(start_k, start_k + count - 1);
     }
 
     void range_update(const K& start_key, uint32_t count, const V& new_val) {
+        std::lock_guard lock{m_mutex};
         auto const start_it = m_map.lower_bound(start_key);
         auto it = start_it;
         uint32_t c = 0;
@@ -34,9 +44,11 @@ public:
             it->second = new_val;
             ++it;
         }
+        m_range_scheduler.remove_keys_from_working(start_key.key(), start_key.key() + count - 1);
     }
 
     std::pair< K, K > pick_existing_range(const K& start_key, uint32_t max_count) const {
+        std::shared_lock lock{m_mutex};
         auto const start_it = m_map.lower_bound(start_key);
         auto it = start_it;
         uint32_t count = 0;
@@ -46,9 +58,13 @@ public:
         return std::pair(start_it->first, it->first);
     }
 
-    bool exists(const K& key) const { return m_map.find(key) != m_map.end(); }
+    bool exists(const K& key) const {
+        std::shared_lock lock{m_mutex};
+        return m_map.find(key) != m_map.end();
+    }
 
     bool exists_in_range(const K& key, uint64_t start_k, uint64_t end_k) const {
+        std::shared_lock lock{m_mutex};
         const auto itlower = m_map.lower_bound(K{start_k});
         const auto itupper = m_map.upper_bound(K{end_k});
         auto it = itlower;
@@ -59,7 +75,10 @@ public:
         return false;
     }
 
-    uint64_t size() const { return m_map.size(); }
+    uint64_t size() const {
+        std::shared_lock lock{m_mutex};
+        return m_map.size();
+    }
 
     uint32_t num_elems_in_range(uint64_t start_k, uint64_t end_k) const {
         const auto itlower = m_map.lower_bound(K{start_k});
@@ -68,29 +87,71 @@ public:
     }
 
     void validate_data(const K& key, const V& btree_val) const {
+        std::shared_lock lock{m_mutex};
         const auto r = m_map.find(key);
         ASSERT_NE(r, m_map.end()) << "Key " << key.to_string() << " is not present in shadow map";
         ASSERT_EQ(btree_val, r->second) << "Found value in btree doesn't return correct data for key=" << r->first;
     }
 
-    void erase(const K& key) { m_map.erase(key); }
+    void erase(const K& key) {
+        std::lock_guard lock{m_mutex};
+        m_map.erase(key);
+        m_range_scheduler.remove_key(key.key());
+    }
 
     void range_erase(const K& start_key, uint32_t count) {
+        std::lock_guard lock{m_mutex};
         auto const it = m_map.lower_bound(start_key);
         uint32_t i{0};
         while ((it != m_map.cend()) && (i++ < count)) {
             it = m_map.erase(it);
         }
+        m_range_scheduler.remove_keys(start_key.key(), start_key.key() + count);
     }
 
     void range_erase(const K& start_key, const K& end_key) {
+        std::lock_guard lock{m_mutex};
         auto it = m_map.lower_bound(start_key);
         auto const end_it = m_map.upper_bound(end_key);
         while ((it != m_map.cend()) && (it != end_it)) {
             it = m_map.erase(it);
         }
+        m_range_scheduler.remove_keys(start_key.key(), end_key.key());
     }
 
+    mutex& guard() { return m_mutex; }
     std::map< K, V >& map() { return m_map; }
     const std::map< K, V >& map_const() const { return m_map; }
+
+    void foreach (std::function< void(K, V) > func) const {
+        std::shared_lock lock{m_mutex};
+        for (const auto& [key, value] : m_map) {
+            func(key, value);
+        }
+    }
+
+    std::pair< uint32_t, uint32_t > pick_random_non_existing_keys(uint32_t max_keys) {
+        std::shared_lock lock{m_mutex};
+        return m_range_scheduler.pick_random_non_existing_keys(max_keys);
+    }
+
+    std::pair< uint32_t, uint32_t > pick_random_existing_keys(uint32_t max_keys) {
+        std::shared_lock lock{m_mutex};
+        return m_range_scheduler.pick_random_existing_keys(max_keys);
+    }
+
+    std::pair< uint32_t, uint32_t > pick_random_non_working_keys(uint32_t max_keys) {
+        std::shared_lock lock{m_mutex};
+        return m_range_scheduler.pick_random_non_working_keys(max_keys);
+    }
+
+    void remove_keys_from_working(uint32_t s, uint32_t e) {
+        std::lock_guard lock{m_mutex};
+        m_range_scheduler.remove_keys_from_working(s, e);
+    }
+
+    void remove_keys(uint32_t start_key, uint32_t end_key) {
+        std::lock_guard lock{m_mutex};
+        m_range_scheduler.remove_keys(start_key, end_key);
+    }
 };

--- a/src/tests/test_mem_btree.cpp
+++ b/src/tests/test_mem_btree.cpp
@@ -41,14 +41,15 @@ SISL_OPTION_GROUP(
     (num_entries, "", "num_entries", "number of entries to test with",
      ::cxxopts::value< uint32_t >()->default_value("10000"), "number"),
     (disable_merge, "", "disable_merge", "disable_merge", ::cxxopts::value< bool >()->default_value("0"), ""),
-    (n_threads, "", "n_threads", "number of threads", ::cxxopts::value< uint32_t >()->default_value("2"), "number"),
-    (n_fibers, "", "n_fibers", "number of fibers", ::cxxopts::value< uint32_t >()->default_value("10"), "number"),
+    (n_threads, "", "num_threads", "number of threads", ::cxxopts::value< uint32_t >()->default_value("2"), "number"),
+    (n_fibers, "", "num_fibers", "number of fibers", ::cxxopts::value< uint32_t >()->default_value("10"), "number"),
     (operation_list, "", "operation_list", "operation list instead of default created following by percentage",
      ::cxxopts::value< std::vector< std::string > >(), "operations [...]"),
     (preload_size, "", "preload_size", "number of entries to preload tree with",
      ::cxxopts::value< uint32_t >()->default_value("1000"), "number"),
     (seed, "", "seed", "random engine seed, use random if not defined",
-     ::cxxopts::value< uint64_t >()->default_value("0"), "number"))
+     ::cxxopts::value< uint64_t >()->default_value("0"), "number"),
+    (run_time, "", "run_time", "run time for io", ::cxxopts::value< uint32_t >()->default_value("360000"), "seconds"))
 
 struct FixedLenBtreeTest {
     using BtreeType = MemBtree< TestFixedKey, TestFixedValue >;
@@ -265,7 +266,7 @@ TYPED_TEST(BtreeTest, RandomRemoveRange) {
         this->put(i, btree_put_type::INSERT);
     }
     // generate keys including out of bound
-    static thread_local std::uniform_int_distribution< uint32_t > s_rand_key_generator{0, 2 * num_entries};
+    static thread_local std::uniform_int_distribution< uint32_t > s_rand_key_generator{0, num_entries};
     //    this->print_keys();
     LOGINFO("Step 2: Do range remove for maximum of {} iterations", num_iters);
     for (uint32_t i{0}; (i < num_iters) && this->m_shadow_map.size(); ++i) {
@@ -289,10 +290,10 @@ struct BtreeConcurrentTest : public BtreeTestHelper< TestType > {
     BtreeConcurrentTest() { this->m_is_multi_threaded = true; }
 
     void SetUp() override {
-        LOGINFO("Starting iomgr with {} threads", SISL_OPTIONS["n_threads"].as< uint32_t >());
-        ioenvironment.with_iomgr(iomgr::iomgr_params{.num_threads = SISL_OPTIONS["n_threads"].as< uint32_t >(),
+        LOGINFO("Starting iomgr with {} threads", SISL_OPTIONS["num_threads"].as< uint32_t >());
+        ioenvironment.with_iomgr(iomgr::iomgr_params{.num_threads = SISL_OPTIONS["num_threads"].as< uint32_t >(),
                                                      .is_spdk = false,
-                                                     .num_fibers = 1 + SISL_OPTIONS["n_fibers"].as< uint32_t >(),
+                                                     .num_fibers = 1 + SISL_OPTIONS["num_fibers"].as< uint32_t >(),
                                                      .app_mem_size_mb = 0,
                                                      .hugepage_size_mb = 0});
 


### PR DESCRIPTION
Add locks for indexbuffer to avoid concurrency issues with cp flush and insert threads. 
Create dependency graph.
Add locks for index btree test code shadow map as there are concurrent requests. 
Use shared ptr's in wb cache.

Testing. Run the index_btree continuously back to back for several hours.
./../failuntil.sh ./bin/test_index_btree --gtest_filter=BtreeTest/0.* --num_entries 100000
