### PR TITLE
disable copy construction for homestore superblock

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.9.1"
+    version = "4.9.2"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/index/index_table.hpp
+++ b/src/include/homestore/index/index_table.hpp
@@ -45,8 +45,7 @@ public:
         if (status != btree_status_t::success) { throw std::runtime_error(fmt::format("Unable to create root node")); }
     }
 
-    IndexTable(const superblk< index_table_sb >& sb, const BtreeConfig& cfg) : Btree< K, V >{cfg} {
-        m_sb = sb;
+    IndexTable(superblk< index_table_sb >&& sb, const BtreeConfig& cfg) : Btree< K, V >{cfg}, m_sb{std::move(sb)} {
         Btree< K, V >::set_root_node_info(BtreeLinkInfo{m_sb->root_node, m_sb->link_version});
     }
 

--- a/src/include/homestore/index_service.hpp
+++ b/src/include/homestore/index_service.hpp
@@ -32,7 +32,7 @@ class VirtualDev;
 class IndexServiceCallbacks {
 public:
     virtual ~IndexServiceCallbacks() = default;
-    virtual std::shared_ptr< IndexTableBase > on_index_table_found(superblk< index_table_sb > const&) {
+    virtual std::shared_ptr< IndexTableBase > on_index_table_found(superblk< index_table_sb >&&) {
         assert(0);
         return nullptr;
     }

--- a/src/include/homestore/superblk_handler.hpp
+++ b/src/include/homestore/superblk_handler.hpp
@@ -32,6 +32,30 @@ public:
 
     superblk(const std::string& meta_name = "") { set_name(meta_name); }
 
+    superblk(const superblk&) = delete;
+    superblk& operator=(const superblk&) = delete;
+
+    superblk(superblk&& rhs) noexcept
+         : m_meta_mgr_cookie(rhs.m_meta_mgr_cookie)
+           , m_raw_buf(std::move(rhs.m_raw_buf))
+           , m_sb(rhs.m_sb)
+           , m_metablk_name(std::move(rhs.m_metablk_name)) {
+	rhs.m_meta_mgr_cookie = nullptr;
+	rhs.m_sb = nullptr;
+    }
+
+    superblk& operator=(superblk&& rhs) noexcept {
+        if (this != &rhs) {
+            m_meta_mgr_cookie = rhs.m_meta_mgr_cookie;
+            m_raw_buf = std::move(rhs.m_raw_buf);
+            m_sb = rhs.m_sb;
+            m_metablk_name = std::move(rhs.m_metablk_name);
+            rhs.m_meta_mgr_cookie = nullptr;
+            rhs.m_sb = nullptr;
+	}
+	return *this;
+    }
+
     void set_name(const std::string& meta_name) {
         if (meta_name.empty()) {
             m_metablk_name = "meta_blk_" + std::to_string(next_count());

--- a/src/lib/index/index_service.cpp
+++ b/src/lib/index/index_service.cpp
@@ -63,7 +63,7 @@ void IndexService::meta_blk_found(const sisl::byte_view& buf, void* meta_cookie)
     // IndexTable instance
     superblk< index_table_sb > sb;
     sb.load(buf, meta_cookie);
-    add_index_table(m_svc_cbs->on_index_table_found(sb));
+    add_index_table(m_svc_cbs->on_index_table_found(std::move(sb)));
 }
 
 void IndexService::start() {

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -5,8 +5,8 @@
 #include "replication/repl_dev/solo_repl_dev.h"
 
 namespace homestore {
-SoloReplDev::SoloReplDev(superblk< repl_dev_superblk > const& rd_sb, bool load_existing) :
-        m_rd_sb{rd_sb}, m_group_id{m_rd_sb->gid} {
+SoloReplDev::SoloReplDev(superblk< repl_dev_superblk >&& rd_sb, bool load_existing) :
+    m_rd_sb{std::move(rd_sb)}, m_group_id{m_rd_sb->gid} {
     if (load_existing) {
         logstore_service().open_log_store(LogStoreService::DATA_LOG_FAMILY_IDX, m_rd_sb->data_journal_id, true,
                                           bind_this(SoloReplDev::on_data_journal_created, 1));
@@ -14,6 +14,7 @@ SoloReplDev::SoloReplDev(superblk< repl_dev_superblk > const& rd_sb, bool load_e
         m_data_journal =
             logstore_service().create_new_log_store(LogStoreService::DATA_LOG_FAMILY_IDX, true /* append_mode */);
         m_rd_sb->data_journal_id = m_data_journal->get_store_id();
+        m_rd_sb.write();
     }
 }
 

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -70,7 +70,7 @@ private:
     std::atomic< logstore_seq_num_t > m_commit_upto{-1};
 
 public:
-    SoloReplDev(superblk< repl_dev_superblk > const& rd_sb, bool load_existing);
+    SoloReplDev(superblk< repl_dev_superblk >&& rd_sb, bool load_existing);
     virtual ~SoloReplDev() = default;
 
     void async_alloc_write(sisl::blob const& header, sisl::blob const& key, sisl::sg_list const& value,

--- a/src/lib/replication/service/repl_service_impl.h
+++ b/src/lib/replication/service/repl_service_impl.h
@@ -73,7 +73,7 @@ public:
 
 
 private:
-    shared< ReplDev > create_repl_dev_instance(superblk< repl_dev_superblk > const& rd_sb, bool load_existing);
+    shared< ReplDev > create_repl_dev_instance(superblk< repl_dev_superblk > &&rd_sb, bool load_existing);
     void rd_super_blk_found(sisl::byte_view const& buf, void* meta_cookie);
 };
 

--- a/src/tests/test_index_btree.cpp
+++ b/src/tests/test_index_btree.cpp
@@ -109,10 +109,10 @@ struct BtreeTest : public BtreeTestHelper< TestType > {
     class TestIndexServiceCallbacks : public IndexServiceCallbacks {
     public:
         TestIndexServiceCallbacks(BtreeTest* test) : m_test(test) {}
-        std::shared_ptr< IndexTableBase > on_index_table_found(const superblk< index_table_sb >& sb) override {
+        std::shared_ptr< IndexTableBase > on_index_table_found(superblk< index_table_sb >&& sb) override {
             LOGINFO("Index table recovered");
             LOGINFO("Root bnode_id {} version {}", sb->root_node, sb->link_version);
-            m_test->m_bt = std::make_shared< typename T::BtreeType >(sb, m_test->m_cfg);
+            m_test->m_bt = std::make_shared< typename T::BtreeType >(std::move(sb), m_test->m_cfg);
             return m_test->m_bt;
         }
 
@@ -464,10 +464,10 @@ struct BtreeConcurrentTest : public BtreeTestHelper< TestType > {
     class TestIndexServiceCallbacks : public IndexServiceCallbacks {
     public:
         TestIndexServiceCallbacks(BtreeConcurrentTest* test) : m_test(test) {}
-        std::shared_ptr< IndexTableBase > on_index_table_found(const superblk< index_table_sb >& sb) override {
+        std::shared_ptr< IndexTableBase > on_index_table_found(superblk< index_table_sb >&& sb) override {
             LOGINFO("Index table recovered");
             LOGINFO("Root bnode_id {} version {}", sb->root_node, sb->link_version);
-            m_test->m_bt = std::make_shared< typename T::BtreeType >(sb, m_test->m_cfg);
+            m_test->m_bt = std::make_shared< typename T::BtreeType >(std::move(sb), m_test->m_cfg);
             return m_test->m_bt;
         }
 


### PR DESCRIPTION
with copy construction, superblock will be easy to cause duplicated metablk when call write() function if it is not carefully enough. we can avoid this by disable copy construction and only allow move construction.