### PR TITLE
add get_local_blkid to repl_req_ctx

### DIFF
--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -16,6 +16,7 @@ struct repl_req_ctx : public boost::intrusive_ref_counter< repl_req_ctx, boost::
 public:
     virtual ~repl_req_ctx();
     int64_t get_lsn() const { return lsn; }
+    MultiBlkId const& get_local_blkid() const { return local_blkid; }
 
 private:
     sisl::blob header;                          // User header


### PR DESCRIPTION
this is used in homeobject to [rollback put blob ](https://github.com/eBay/HomeObject/blob/8457aaa0cc51f29772b52f6bad291145d2c44565/src/lib/homestore_backend/hs_blob_manager.cpp#L175)
