### PR TITLE
issue #245: appendblk allocator cp change

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.9.1"
+    version = "4.9.2"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/blkalloc/append_blk_allocator.cpp
+++ b/src/lib/blkalloc/append_blk_allocator.cpp
@@ -41,28 +41,12 @@ AppendBlkAllocator::AppendBlkAllocator(const BlkAllocConfig& cfg, bool need_form
     m_sb->last_append_offset = m_last_append_offset;
     m_sb->freeable_nblks = m_freeable_nblks;
 
-#if 0
-    for (uint8_t i = 0; i < m_sb.size(); ++i) {
-        m_sb[i].set_name(get_name());
-        m_sb[i].create(sizeof(append_blkalloc_ctx));
-        m_sb[i]->is_dirty = false;
-        m_sb[i]->allocator_id = id;
-        m_sb[i]->last_append_offset = 0;
-        m_sb[i]->freeable_nblks = m_freeable_nblks;
-    }
-#endif
-
     // for recovery boot, fields will also be recovered from metablks;
 }
 
 void AppendBlkAllocator::on_meta_blk_found(const sisl::byte_view& buf, void* meta_cookie) {
     m_sb.load(buf, meta_cookie);
-#if 0
-    // load all dirty buffer from the same starting point;
-    for (uint8_t i = 0; i < m_sb.size(); ++i) {
-        m_sb[i].load(buf, meta_cookie);
-    }
-#endif
+
     // recover in-memory counter/offset from metablk;
     m_last_append_offset = m_sb->last_append_offset;
     m_freeable_nblks = m_sb->freeable_nblks;

--- a/src/lib/blkalloc/append_blk_allocator.h
+++ b/src/lib/blkalloc/append_blk_allocator.h
@@ -29,11 +29,16 @@ static constexpr uint64_t append_blkalloc_sb_magic{0xd0d0d02b};
 static constexpr uint64_t append_blkalloc_sb_version{0x1};
 
 #pragma pack(1)
-struct append_blkalloc_ctx {
+struct append_blk_sb_t {
     uint64_t magic{append_blkalloc_sb_magic};
     uint32_t version{append_blkalloc_sb_version};
+    allocator_id_t allocator_id; // doesn't expect this to be changed once initialized;
+    blk_num_t freeable_nblks;
+    blk_num_t last_append_offset;
+};
+
+struct append_blk_dirty_buf_t {
     bool is_dirty; // this field is needed for cp_flush, but not necessarily needed for persistence;
-    allocator_id_t allocator_id;
     blk_num_t freeable_nblks;
     blk_num_t last_append_offset;
 };
@@ -136,7 +141,8 @@ private:
     blk_num_t m_last_append_offset{0}; // last appended offset in blocks;
     blk_num_t m_freeable_nblks{0};
     AppendBlkAllocMetrics m_metrics;
-    std::array< superblk< append_blkalloc_ctx >, MAX_CP_COUNT > m_sb;
+    superblk< append_blk_sb_t > m_sb;                              // only cp will be writing to this disk
+    std::array< append_blk_dirty_buf_t, MAX_CP_COUNT > m_dirty_sb; // keep track of dirty sb;
 };
 
 } // namespace homestore


### PR DESCRIPTION
1. append blk allocator shouldn't assume metablk cookie stays the same (although it is true now, it is not a correct assumption to have) during update. 
2. Solution is to only use *one* superblk hander to do the persistence during cp. 

- During cp_flush, every blk allocator if dirtied, will copy its dirty buf (which is only 64 Bytes total) to the sb being persisted to disk. The reason we don't always update the sb being persisted is when there are back-2-back cps, we want dirty buffs to be maintained in its local (per-cp) list and only pick the cur_cp's dirty buf to persist when cp_flush happens.

3. remove unnecessary fields from sb that is being persisted, e.g. is_dirty, etc. and remove unnecessary fields from dirty buf that never changes once set.

Existing test cases is enough to cover the change. 