### PR TITLE
issue #221: HomeStore to report capacity stats

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.5.11"
+    version = "4.6.1"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.5.10"
+    version = "4.5.11"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/blkdata_service.hpp
+++ b/src/include/homestore/blkdata_service.hpp
@@ -187,6 +187,10 @@ public:
      */
     void start();
 
+    uint64_t get_total_capacity() const;
+
+    uint64_t get_used_capacity() const;
+
 private:
     /**
      * @brief Initializes the block data service.

--- a/src/include/homestore/homestore.hpp
+++ b/src/include/homestore/homestore.hpp
@@ -67,6 +67,11 @@ struct hs_vdev_context {
 
 using hs_before_services_starting_cb_t = std::function< void(void) >;
 
+struct hs_stats {
+    uint64_t total_capacity{0ul};
+    uint64_t used_capacity{0ul};
+};
+
 struct HS_SERVICE {
     static constexpr uint32_t META = 1 << 0;
     static constexpr uint32_t LOG_REPLICATED = 1 << 1;

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -6,6 +6,7 @@
 
 #include <folly/futures/Future.h>
 
+#include <homestore/homestore.hpp>
 #include <homestore/replication/repl_decls.h>
 
 namespace homestore {
@@ -84,5 +85,8 @@ public:
     /// @brief Iterate over all repl devs and then call the callback provided
     /// @param cb Callback with repl dev
     virtual void iterate_repl_devs(std::function< void(cshared< ReplDev >&) > const& cb) = 0;
+
+    /// @brief Get the current term of the repl dev
+    virtual hs_stats get_cap_stats() const = 0;
 };
 } // namespace homestore

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -86,7 +86,8 @@ public:
     /// @param cb Callback with repl dev
     virtual void iterate_repl_devs(std::function< void(cshared< ReplDev >&) > const& cb) = 0;
 
-    /// @brief Get the current term of the repl dev
+    /// @brief get the capacity stats form underlying backend;
+    /// @return the capacity stats;
     virtual hs_stats get_cap_stats() const = 0;
 };
 } // namespace homestore

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -6,7 +6,6 @@
 
 #include <folly/futures/Future.h>
 
-#include <homestore/homestore.hpp>
 #include <homestore/replication/repl_decls.h>
 
 namespace homestore {
@@ -32,6 +31,7 @@ VENUM(ReplServiceError, int32_t,
 
 class ReplDev;
 class ReplDevListener;
+struct hs_stats;
 
 template < typename V, typename E >
 using Result = folly::Expected< V, E >;

--- a/src/lib/blkdata_svc/blkdata_service.cpp
+++ b/src/lib/blkdata_svc/blkdata_service.cpp
@@ -224,4 +224,8 @@ void BlkDataService::start() {
                                      std::move(std::make_unique< DataSvcCPCallbacks >(m_vdev)));
 }
 
+uint64_t BlkDataService::get_total_capacity() const { return m_vdev->size(); }
+
+uint64_t BlkDataService::get_used_capacity() const { return m_vdev->used_size(); }
+
 } // namespace homestore

--- a/src/lib/replication/service/repl_service_impl.cpp
+++ b/src/lib/replication/service/repl_service_impl.cpp
@@ -18,6 +18,7 @@
 #include "replication/service/repl_service_impl.h"
 #include "replication/repl_dev/solo_repl_dev.h"
 #include "homestore/blkdata_service.hpp"
+#include "homestore/homestore.hpp"
 
 namespace homestore {
 ReplicationService& repl_service() { return hs()->repl_service(); }

--- a/src/lib/replication/service/repl_service_impl.cpp
+++ b/src/lib/replication/service/repl_service_impl.cpp
@@ -17,6 +17,7 @@
 #include "common/homestore_assert.hpp"
 #include "replication/service/repl_service_impl.h"
 #include "replication/repl_dev/solo_repl_dev.h"
+#include "homestore/blkdata_service.hpp"
 
 namespace homestore {
 ReplicationService& repl_service() { return hs()->repl_service(); }
@@ -44,6 +45,14 @@ void ReplicationServiceImpl::start() {
 void ReplicationServiceImpl::stop() {
     std::unique_lock lg{m_rd_map_mtx};
     m_rd_map.clear();
+}
+
+hs_stats ReplicationServiceImpl::get_cap_stats() const {
+    hs_stats stats;
+
+    stats.total_capacity = data_service().get_total_capacity();
+    stats.used_capacity = data_service().get_used_capacity();
+    return stats;
 }
 
 AsyncReplResult< shared< ReplDev > >

--- a/src/lib/replication/service/repl_service_impl.h
+++ b/src/lib/replication/service/repl_service_impl.h
@@ -69,6 +69,8 @@ public:
 
     folly::Future< ReplServiceError > replace_member(uuid_t group_id, std::string const& member_out,
                                                      std::string const& member_in) const override;
+    hs_stats get_cap_stats() const override;
+
 
 private:
     shared< ReplDev > create_repl_dev_instance(superblk< repl_dev_superblk > const& rd_sb, bool load_existing);

--- a/src/tests/test_solo_repl_dev.cpp
+++ b/src/tests/test_solo_repl_dev.cpp
@@ -249,6 +249,10 @@ public:
         }
 
         auto& rdev = (rand() % 2) ? m_repl_dev1 : m_repl_dev2;
+
+        auto const cap = hs()->repl_service().get_cap_stats();
+        LOGDEBUG("Before write, cap stats: used={} total={}", cap.used_capacity, cap.total_capacity);
+
         rdev->async_alloc_write(*req->header, req->key ? *req->key : sisl::blob{}, req->write_sgs, req);
     }
 
@@ -284,6 +288,9 @@ public:
         // If we did send some data to the repl_dev, validate it by doing async_read
         if (req->write_sgs.size != 0) {
             req->read_sgs = HSTestHelper::create_sgs(req->write_sgs.size, g_block_size, req->write_sgs.size);
+
+            auto const cap = hs()->repl_service().get_cap_stats();
+            LOGDEBUG("Write complete with cap stats: used={} total={}", cap.used_capacity, cap.total_capacity);
 
             rdev.async_read(req->written_blkids, req->read_sgs, req->read_sgs.size)
                 .thenValue([this, &rdev, req](auto&& err) {


### PR DESCRIPTION
HomeStore to provide used/total space which will be consumed by HomeObject/SM

Testing:
======
```
[11/07/23 18:14:40-07:00] [info] [test_solo_repl_dev] [206264] [test_solo_repl_dev.cpp:254:write_io] Before write, cap stats: used=0 total=1277747200
[11/07/23 18:14:40-07:00] [info] [test_solo_repl_dev] [206265] [test_solo_repl_dev.cpp:254:write_io] Before write, cap stats: used=0 total=1277747200
[11/07/23 18:14:40-07:00] [info] [test_solo_repl_dev] [206264] [test_solo_repl_dev.cpp:254:write_io] Before write, cap stats: used=8192 total=1277747200
[11/07/23 18:14:40-07:00] [info] [test_solo_repl_dev] [206265] [test_solo_repl_dev.cpp:254:write_io] Before write, cap stats: used=8192 total=1277747200
[11/07/23 18:14:40-07:00] [info] [test_solo_repl_dev] [206265] [test_solo_repl_dev.cpp:254:write_io] Before write, cap stats: used=16384 total=1277747200
[11/07/23 18:14:40-07:00] [info] [test_solo_repl_dev] [206264] [test_solo_repl_dev.cpp:254:write_io] Before write, cap stats: used=16384 total=1277747200
[11/07/23 18:14:40-07:00] [info] [test_solo_repl_dev] [206264] [test_solo_repl_dev.cpp:254:write_io] Before write, cap stats: used=24576 total=1277747200
[11/07/23 18:14:40-07:00] [info] [test_solo_repl_dev] [206264] [test_solo_repl_dev.cpp:254:write_io] Before write, cap stats: used=28672 total=1277747200
[11/07/23 18:14:40-07:00] [info] [test_solo_repl_dev] [206265] [test_solo_repl_dev.cpp:293:on_write_complete] Write complete with cap stats: used=32768 total=1277747200
[11/07/23 18:14:40-07:00] [info] [test_solo_repl_dev] [206264] [test_solo_repl_dev.cpp:254:write_io] Before write, cap stats: used=32768 total=1277747200
```