### PR TITLE
FIX btree remove

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.9.1"
+    version = "4.9.2"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/btree/detail/simple_node.hpp
+++ b/src/include/homestore/btree/detail/simple_node.hpp
@@ -230,9 +230,7 @@ public:
 #if 0
         std::string delimiter = print_friendly ? "\n" : "\t";
         auto str = fmt::format("{}{}.{} nEntries={} {} ",
-        auto str = fmt::format("{}{}.{} nEntries={} {} ",
                                print_friendly ? "------------------------------------------------------------\n" : "",
-                               this->node_id(), this->link_version(), this->total_entries(), (this->is_leaf() ? "LEAF" : "INTERIOR"));
                                this->node_id(), this->link_version(), this->total_entries(), (this->is_leaf() ? "LEAF" : "INTERIOR"));
         if (!this->is_leaf() && (this->has_valid_edge())) {
             fmt::format_to(std::back_inserter(str), "edge_id={}.{}", this->edge_info().m_bnodeid,

--- a/src/include/homestore/btree/detail/varlen_node.hpp
+++ b/src/include/homestore/btree/detail/varlen_node.hpp
@@ -71,6 +71,10 @@ public:
 
     virtual ~VariableNode() = default;
 
+    uint32_t occupied_size() const override {
+        return (get_var_node_header_const()->m_init_available_space - sizeof(var_node_header) - available_size());
+    }
+
     /* Insert the key and value in provided index
      * Assumption: Node lock is already taken */
     btree_status_t insert(uint32_t ind, const BtreeKey& key, const BtreeValue& val) override {
@@ -518,9 +522,7 @@ public:
 #if 0
         std::string delimiter = print_friendly ? "\n" : "\t";
         auto str = fmt::format("{}{}.{} nEntries={} {} ",
-        auto str = fmt::format("{}{}.{} nEntries={} {} ",
                                print_friendly ? "------------------------------------------------------------\n" : "",
-                               this->node_id(), this->link_version(), this->total_entries(), (this->is_leaf() ? "LEAF" : "INTERIOR"));
                                this->node_id(), this->link_version(), this->total_entries(), (this->is_leaf() ? "LEAF" : "INTERIOR"));
         if (!this->is_leaf() && (this->has_valid_edge())) {
             fmt::format_to(std::back_inserter(str), "edge_id={}.{}", this->edge_info().m_bnodeid,

--- a/src/lib/common/resource_mgr.cpp
+++ b/src/lib/common/resource_mgr.cpp
@@ -36,7 +36,7 @@ void ResourceMgr::dec_dirty_buf_size(const uint32_t size) {
     HS_REL_ASSERT_GT(size, 0);
     const int64_t dirty_buf_cnt = m_hs_dirty_buf_cnt.fetch_sub(size, std::memory_order_relaxed);
     COUNTER_DECREMENT(m_metrics, dirty_buf_cnt, size);
-    HS_REL_ASSERT_GE(dirty_buf_cnt, size);
+    HS_REL_ASSERT_GE(dirty_buf_cnt, 0);
 }
 
 void ResourceMgr::register_dirty_buf_exceed_cb(exceed_limit_cb_t cb) { m_dirty_buf_exceed_cb = std::move(cb); }

--- a/src/tests/btree_helpers/btree_test_helper.hpp
+++ b/src/tests/btree_helpers/btree_test_helper.hpp
@@ -294,9 +294,7 @@ public:
 
     void multi_op_execute(const std::vector< std::pair< std::string, int > >& op_list) {
         preload(SISL_OPTIONS["preload_size"].as< uint32_t >());
-        print_keys();
         run_in_parallel(op_list);
-        print_keys();
     }
 
     void print(const std::string& file = "") const { m_bt->print_tree(file); }


### PR DESCRIPTION
There exist multiple multiple problems in btree that this pr will address them. 

1. In varlen node type, some room has been reserved for `var_node_header` that should be deducted for `occupied_size() ` . This change is needed to taken account when the entries transfer size is getting calculated for moving entries from a node to its next adjacent one. 
2. Fixing the calculation for parent. For sake of simplicity, suppose that there is no excess node to remove during `merge_nodes()` and the number of new nodes is the same as old nodes. However, the last key of some of new nodes is different. In this case the new size of parent node must be checked even though the number of new nodes is the same. 
3. (Improvement): If an entry is large and cannot accommodate in the last node according to calculated balanced size, but it can be fitted to the last new node; let it be there instead of making a new sparse node.

### Testing:
The remove op is tested 100 times with node size of 512 bytes with over 100K entries and iterations. 