### PR TITLE
Add flexible journal vdev.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "5.0.4"
+    version = "5.0.5"
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")

--- a/src/include/homestore/chunk_selector.h
+++ b/src/include/homestore/chunk_selector.h
@@ -22,6 +22,7 @@ class ChunkSelector {
 public:
     ChunkSelector() = default;
     virtual void add_chunk(cshared< Chunk >&) = 0;
+    virtual void remove_chunk(cshared< Chunk >&){};
     virtual void foreach_chunks(std::function< void(cshared< Chunk >&) >&& cb) = 0;
     virtual cshared< Chunk > select_chunk(blk_count_t nblks, const blk_alloc_hints& hints) = 0;
 

--- a/src/include/homestore/homestore_decl.hpp
+++ b/src/include/homestore/homestore_decl.hpp
@@ -106,6 +106,8 @@ ENUM(chunk_selector_type_t, uint8_t, // What are the options to select chunk to 
      ALWAYS_CALLER_CONTROLLED        // Expect the caller to always provide the specific chunkid
 );
 
+ENUM(vdev_size_type_t, uint8_t, VDEV_SIZE_STATIC, VDEV_SIZE_DYNAMIC);
+
 ////////////// All structs ///////////////////
 struct dev_info {
     explicit dev_info(std::string name, HSDevType type = HSDevType::Data) : dev_name{std::move(name)}, dev_type{type} {}
@@ -148,7 +150,9 @@ static std::string in_bytes(uint64_t sz) {
 struct hs_format_params {
     float size_pct;
     uint32_t num_chunks{1};
+    uint64_t chunk_size{0};
     uint32_t block_size{0};
+    vdev_size_type_t vdev_size_type{vdev_size_type_t::VDEV_SIZE_STATIC};
     blk_allocator_type_t alloc_type{blk_allocator_type_t::varsize};
     chunk_selector_type_t chunk_sel_type{chunk_selector_type_t::ROUND_ROBIN};
 };
@@ -199,5 +203,4 @@ struct cap_attrs {
 } // namespace homestore
 
 ////////////// Misc ///////////////////
-#define HOMESTORE_LOG_MODS                                                                                             \
-    btree, device, blkalloc, cp, metablk, wbcache, logstore, transient, replication
+#define HOMESTORE_LOG_MODS btree, device, blkalloc, cp, metablk, wbcache, logstore, transient, replication, journalvdev

--- a/src/include/homestore/logstore_service.hpp
+++ b/src/include/homestore/logstore_service.hpp
@@ -135,7 +135,7 @@ public:
     void device_truncate(const device_truncate_cb_t& cb = nullptr, const bool wait_till_done = false,
                          const bool dry_run = false);
 
-    folly::Future< std::error_code > create_vdev(uint64_t size, logstore_family_id_t family, uint32_t num_chunks);
+    folly::Future< std::error_code > create_vdev(uint64_t size, logstore_family_id_t family, uint32_t chunk_size);
     shared< VirtualDev > open_vdev(const vdev_info& vinfo, logstore_family_id_t family, bool load_existing);
     shared< JournalVirtualDev > get_vdev(logstore_family_id_t family) const {
         return (family == DATA_LOG_FAMILY_IDX) ? m_data_logdev_vdev : m_ctrl_logdev_vdev;

--- a/src/lib/common/homestore_config.fbs
+++ b/src/lib/common/homestore_config.fbs
@@ -140,6 +140,9 @@ table Generic {
     // percentage of cache used to create indx mempool. It should be more than 100 to 
     // take into account some floating buffers in writeback cache.
     indx_mempool_percent : uint32 = 110;
+
+    // Number of chunks in journal chunk pool.
+    journal_chunk_pool_capacity: uint32 = 5;
 }
 
 table ResourceLimits {

--- a/src/lib/device/chunk.cpp
+++ b/src/lib/device/chunk.cpp
@@ -23,22 +23,15 @@ Chunk::Chunk(PhysicalDev* pdev, const chunk_info& cinfo, uint32_t chunk_slot) :
         m_chunk_info{cinfo}, m_pdev{pdev}, m_chunk_slot{chunk_slot}, m_stream_id{pdev->chunk_to_stream_id(cinfo)} {}
 
 std::string Chunk::to_string() const {
-    return fmt::format("chunk_id={}, vdev_id={}, start_offset={}, size={}, end_of_chunk={}, slot_num_in_pdev={} "
+    return fmt::format("chunk_id={}, vdev_id={}, start_offset={}, size={}, slot_num_in_pdev={} "
                        "pdev_ordinal={} vdev_ordinal={} stream_id={}",
-                       chunk_id(), vdev_id(), start_offset(), in_bytes(size()), end_of_chunk(), slot_number(),
-                       pdev_ordinal(), vdev_ordinal(), stream_id());
+                       chunk_id(), vdev_id(), start_offset(), in_bytes(size()), slot_number(), pdev_ordinal(),
+                       vdev_ordinal(), stream_id());
 }
 
 void Chunk::set_user_private(const sisl::blob& data) {
     std::unique_lock lg{m_mgmt_mutex};
     m_chunk_info.set_user_private(data);
-    m_chunk_info.compute_checksum();
-    write_chunk_info();
-}
-
-void Chunk::update_end_of_chunk(uint64_t end_offset) {
-    std::unique_lock lg{m_mgmt_mutex};
-    m_chunk_info.end_of_chunk_size = end_offset;
     m_chunk_info.compute_checksum();
     write_chunk_info();
 }
@@ -59,7 +52,6 @@ nlohmann::json Chunk::get_status([[maybe_unused]] int log_level) const {
     j["vdev_id"] = vdev_id();
     j["start_offset"] = start_offset();
     j["size"] = size();
-    j["end_of_chunk_size"] = end_of_chunk();
     j["slot_alloced?"] = is_busy();
     return j;
 }

--- a/src/lib/device/chunk.h
+++ b/src/lib/device/chunk.h
@@ -49,7 +49,6 @@ public:
     bool is_busy() const { return m_chunk_info.is_allocated(); }
     uint32_t vdev_id() const { return m_chunk_info.vdev_id; }
     uint16_t chunk_id() const { return static_cast< uint16_t >(m_chunk_info.chunk_id); }
-    uint64_t end_of_chunk() const { return m_chunk_info.end_of_chunk_size; }
     uint32_t pdev_ordinal() const { return m_chunk_info.chunk_ordinal; }
     const uint8_t* user_private() { return &m_chunk_info.user_private[0]; }
     uint32_t stream_id() const { return m_stream_id; }
@@ -62,7 +61,6 @@ public:
     BlkAllocator* blk_allocator_mutable() { return m_blk_allocator.get(); }
 
     ////////////// Setters /////////////////////
-    void update_end_of_chunk(uint64_t end_offset);
     void set_user_private(const sisl::blob& data);
     void set_block_allocator(cshared< BlkAllocator >& blkalloc) { m_blk_allocator = blkalloc; }
     void set_vdev_ordinal(uint32_t vdev_ordinal) { m_vdev_ordinal = vdev_ordinal; }

--- a/src/lib/device/journal_vdev.cpp
+++ b/src/lib/device/journal_vdev.cpp
@@ -32,115 +32,247 @@
 #include "common/homestore_utils.hpp"
 #include "common/resource_mgr.hpp"
 
+SISL_LOGGING_DECL(journalvdev)
+
 namespace homestore {
 JournalVirtualDev::JournalVirtualDev(DeviceManager& dmgr, const vdev_info& vinfo, vdev_event_cb_t event_cb) :
-        VirtualDev{dmgr, vinfo, std::move(event_cb), false /* is_auto_recovery */} {}
+        VirtualDev{dmgr, vinfo, std::move(event_cb), false /* is_auto_recovery */} {
 
-off_t JournalVirtualDev::alloc_next_append_blk(size_t sz) {
-    if (used_size() + sz > size()) {
-        // not enough space left;
-        HS_LOG(ERROR, device, "No space left! m_write_sz_in_total: {}, m_reserved_sz: {}", m_write_sz_in_total.load(),
-               m_reserved_sz);
-        return INVALID_OFFSET;
+    // Private data stored when chunks are created.
+    init_private_data = std::make_shared< JournalChunkPrivate >();
+    m_chunk_pool = std::make_unique< ChunkPool >(
+        dmgr,
+        ChunkPool::Params{
+            HS_DYNAMIC_CONFIG(generic.journal_chunk_pool_capacity),
+            [this]() {
+                init_private_data->created_at = get_time_since_epoch_ms();
+                sisl::blob private_blob{r_cast< uint8_t* >(init_private_data.get()), sizeof(JournalChunkPrivate)};
+                return private_blob;
+            },
+            m_vdev_info.hs_dev_type, m_vdev_info.vdev_id, m_vdev_info.chunk_size});
+}
+
+JournalVirtualDev::~JournalVirtualDev() {}
+
+void JournalVirtualDev::init() {
+    struct HeadChunk {
+        chunk_num_t chunk_num{};
+        uint64_t created_at{};
+    };
+
+    // Create a mapp of logdev_id to the head chunk and chunk_id to chunk.
+    std::unordered_map< logdev_id_t, HeadChunk > logdev_head_map;
+    std::unordered_map< chunk_num_t, shared< Chunk > > chunk_map;
+    std::unordered_set< chunk_num_t > visited_chunks;
+
+    // Traverse the chunks and find the heads of the logdev_id's.
+    for (auto& chunk : m_all_chunks) {
+        auto* data = r_cast< JournalChunkPrivate* >(const_cast< uint8_t* >(chunk->user_private()));
+        auto chunk_id = chunk->chunk_id();
+        auto logdev_id = data->logdev_id;
+        // Create index for chunks.
+        chunk_map[chunk_id] = chunk;
+        if (data->is_head) {
+            // Store the head which has the latest creation timestamp.
+            if (data->created_at > logdev_head_map[logdev_id].created_at) {
+                logdev_head_map[logdev_id] = HeadChunk{chunk_id, data->created_at};
+            }
+        }
     }
 
-#ifdef _PRERELEASE
-    iomgr_flip::test_and_abort("abort_before_update_eof_cur_chunk");
-#endif
+    for (auto& [logdev_id, head] : logdev_head_map) {
+        // Create descriptor for each logdev_id
+        auto journal_desc = std::make_shared< JournalVirtualDev::Descriptor >(*this, logdev_id);
+        m_journal_descriptors.emplace(logdev_id, journal_desc);
+        LOGDEBUGMOD(journalvdev, "Loading descriptor {}", logdev_id);
+        // Traverse the list starting from the head and add those chunks
+        // in order to the journal descriptor. next_chunk is stored in private_data.
+        // Last chunk will have next_chunk as 0.
+        auto chunk_num = head.chunk_num;
+        while (chunk_num != 0) {
+            auto& c = chunk_map[chunk_num];
+            RELEASE_ASSERT(c, "Invalid chunk found logdev {} chunk {}", logdev_id, chunk_num);
+            journal_desc->m_journal_chunks.push_back(c);
+            visited_chunks.insert(chunk_num);
+            LOGDEBUGMOD(journalvdev, "Loading chunk {} descriptor {}", chunk_num, logdev_id);
 
-    const off_t ds_off = data_start_offset();
-    const off_t end_offset = tail_offset();
+            // Increase the the total size.
+            journal_desc->m_total_size += c->size();
 
-    auto const [chunk, offset_in_chunk] = offset_to_chunk(end_offset);
-
-#ifndef NDEBUG
-    if (end_offset < ds_off) { HS_DBG_ASSERT_EQ(size() - used_size(), static_cast< uint64_t >(ds_off - end_offset)); }
-#endif
-    // works for both "end_offset >= ds_off" and "end_offset < ds_off";
-    if (offset_in_chunk + sz <= chunk->size()) {
-        // not acrossing boundary, nothing to do;
-    } else if ((used_size() + (chunk->size() - offset_in_chunk) + sz) <= size()) {
-        // across chunk boundary, still enough space;
-
-        // Update the overhead to total write size;
-        m_write_sz_in_total.fetch_add(chunk->size() - offset_in_chunk, std::memory_order_relaxed);
-
-        // If across chunk boundary, update the chunk super-block of the chunk size
-        chunk->update_end_of_chunk(offset_in_chunk);
-
-#ifdef _PRERELEASE
-        iomgr_flip::test_and_abort("abort_after_update_eof_cur_chunk");
-#endif
-        // get next chunk handle
-        auto next_chunk = get_next_chunk(chunk);
-        if (next_chunk != chunk) {
-            // Since we are re-using a new chunk, update this chunk's end as its original size;
-            next_chunk->update_end_of_chunk(chunk->size());
+            auto data = r_cast< JournalChunkPrivate* >(const_cast< uint8_t* >(c->user_private()));
+            chunk_num = data->next_chunk;
         }
+    }
+
+    // Chunks which are not in visited set are orphans and needs to be cleaned up.
+    // Remove chunk will affect the m_all_chunks so keep a separate list.
+    std::vector< shared< Chunk > > orphan_chunks;
+    for (auto& chunk : m_all_chunks) {
+        if (!visited_chunks.count(chunk->chunk_id())) { orphan_chunks.push_back(chunk); }
+    }
+
+    for (auto& chunk : orphan_chunks) {
+        auto* data = r_cast< JournalChunkPrivate* >(const_cast< uint8_t* >(chunk->user_private()));
+        auto chunk_id = chunk->chunk_id();
+        auto logdev_id = data->logdev_id;
+        auto next_chunk = data->next_chunk;
+
+        // Clear the private chunk data.
+        *data = JournalChunkPrivate{};
+        update_chunk_private(chunk, data);
+
+        LOGDEBUGMOD(journalvdev, "Removing orphan chunk {} found for logdev {} next {}.", chunk_id, logdev_id,
+                    next_chunk);
+        m_dmgr.remove_chunk_locked(chunk);
+    }
+
+    // Start the chunk pool.
+    m_chunk_pool->start();
+    LOGINFO("Journal vdev init done");
+}
+
+void JournalVirtualDev::update_chunk_private(shared< Chunk >& chunk, JournalChunkPrivate* private_data) {
+    sisl::blob private_blob{r_cast< uint8_t* >(private_data), sizeof(JournalChunkPrivate)};
+    chunk->set_user_private(private_blob);
+}
+
+uint64_t JournalVirtualDev::get_end_of_chunk(shared< Chunk >& chunk) const {
+    auto* private_data = r_cast< JournalChunkPrivate* >(const_cast< uint8_t* >(chunk->user_private()));
+    return private_data->end_of_chunk;
+}
+
+shared< JournalVirtualDev::Descriptor > JournalVirtualDev::open(logdev_id_t logdev_id) {
+    auto it = m_journal_descriptors.find(logdev_id);
+    if (it == m_journal_descriptors.end()) {
+        auto journal_desc = std::make_shared< JournalVirtualDev::Descriptor >(*this, logdev_id);
+        m_journal_descriptors.emplace(logdev_id, journal_desc);
+        return journal_desc;
+    }
+
+    LOGDEBUGMOD(journalvdev, "Opened log device descriptor {}", logdev_id);
+    return it->second;
+}
+
+void JournalVirtualDev::Descriptor::append_chunk() {
+    // Get a new chunk from the pool.
+    auto new_chunk = m_vdev.m_chunk_pool->dequeue();
+
+    // Increase the right window and total size.
+    m_total_size += new_chunk->size();
+    m_end_offset += new_chunk->size();
+
+    if (!m_journal_chunks.empty()) {
+        // If there are already chunks in the m_journal_chunks list, append this new chunk to the end of the list. Write
+        // the next_chunk of the last chunk in the list to point to this new chunk. If already there are no chunks make
+        // the new chunk as the head.
+        auto last_chunk = m_journal_chunks.back();
+        auto* last_chunk_private = r_cast< JournalChunkPrivate* >(const_cast< uint8_t* >(last_chunk->user_private()));
+
+        // Set the next chunk with the newly created chunk id.
+        last_chunk_private->next_chunk = new_chunk->chunk_id();
+
+        // Append the new chunk
+        m_journal_chunks.push_back(new_chunk);
+        auto chunk_size = m_vdev.info().chunk_size;
+        auto offset_in_chunk = (tail_offset() % chunk_size);
+        if (offset_in_chunk != 0) {
+            // Update the overhead to total write size
+            m_write_sz_in_total.fetch_add(last_chunk->size() - offset_in_chunk, std::memory_order_relaxed);
+            last_chunk_private->end_of_chunk = offset_in_chunk;
+        }
+        m_vdev.update_chunk_private(last_chunk, last_chunk_private);
+        LOGDEBUGMOD(journalvdev, "Added chunk new {} last {} desc {}", new_chunk->chunk_id(), last_chunk->chunk_id(),
+                    to_string());
+
     } else {
-        // across chunk boundary and no space left;
-        HS_LOG(ERROR, device, "No space left! m_write_sz_in_total: {}, m_reserved_sz: {}", m_write_sz_in_total.load(),
-               m_reserved_sz);
-        return INVALID_OFFSET;
-        // m_reserved_sz stays sthe same;
+        // If the list is empty, update the new chunk as the head. Only head chunk contains the logdev_id.
+        auto* new_chunk_private = r_cast< JournalChunkPrivate* >(const_cast< uint8_t* >(new_chunk->user_private()));
+        new_chunk_private->is_head = true;
+        new_chunk_private->logdev_id = m_logdev_id;
+        // Append the new chunk
+        m_journal_chunks.push_back(new_chunk);
+        m_vdev.update_chunk_private(new_chunk, new_chunk_private);
+        LOGDEBUGMOD(journalvdev, "Added head chunk {} desc {}", new_chunk->chunk_id(), to_string());
+    }
+}
+
+off_t JournalVirtualDev::Descriptor::alloc_next_append_blk(size_t sz) {
+    // We currently assume size requested is less than chunk_size.
+    auto chunk_size = m_vdev.info().chunk_size;
+    RELEASE_ASSERT_LT(sz, chunk_size, "Size requested greater than chunk size");
+
+    if ((tail_offset() + static_cast< off_t >(sz)) >= m_end_offset) {
+        // not enough space left, add a new chunk.
+        LOGDEBUGMOD(journalvdev, "No space left for size {} Creating chunk desc {}", sz, to_string());
+
+#ifdef _PRERELEASE
+        iomgr_flip::test_and_abort("abort_before_update_eof_cur_chunk");
+#endif
+
+        // Append a chunk to m_journal_chunks list. This will increase the m_end_offset.
+        append_chunk();
+
+#ifdef _PRERELEASE
+        iomgr_flip::test_and_abort("abort_after_update_eof_next_chunk");
+#endif
+
+        RELEASE_ASSERT((tail_offset() + static_cast< off_t >(sz)) < m_end_offset, "No space for append blk");
     }
 
     // if we made a successful reserve, return the tail offset;
-    const off_t offset = tail_offset();
+    const off_t start_offset = data_start_offset();
+    const off_t tail_off = tail_offset();
+    RELEASE_ASSERT(tail_off >= start_offset, "Invalid start and tail offset");
 
     // update reserved size;
     m_reserved_sz += sz;
 
     high_watermark_check();
 
-#ifdef _PRERELEASE
-    iomgr_flip::test_and_abort("abort_after_update_eof_next_chunk");
-#endif
-    // assert that returnning logical offset is in good range;
-    HS_DBG_ASSERT_LE(static_cast< uint64_t >(offset), size());
-    return offset;
+    // assert that returnning logical offset is in good range
+    HS_DBG_ASSERT_LE(tail_off, m_end_offset);
+    LOGDEBUGMOD(journalvdev, "returned tail_off 0x{} desc {}", to_hex(tail_off), to_string());
+    return tail_off;
 }
 
-bool JournalVirtualDev::validate_append_size(size_t count) const {
-    if (used_size() + count > size()) {
+bool JournalVirtualDev::Descriptor::validate_append_size(size_t req_sz) const {
+    if (used_size() + req_sz > size()) {
         // not enough space left;
-        HS_LOG(ERROR, device, "No space left! m_write_sz_in_total: {}, m_reserved_sz: {}", m_write_sz_in_total.load(),
-               m_reserved_sz);
+        HS_LOG(ERROR, device, "No space left! req_sz {} desc {}", req_sz, to_string());
         return false;
     }
 
     if (m_reserved_sz != 0) {
-        HS_LOG(ERROR, device, "write can't be served when m_reserved_sz:{} is not comsumed by pwrite yet.",
-               m_reserved_sz);
+        HS_LOG(ERROR, device, "write can't be served when m_reserved_sz is not comsumed by pwrite yet {}", to_string());
         return false;
     }
     return true;
 }
 
-auto JournalVirtualDev::process_pwrite_offset(size_t len, off_t offset) {
+auto JournalVirtualDev::Descriptor::process_pwrite_offset(size_t len, off_t offset) {
     // convert logical offset to chunk and its offset
     auto const chunk_details = offset_to_chunk(offset);
-    auto const [chunk, offset_in_chunk] = chunk_details;
+    auto const [chunk, _, offset_in_chunk] = chunk_details;
+
+    LOGTRACEMOD(journalvdev, "writing in chunk: {}, offset: 0x{} len: {} offset_in_chunk: 0x{} chunk_sz: {} desc {}",
+                chunk->chunk_id(), to_hex(offset), len, to_hex(offset_in_chunk), chunk->size(), to_string());
 
     // this assert only valid for pwrite/pwritev, which calls alloc_next_append_blk to get the offset to do the
     // write, which guarantees write will with the returned offset will not accross chunk boundary.
     HS_REL_ASSERT_GE(chunk->size() - offset_in_chunk, len, "Writing size: {} crossing chunk is not allowed!", len);
     m_write_sz_in_total.fetch_add(len, std::memory_order_relaxed);
 
-    HS_LOG(TRACE, device, "Writing in chunk: {}, offset: {}, m_write_sz_in_total: {}, start off: {}", chunk->chunk_id(),
-           to_hex(offset_in_chunk), to_hex(m_write_sz_in_total.load()), to_hex(data_start_offset()));
-
     return chunk_details;
 }
 
 /////////////////////////////// Write Section //////////////////////////////////
-folly::Future< std::error_code > JournalVirtualDev::async_append(const uint8_t* buf, size_t size) {
+folly::Future< std::error_code > JournalVirtualDev::Descriptor::async_append(const uint8_t* buf, size_t size) {
     if (!validate_append_size(size)) {
         return folly::makeFuture< std::error_code >(std::make_error_code(std::errc::no_space_on_device));
     } else {
-        auto const [chunk, offset_in_chunk] = process_pwrite_offset(size, m_seek_cursor);
+        auto const [chunk, _, offset_in_chunk] = process_pwrite_offset(size, m_seek_cursor);
         m_seek_cursor += size;
-        return async_write(r_cast< const char* >(buf), size, chunk, offset_in_chunk);
+        return m_vdev.async_write(r_cast< const char* >(buf), size, chunk, offset_in_chunk);
     }
 }
 
@@ -157,15 +289,17 @@ folly::Future< std::error_code > JournalVirtualDev::async_append(const uint8_t* 
  * @param cb : callback after write is completed, can be null
  *
  */
-folly::Future< std::error_code > JournalVirtualDev::async_pwrite(const uint8_t* buf, size_t size, off_t offset) {
+folly::Future< std::error_code > JournalVirtualDev::Descriptor::async_pwrite(const uint8_t* buf, size_t size,
+                                                                             off_t offset) {
     HS_REL_ASSERT_LE(size, m_reserved_sz, "Write size: larger then reserved size is not allowed!");
     m_reserved_sz -= size; // update reserved size
 
-    auto const [chunk, offset_in_chunk] = process_pwrite_offset(size, offset);
-    return async_write(r_cast< const char* >(buf), size, chunk, offset_in_chunk);
+    auto const [chunk, _, offset_in_chunk] = process_pwrite_offset(size, offset);
+    return m_vdev.async_write(r_cast< const char* >(buf), size, chunk, offset_in_chunk);
 }
 
-folly::Future< std::error_code > JournalVirtualDev::async_pwritev(const iovec* iov, int iovcnt, off_t offset) {
+folly::Future< std::error_code > JournalVirtualDev::Descriptor::async_pwritev(const iovec* iov, int iovcnt,
+                                                                              off_t offset) {
     auto const size = VirtualDev::get_len(iov, iovcnt);
 
     // if size is smaller than reserved size, it means write will never be overlapping start offset;
@@ -173,19 +307,20 @@ folly::Future< std::error_code > JournalVirtualDev::async_pwritev(const iovec* i
     HS_REL_ASSERT_LE(size, m_reserved_sz, "Write size: larger then reserved size: is not allowed!");
 
     m_reserved_sz -= size;
-    auto const [chunk, offset_in_chunk] = process_pwrite_offset(size, offset);
-    return async_writev(iov, iovcnt, chunk, offset_in_chunk);
+    auto const [chunk, _, offset_in_chunk] = process_pwrite_offset(size, offset);
+    return m_vdev.async_writev(iov, iovcnt, chunk, offset_in_chunk);
 }
 
-void JournalVirtualDev::sync_pwrite(const uint8_t* buf, size_t size, off_t offset) {
+void JournalVirtualDev::Descriptor::sync_pwrite(const uint8_t* buf, size_t size, off_t offset) {
+
     HS_REL_ASSERT_LE(size, m_reserved_sz, "Write size: larger then reserved size is not allowed!");
     m_reserved_sz -= size; // update reserved size
 
-    auto const [chunk, offset_in_chunk] = process_pwrite_offset(size, offset);
-    sync_write(r_cast< const char* >(buf), size, chunk, offset_in_chunk);
+    auto const [chunk, index, offset_in_chunk] = process_pwrite_offset(size, offset);
+    m_vdev.sync_write(r_cast< const char* >(buf), size, chunk, offset_in_chunk);
 }
 
-void JournalVirtualDev::sync_pwritev(const iovec* iov, int iovcnt, off_t offset) {
+void JournalVirtualDev::Descriptor::sync_pwritev(const iovec* iov, int iovcnt, off_t offset) {
     auto const size = VirtualDev::get_len(iov, iovcnt);
 
     // if size is smaller than reserved size, it means write will never be overlapping start offset;
@@ -193,14 +328,16 @@ void JournalVirtualDev::sync_pwritev(const iovec* iov, int iovcnt, off_t offset)
     HS_REL_ASSERT_LE(size, m_reserved_sz, "Write size: larger then reserved size: is not allowed!");
 
     m_reserved_sz -= size;
-    auto const [chunk, offset_in_chunk] = process_pwrite_offset(size, offset);
-    sync_writev(iov, iovcnt, chunk, offset_in_chunk);
+    auto const [chunk, _, offset_in_chunk] = process_pwrite_offset(size, offset);
+    m_vdev.sync_writev(iov, iovcnt, chunk, offset_in_chunk);
 }
 
 /////////////////////////////// Read Section //////////////////////////////////
-void JournalVirtualDev::sync_next_read(uint8_t* buf, size_t size_rd) {
-    auto const [chunk, offset_in_chunk] = offset_to_chunk(m_seek_cursor);
-    auto const end_of_chunk = chunk->end_of_chunk();
+size_t JournalVirtualDev::Descriptor::sync_next_read(uint8_t* buf, size_t size_rd) {
+    if (m_journal_chunks.empty()) { return 0; }
+
+    auto [chunk, _, offset_in_chunk] = offset_to_chunk(m_seek_cursor);
+    auto const end_of_chunk = m_vdev.get_end_of_chunk(chunk);
     auto const chunk_size = std::min< uint64_t >(end_of_chunk, chunk->size());
     bool across_chunk{false};
 
@@ -223,11 +360,11 @@ void JournalVirtualDev::sync_next_read(uint8_t* buf, size_t size_rd) {
     // Update seek cursor after read;
     m_seek_cursor += size_rd;
     if (across_chunk) { m_seek_cursor += (chunk->size() - end_of_chunk); }
-    m_seek_cursor = m_seek_cursor % size();
+    return size_rd;
 }
 
-std::error_code JournalVirtualDev::sync_pread(uint8_t* buf, size_t size, off_t offset) {
-    auto const [chunk, offset_in_chunk] = offset_to_chunk(offset);
+std::error_code JournalVirtualDev::Descriptor::sync_pread(uint8_t* buf, size_t size, off_t offset) {
+    auto [chunk, index, offset_in_chunk] = offset_to_chunk(offset);
 
     // if the read count is acrossing chunk, only return what's left in this chunk
     if (chunk->size() - offset_in_chunk < size) {
@@ -235,12 +372,14 @@ std::error_code JournalVirtualDev::sync_pread(uint8_t* buf, size_t size, off_t o
         size = chunk->size() - offset_in_chunk;
     }
 
-    return sync_read(r_cast< char* >(buf), size, chunk, offset_in_chunk);
+    LOGTRACEMOD(journalvdev, "offset: 0x{} size: {} chunk: {} index: {} offset_in_chunk: 0x{} desc {}", to_hex(offset),
+                size, chunk->chunk_id(), index, to_hex(offset_in_chunk), to_string());
+    return m_vdev.sync_read(r_cast< char* >(buf), size, chunk, offset_in_chunk);
 }
 
-std::error_code JournalVirtualDev::sync_preadv(iovec* iov, int iovcnt, off_t offset) {
+std::error_code JournalVirtualDev::Descriptor::sync_preadv(iovec* iov, int iovcnt, off_t offset) {
     uint64_t len = VirtualDev::get_len(iov, iovcnt);
-    auto const [chunk, offset_in_chunk] = offset_to_chunk(offset);
+    auto [chunk, index, offset_in_chunk] = offset_to_chunk(offset);
 
     if (chunk->size() - offset_in_chunk < len) {
         if (iovcnt > 1) {
@@ -253,10 +392,13 @@ std::error_code JournalVirtualDev::sync_preadv(iovec* iov, int iovcnt, off_t off
         iov[0].iov_len = len; // is this needed?
     }
 
-    return sync_readv(iov, iovcnt, chunk, offset_in_chunk);
+    LOGTRACEMOD(journalvdev, "offset: 0x{} iov: {} len: {} chunk: {} index: {} offset_in_chunk: 0x{} desc {}",
+                to_hex(offset), iovcnt, len, chunk->chunk_id(), index, to_hex(offset_in_chunk), to_string());
+
+    return m_vdev.sync_readv(iov, iovcnt, chunk, offset_in_chunk);
 }
 
-off_t JournalVirtualDev::lseek(off_t offset, int whence) {
+off_t JournalVirtualDev::Descriptor::lseek(off_t offset, int whence) {
     switch (whence) {
     case SEEK_SET:
         m_seek_cursor = offset;
@@ -276,22 +418,23 @@ off_t JournalVirtualDev::lseek(off_t offset, int whence) {
 /**
  * @brief :- it returns the vdev offset after nbytes from start offset
  */
-off_t JournalVirtualDev::dev_offset(off_t nbytes) const {
+off_t JournalVirtualDev::Descriptor::dev_offset(off_t nbytes) const {
+    if (m_journal_chunks.empty()) { return 0; }
+
     off_t vdev_offset = data_start_offset();
     uint32_t dev_id{0}, chunk_id{0};
     off_t offset_in_chunk{0};
     off_t cur_read_cur{0};
 
     while (cur_read_cur != nbytes) {
-        auto const [chunk, offset_in_chunk] = offset_to_chunk(vdev_offset);
+        auto [chunk, _, offset_in_chunk] = offset_to_chunk(vdev_offset);
 
-        auto const end_of_chunk = chunk->end_of_chunk();
+        auto const end_of_chunk = m_vdev.get_end_of_chunk(chunk);
         auto const chunk_size = std::min< uint64_t >(end_of_chunk, chunk->size());
         auto const remaining = nbytes - cur_read_cur;
         if (remaining >= (static_cast< off_t >(chunk->size()) - offset_in_chunk)) {
             cur_read_cur += (chunk->size() - offset_in_chunk);
             vdev_offset += (chunk->size() - offset_in_chunk);
-            vdev_offset = vdev_offset % size();
         } else {
             vdev_offset += remaining;
             cur_read_cur = nbytes;
@@ -300,75 +443,98 @@ off_t JournalVirtualDev::dev_offset(off_t nbytes) const {
     return vdev_offset;
 }
 
-off_t JournalVirtualDev::tail_offset(bool reserve_space_include) const {
+off_t JournalVirtualDev::Descriptor::tail_offset(bool reserve_space_include) const {
     off_t tail = static_cast< off_t >(data_start_offset() + m_write_sz_in_total.load(std::memory_order_relaxed));
     if (reserve_space_include) { tail += m_reserved_sz; }
-    if (static_cast< uint64_t >(tail) >= size()) { tail -= size(); }
-
+    HS_REL_ASSERT(static_cast< int64_t >(tail) <= m_end_offset, "tail is more than offset tail {} offset {}", tail,
+                  m_end_offset);
     return tail;
 }
 
-void JournalVirtualDev::update_tail_offset(off_t tail) {
+void JournalVirtualDev::Descriptor::update_tail_offset(off_t tail) {
     const off_t start = data_start_offset();
-    HS_LOG(INFO, device, "total_size: {}, tail is being updated to: {}, start: {}", to_hex(size()), to_hex(tail),
-           to_hex(start));
 
     if (tail >= start) {
         m_write_sz_in_total.store(tail - start, std::memory_order_relaxed);
     } else {
-        m_write_sz_in_total.store(size() - start + tail, std::memory_order_relaxed);
+        RELEASE_ASSERT(false, "tail {} less than start offset {}", tail, start);
     }
     lseek(tail);
 
-    HS_LOG(INFO, device, "m_write_sz_in_total updated to: {}", to_hex(m_write_sz_in_total.load()));
-
-    HS_REL_ASSERT(tail_offset() == tail, "tail offset mismatch after calculation {} : {}", tail_offset(), tail);
+    LOGDEBUGMOD(journalvdev, "tail arg 0x{} desc {} ", to_hex(tail), to_string());
+    HS_REL_ASSERT(tail_offset() == tail, "tail offset mismatch after calculation 0x{} : {}", tail_offset(), tail);
 }
 
-void JournalVirtualDev::truncate(off_t offset) {
+void JournalVirtualDev::Descriptor::truncate(off_t truncate_offset) {
     const off_t ds_off = data_start_offset();
 
-    COUNTER_INCREMENT(m_metrics, vdev_truncate_count, 1);
+    COUNTER_INCREMENT(m_vdev.m_metrics, vdev_truncate_count, 1);
 
-    HS_PERIODIC_LOG(INFO, device, "truncating to logical offset: {}, start: {}, m_write_sz_in_total: {} ",
-                    to_hex(offset), to_hex(ds_off), to_hex(m_write_sz_in_total.load()));
+    HS_PERIODIC_LOG(DEBUG, journalvdev, "truncating to logical offset: 0x{} desc {}", to_hex(truncate_offset),
+                    to_string());
 
     uint64_t size_to_truncate{0};
-    if (offset >= ds_off) {
+    if (truncate_offset >= ds_off) {
         // the truncate offset is larger than current start offset
-        size_to_truncate = offset - ds_off;
+        size_to_truncate = truncate_offset - ds_off;
     } else {
-        // the truncate offset is smaller than current start offset, meaning we are looping back to previous chunks;
-        HS_PERIODIC_LOG(INFO, device,
-                        "Loop-back truncating to logical offset: {} which is smaller than current data start "
-                        "offset: {}, m_write_sz_in_total: {}",
-                        to_hex(offset), to_hex(ds_off), to_hex(m_write_sz_in_total.load()));
-        size_to_truncate = size() - (ds_off - offset);
-        HS_REL_ASSERT_GE(m_write_sz_in_total.load(), size_to_truncate, "invalid truncate offset");
-        HS_REL_ASSERT_GE(tail_offset(), offset);
+        RELEASE_ASSERT(false, "Loop-back not supported");
     }
+
+    // Find the chunk which has the truncation offset. This will be the new
+    // head chunk in the list. We first update the is_head is true of this chunk.
+    // So if a crash happens after this, we could have two chunks which has is_head
+    // true in the list and during recovery we select head with the highest creation
+    // timestamp and reuse or cleanup the other.
+    auto [new_head_chunk, _, offset_in_chunk] = offset_to_chunk(truncate_offset);
+    auto* private_data = r_cast< JournalChunkPrivate* >(const_cast< uint8_t* >(new_head_chunk->user_private()));
+    private_data->is_head = true;
+    private_data->logdev_id = m_logdev_id;
+    m_vdev.update_chunk_private(new_head_chunk, private_data);
+
+    // Find all chunks which needs to be removed from the start of m_journal_chunks.
+    // We stop till the truncation offset. Start from the old data_start_offset.
+    // Align the data_start_offset to the chunk_size as we deleting chunks and
+    // all chunks are same size in a journal vdev.
+    uint32_t start = sisl::round_down(ds_off, m_vdev.info().chunk_size);
+    for (auto it = m_journal_chunks.begin(); it != m_journal_chunks.end();) {
+        auto chunk = *it;
+        start += chunk->size();
+        if (start >= truncate_offset) { break; }
+
+        m_total_size -= chunk->size();
+        it = m_journal_chunks.erase(it);
+
+        // Clear the private chunk data before adding to pool.
+        auto* data = r_cast< JournalChunkPrivate* >(const_cast< uint8_t* >(chunk->user_private()));
+        *data = JournalChunkPrivate{};
+        m_vdev.update_chunk_private(chunk, data);
+
+        m_vdev.m_chunk_pool->enqueue(chunk);
+        HS_PERIODIC_LOG(TRACE, journalvdev, "adding chunk {} back to pool desc {}", chunk->chunk_id(), to_string());
+    }
+
+    // Update our start offset, to keep track of actual size
+    HS_REL_ASSERT_LE(truncate_offset, m_end_offset, "truncate offset less than end offset");
+    update_data_start_offset(truncate_offset);
 
     // update in-memory total write size counter;
     m_write_sz_in_total.fetch_sub(size_to_truncate, std::memory_order_relaxed);
-
-    // Update our start offset, to keep track of actual size
-    update_data_start_offset(offset);
-
-    HS_PERIODIC_LOG(INFO, device, "after truncate: m_write_sz_in_total: {}, start: {} ",
-                    to_hex(m_write_sz_in_total.load()), to_hex(data_start_offset()));
     m_truncate_done = true;
+
+    HS_PERIODIC_LOG(DEBUG, journalvdev, "After truncate desc {}", to_string());
 }
 
 #if 0
-uint64_t JournalVirtualDev::get_offset_in_dev(uint32_t dev_id, uint32_t chunk_id, uint64_t offset_in_chunk) const {
+uint64_t JournalVirtualDev::Descriptor::get_offset_in_dev(uint32_t dev_id, uint32_t chunk_id, uint64_t offset_in_chunk) const {
     return get_chunk_start_offset(dev_id, chunk_id) + offset_in_chunk;
 }
 
-uint64_t JournalVirtualDev::get_chunk_start_offset(uint32_t dev_id, uint32_t chunk_id) const {
+uint64_t JournalVirtualDev::Descriptor::get_chunk_start_offset(uint32_t dev_id, uint32_t chunk_id) const {
     return m_primary_pdev_chunks_list[dev_id].chunks_in_pdev[chunk_id]->start_offset();
 }
 
-uint64_t JournalVirtualDev::logical_to_dev_offset(off_t log_offset, uint32_t& dev_id, uint32_t& chunk_id,
+uint64_t JournalVirtualDev::Descriptor::logical_to_dev_offset(off_t log_offset, uint32_t& dev_id, uint32_t& chunk_id,
                                                   off_t& offset_in_chunk) const {
     dev_id = 0;
     chunk_id = 0;
@@ -395,46 +561,100 @@ uint64_t JournalVirtualDev::logical_to_dev_offset(off_t log_offset, uint32_t& de
 }
 #endif
 
-std::pair< cshared< Chunk >&, off_t > JournalVirtualDev::offset_to_chunk(off_t log_offset) const {
-    uint64_t off_l{static_cast< uint64_t >(log_offset)};
-    for (const auto& chunk : m_all_chunks) {
+std::tuple< shared< Chunk >, uint32_t, off_t > JournalVirtualDev::Descriptor::offset_to_chunk(off_t log_offset) const {
+    uint64_t chunk_aligned_offset = sisl::round_down(m_data_start_offset, m_vdev.info().chunk_size);
+    uint64_t off_l{static_cast< uint64_t >(log_offset) - chunk_aligned_offset};
+    uint32_t index = 0;
+    for (auto& chunk : m_journal_chunks) {
         if (off_l >= chunk->size()) {
             off_l -= chunk->size();
+            index++;
         } else {
-            return std::pair< cshared< Chunk >&, off_t >(chunk, off_l);
+            return {chunk, index, off_l};
         }
     }
 
     HS_DBG_ASSERT(false, "Input log_offset is invalid: {}", log_offset);
-    return std::pair(nullptr, 0);
+    return {nullptr, 0L, 0L};
 }
 
-void JournalVirtualDev::high_watermark_check() {
+void JournalVirtualDev::Descriptor::high_watermark_check() {
     if (resource_mgr().check_journal_size(used_size(), size())) {
-        COUNTER_INCREMENT(m_metrics, vdev_high_watermark_count, 1);
+        COUNTER_INCREMENT(m_vdev.m_metrics, vdev_high_watermark_count, 1);
 
-        if (m_event_cb && m_truncate_done) {
+        if (m_vdev.m_event_cb && m_truncate_done) {
             // don't send high watermark callback repeated until at least one truncate has been received;
             HS_LOG(INFO, device, "Callback to client for high watermark warning.");
-            m_event_cb(*this, vdev_event_t::SIZE_THRESHOLD_REACHED, "High watermark reached");
+            m_vdev.m_event_cb(m_vdev, vdev_event_t::SIZE_THRESHOLD_REACHED, "High watermark reached");
             m_truncate_done = false;
         }
     }
 }
 
-bool JournalVirtualDev::is_alloc_accross_chunk(size_t size) const {
-    auto const [chunk, offset_in_chunk] = offset_to_chunk(tail_offset());
+bool JournalVirtualDev::Descriptor::is_alloc_accross_chunk(size_t size) const {
+    auto [chunk, _, offset_in_chunk] = offset_to_chunk(tail_offset());
     return (offset_in_chunk + size > chunk->size());
 }
 
-nlohmann::json JournalVirtualDev::get_status(int log_level) const {
+nlohmann::json JournalVirtualDev::Descriptor::get_status(int log_level) const {
     nlohmann::json j;
-    j["VirtualDev"] = VirtualDev::get_status(log_level);
-    j["JournalVirtualDev"]["m_seek_cursor"] = m_seek_cursor;
-    j["JournalVirtualDev"]["data_start_offset"] = m_data_start_offset;
-    j["JournalVirtualDev"]["write_size"] = m_write_sz_in_total.load(std::memory_order_relaxed);
-    j["JournalVirtualDev"]["truncate_done"] = m_truncate_done;
-    j["JournalVirtualDev"]["reserved_size"] = m_reserved_sz;
+    j["logdev_id"] = m_logdev_id;
+    j["seek_cursor"] = m_seek_cursor;
+    j["data_start_offset"] = m_data_start_offset;
+    j["end_offset"] = m_end_offset;
+    j["write_size"] = m_write_sz_in_total.load(std::memory_order_relaxed);
+    j["truncate_done"] = m_truncate_done;
+    j["reserved_size"] = m_reserved_sz;
+    j["num_chunks"] = m_journal_chunks.size();
+    j["total_size"] = m_total_size;
+    if (log_level >= 3) {
+        nlohmann::json chunk_js = nlohmann::json::array();
+        for (const auto& chunk : m_journal_chunks) {
+            nlohmann::json c;
+            auto* private_data = r_cast< JournalChunkPrivate* >(const_cast< uint8_t* >(chunk->user_private()));
+            c["chunk_id"] = chunk->chunk_id();
+            c["logdev_id"] = private_data->logdev_id;
+            c["is_head"] = private_data->is_head;
+            c["end_of_chunk"] = private_data->end_of_chunk;
+            c["next_chunk"] = private_data->next_chunk;
+            chunk_js.push_back(move(c));
+        }
+        j["chunks"] = std::move(chunk_js);
+    }
+
+    LOGINFO("{}", j.dump(2, ' '));
     return j;
 }
+
+std::string JournalVirtualDev::Descriptor::to_string() const {
+    std::string str{fmt::format("id={};ds=0x{};end=0x{};writesz={};tail=0x{};"
+                                "rsvdsz={};chunks={};trunc={};total={};seek=0x{} ",
+                                m_logdev_id, to_hex(m_data_start_offset), to_hex(m_end_offset),
+                                m_write_sz_in_total.load(std::memory_order_relaxed), to_hex(tail_offset()),
+                                m_reserved_sz, m_journal_chunks.size(), m_truncate_done, m_total_size,
+                                to_hex(m_seek_cursor))};
+    return str;
+}
+
+uint64_t JournalVirtualDev::used_size() const {
+    std::lock_guard lock{m_mutex};
+    uint64_t total_size = 0;
+    for (const auto& [id, jd] : m_journal_descriptors) {
+        total_size += jd->used_size();
+    }
+    return total_size;
+}
+
+uint64_t JournalVirtualDev::available_blks() const { return (size() - used_size()) / block_size(); }
+
+nlohmann::json JournalVirtualDev::get_status(int log_level) const {
+    std::lock_guard lock{m_mutex};
+    nlohmann::json j;
+    j["num_descriptors"] = std::to_string(m_journal_descriptors.size());
+    for (const auto& [logdev_id, descriptor] : m_journal_descriptors) {
+        j["journalvdev_logdev_id_" + std::to_string(logdev_id)] = descriptor->get_status(log_level);
+    }
+    return j;
+}
+
 } // namespace homestore

--- a/src/lib/device/journal_vdev.hpp
+++ b/src/lib/device/journal_vdev.hpp
@@ -19,250 +19,375 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <vector>
+#include <condition_variable>
 
 #include "device.h"
+#include "physical_dev.hpp"
 #include "virtual_dev.hpp"
 
 namespace homestore {
 typedef std::function< void(const off_t ret_off) > alloc_next_blk_cb_t;
+using journal_id_t = uint64_t;
+// Each logstore family is associated to a single logdevice.
+using logdev_id_t = uint64_t;
+
+// Chunks used for journal vdev has journal related info stored in chunk private data.
+// Each log device has a list of journal chunk data with next_chunk.
+// Journal vdev will arrange the chunks in order during recovery.
+struct JournalChunkPrivate {
+    logdev_id_t logdev_id{0};
+    bool is_head{false};       // Is it the head element.
+    uint64_t created_at{0};    // Creation timestamp
+    uint64_t end_of_chunk{0};  // The offset indicates end of chunk.
+    chunk_num_t next_chunk{0}; // Next chunk in the list.
+};
+
+static_assert(sizeof(JournalChunkPrivate) <= chunk_info::user_private_size, "Journal private area bigger");
 
 class JournalVirtualDev : public VirtualDev {
-    struct Chunk_EOF_t {
-        uint64_t e;
+public:
+    // Client use journal vdev open to create a descriptor to append log entries.
+    // Each descriptor is independent list of chunks in order and like sliding window
+    // maintains size, offsets like the left side (m_data_start_offset) and
+    // right side (m_end_offset). Truncate increases the left m_data_start_offset
+    // and pop chunks from the front of the list. alloc_next_append_blk adds more chunk to
+    // the back of list if no space and adjusts the right m_end_offset. All offsets
+    // only increase and never wraps around. Each chunk in the descriptor has private
+    // data about the logdev_id its part of, next chunk to maintain the list.
+    struct Descriptor {
+    private:
+        JournalVirtualDev& m_vdev;
+        logdev_id_t m_logdev_id; // Unique id identifying the journal descriptor.
+        // off_t is long. make it uint64_t ?
+        off_t m_seek_cursor{0}; // the seek cursor
+
+        off_t m_data_start_offset{0};                   // Start offset of where actual data begin for this vdev
+        std::atomic< uint64_t > m_write_sz_in_total{0}; //  Size will be decreased by truncate and increased by append;
+        bool m_truncate_done{true};
+        uint64_t m_reserved_sz{0};                       // write size within chunk, used to check chunk boundary;
+        std::vector< shared< Chunk > > m_journal_chunks; // Chunks part of this journal in order.
+        uint64_t m_total_size{0};                        // Total size of all chunks.
+        off_t m_end_offset{0};        // Offset right to window. Never reduced. Increased in multiple of chunk size.
+        bool m_end_offset_set{false}; // Adjust the m_end_offset only once during init.
+        friend class JournalVirtualDev;
+
+    public:
+        // Descriptor is created via JournalVirtualDev::open similar to file descriptor.
+        Descriptor(JournalVirtualDev& vdev, logdev_id_t id) : m_vdev(vdev), m_logdev_id(id) {}
+
+        // Create and append the chunk to m_journal_chunks.
+        void append_chunk();
+
+        /**
+         * @brief : allocate space specified by input size.
+         *
+         * @param size : size to be allocated
+         *
+         * @return : the start unique offset of the allocated space
+         *
+         * Possible calling sequence:
+         * offset_1 = reserve(size1);
+         * offset_2 = reserve(size2);
+         * write_at_offset(offset_2);
+         * write_at_offset(offset_1);
+         */
+        off_t alloc_next_append_blk(const size_t size);
+
+        /**
+         * @brief : writes up to count bytes from the buffer starting at buf. append advances seek cursor;
+         *
+         * @param buf : buffer to be written
+         * @param count : size of buffer in bytes
+         * @param req : async req;
+         *
+         * @return : On success, the number of bytes written is returned.  On error, -1 is returned.
+         */
+        folly::Future< std::error_code > async_append(const uint8_t* buf, size_t count);
+
+        /**
+         * @brief : writes up to count bytes from the buffer starting at buf at offset offset.
+         * The cursor is not changed.
+         * pwrite always use offset returned from alloc_next_append_blk to do the write;
+         * pwrite should not across chunk boundaries because alloc_next_append_blk guarantees offset returned always
+         * doesn't across chunk boundary;
+         *
+         * @param buf : buffer pointing to the data being written
+         * @param size : size of buffer to be written
+         * @param offset : offset to be written
+         * @param req : async req
+         *
+         * @return : On success, the number of bytes read or written is returned, or -1 on error.
+         */
+        folly::Future< std::error_code > async_pwrite(const uint8_t* buf, size_t size, off_t offset);
+
+        /**
+         * @brief : writes iovcnt buffers of data described by iov to the offset.
+         * pwritev doesn't advance curosr;
+         *
+         * @param iov : the iovec that holds vector of data buffers
+         * @param iovcnt : size of iov
+         * @param offset : offset to be written
+         * @param req : aync req.
+         * if req is not nullptr, it will be an async call.
+         * if req is nullptr, it will be a sync call.
+         *
+         * @return : On success, number of bytes written. On error, -1 is returned
+         */
+        folly::Future< std::error_code > async_pwritev(const iovec* iov, int iovcnt, off_t offset);
+
+        /// @brief writes up to count bytes from the buffer starting at buf at offset offset. The cursor is not
+        /// changed. pwrite always use offset returned from alloc_next_append_blk to do the write;pwrite should not
+        /// across chunk boundaries because alloc_next_append_blk guarantees offset returned always doesn't across chunk
+        /// boundary;
+        ///
+        /// @param buf : buffer pointing to the data being written
+        /// @param size : size of buffer to be written
+        /// @param offset : offset to be written
+        /// @return : On success, the number of bytes written is returned, or -1 on error.
+        void sync_pwrite(const uint8_t* buf, size_t size, off_t offset);
+
+        void sync_pwritev(const iovec* iov, int iovcnt, off_t offset);
+
+        /**
+         * @brief : read up to count bytes into the buffer starting at buf.
+         * Only read the size before end of chunk and update m_seek_cursor to next chunk;
+         *
+         * @param buf : the buffer that points to read out data
+         * @param count : the size of buffer;
+         *
+         * @return : On success, the number of bytes read is returned (zero indicates end of file), and the cursor is
+         * advanced by this number. it is not an error if this number is smaller than the number requested, because it
+         * can be end of chunk, since read won't across chunk.
+         */
+        size_t sync_next_read(uint8_t* buf, size_t count_in);
+
+        /**
+         * @brief : reads up to count bytes at offset into the buffer starting at buf.
+         * The curosr is not updated.
+         *
+         * @param buf : the buffer that points to the read out data.
+         * @param count : size of buffer
+         * @param offset : the start offset to do read
+         *
+         * @return : return the error code of the read
+         */
+        std::error_code sync_pread(uint8_t* buf, size_t count_in, off_t offset);
+
+        /**
+         * @brief : read at offset and save output to iov.
+         * We don't have a use case for external caller of preadv now, meaning iov will always have only 1 element;
+         * if the len is acrossing chunk boundary,
+         * we only do read on one chunk and return the num of bytes read on this chunk;
+         *
+         * @param iov : the iovect to store the read out data
+         * @param iovcnt : size of iovev
+         * @param offset : the start offset to read
+         *
+         * @return : return the error code of the read
+         */
+        std::error_code sync_preadv(iovec* iov, int iovcnt, off_t offset);
+
+        /**
+         * @brief : repositions the cusor of the device to the argument offset
+         * according to the directive whence as follows:
+         * SEEK_SET
+         *     The curosr is set to offset bytes.
+         * SEEK_CUR
+         *     The cursor is set to its current location plus offset bytes.
+         * SEEK_END
+         *     Not supported yet. No use case for now.
+         *
+         * @param offset : the logical offset
+         * @param whence : see above
+         *
+         * @return :  Upon successful completion, lseek() returns the resulting offset
+         * location as measured in bytes from the beginning of the file.  On
+         * error, the value (off_t) -1 is returned
+         */
+        off_t lseek(off_t offset, int whence = SEEK_SET);
+
+        /**
+         * @brief : this API can be replaced by lseek(0, SEEK_CUR);
+         *
+         * @return : current curosr offset
+         */
+        off_t seeked_pos() const { return m_seek_cursor; }
+
+        /**
+         * @brief :- it returns the vdev offset after nbytes from start offset
+         */
+        off_t dev_offset(off_t nbytes) const;
+
+        /**
+         * @brief : get the start logical offset where data starts;
+         *
+         * @return : the start logical offset where data starts;
+         */
+        off_t data_start_offset() const { return m_data_start_offset; }
+
+        off_t end_offset() const { return m_end_offset; }
+
+        /**
+         * @brief : persist start logical offset to vdev's super block
+         * Supposed to be called when truncate happens;
+         *
+         * @param offset : the start logical offset to be persisted
+         */
+        void update_data_start_offset(off_t offset) {
+            m_data_start_offset = offset;
+            auto data_start_offset_aligned = sisl::round_down(m_data_start_offset, m_vdev.info().chunk_size);
+            m_end_offset = data_start_offset_aligned + m_journal_chunks.size() * m_vdev.info().chunk_size;
+            RELEASE_ASSERT_EQ(m_end_offset - data_start_offset_aligned, m_total_size, "offset size mismatch");
+        }
+
+        /**
+         * @brief : get the logical tail offset;
+         *
+         * @param reserve_space_include : include reserved space or not;
+         *
+         * @return : the logical tail offset;
+         */
+        off_t tail_offset(bool reserve_space_include = true) const;
+
+        /**
+         * @brief : update the tail to vdev, this API will be called during reboot and
+         * upper layer(logdev) has completed scanning all the valid records in vdev and then
+         * update the tail in vdev.
+         *
+         * @param tail : logical tail offset
+         */
+        void update_tail_offset(off_t tail);
+
+        /**
+         * @brief : truncate vdev to the provided logcial offset
+         *
+         * @param truncate_offset: logical offset that vdev needs to truncate to.
+         *
+         * Concurrency:
+         * 1. truncate and write can be received concurrently.
+         * 2. multiple truncate calls can be received concurently.
+         *
+         * Following things should happen for truncate:
+         * 1. update in-memory counter of total write size.
+         * 2. update vdev superblock of the new start logical offset that is being truncate to;
+         *
+         */
+        void truncate(off_t truncate_offset);
+
+        /**
+         * @brief : get the total size in journal
+         *
+         * @return : the total space in journal
+         */
+        uint64_t size() const { return m_total_size; }
+
+        /**
+         * @brief : get the used size in journal
+         *
+         * @return : the used space in journal
+         */
+        uint64_t used_size() const { return m_write_sz_in_total.load(std::memory_order_relaxed) + m_reserved_sz; }
+
+        /**
+         * @brief : get the free space left in journal
+         *
+         * @return : free space left in journal
+         */
+        uint64_t available_size() const { return size() - used_size(); }
+
+        /**
+         * @brief : get the free blks available in journal, assuming page_size as a measure of blks
+         *
+         * @return : free number of pages/blks available.
+         */
+        uint64_t available_blks() const { return available_size() / m_vdev.block_size(); }
+
+        /**
+         * @brief Get the status of the journal vdev and its internal structures
+         * @param log_level: Log level to do verbosity.
+         * @return Json containing internal details
+         */
+        nlohmann::json get_status(int log_level) const;
+
+        std::string to_string() const;
+
+    private:
+        /**
+         * @brief : convert logical offset to physical offset for pwrite/pwritev;
+         *
+         * @param len : len of data that is going to be written
+         * @param offset : logical offset to be written
+         * @param dev_id : the return value of device id
+         * @param chunk_id : the return value of chunk id
+         * @param req : async req
+         *
+         * @return : the unique offset
+         */
+        auto process_pwrite_offset(size_t len, off_t offset);
+
+        /**
+         * @brief : convert logical offset in chunk to the physical device offset
+         *
+         * @param dev_id : the device id
+         * @param chunk_id : the chunk id;
+         * @param offset_in_chunk : the logical offset in chunk;
+         *
+         * @return : the physical device offset;
+         */
+        uint64_t get_offset_in_dev(uint32_t dev_id, uint32_t chunk_id, uint64_t offset_in_chunk) const;
+
+        /**
+         * @brief : get the physical start offset of the chunk;
+         *
+         * @param dev_id : the deivce id;
+         * @param chunk_id : the chunk id;
+         *
+         * @return : the physical start offset of the chunk;
+         */
+        uint64_t get_chunk_start_offset(uint32_t dev_id, uint32_t chunk_id) const;
+
+        /**
+         * @brief : Convert from logical offset to device offset.
+         * It handles device overloop, e.g. reach to end of the device then start from the beginning device
+         *
+         * @param log_offset : the logical offset
+         * @param dev_id     : the device id after convertion
+         * @param chunk_id   : the chunk id after convertion
+         * @param offset_in_chunk : the relative offset in chunk
+         *
+         * @return : the unique offset after converion;
+         */
+        // uint64_t logical_to_dev_offset(off_t log_offset, uint32_t& dev_id, uint32_t& chunk_id,
+        //                                off_t& offset_in_chunk) const;
+
+        // Return the chunk, its index and offset in the chunk list.
+        std::tuple< shared< Chunk >, uint32_t, off_t > offset_to_chunk(off_t log_offset) const;
+
+        bool validate_append_size(size_t count) const;
+
+        void high_watermark_check();
+
+        bool is_alloc_accross_chunk(size_t size) const;
+
+        auto get_dev_details(size_t len, off_t offset);
     };
 
-    // NOTE:  Usage of this needs to avoid punning which is now illegal in C++ 11 and up
-    typedef union {
-        struct Chunk_EOF_t eof;
-        std::array< unsigned char, VIRDEV_BLKSIZE > padding;
-    } Chunk_EOF;
-
-    static_assert(sizeof(Chunk_EOF) == VIRDEV_BLKSIZE, "LogDevRecordHeader must be VIRDEV_SIZE bytes");
-
-private:
-    off_t m_seek_cursor{0};                         // the seek cursor
-    off_t m_data_start_offset{0};                   // Start offset of where actual data begin for this vdev
-    std::atomic< uint64_t > m_write_sz_in_total{0}; // this size will be decreased by truncate and increased by append;
-    bool m_truncate_done{true};
-    uint64_t m_reserved_sz{0}; // write size within chunk, used to check chunk boundary;
-
-public:
     /* Create a new virtual dev for these parameters */
     JournalVirtualDev(DeviceManager& dmgr, const vdev_info& vinfo, vdev_event_cb_t event_cb);
     JournalVirtualDev(const JournalVirtualDev& other) = delete;
     JournalVirtualDev& operator=(const JournalVirtualDev& other) = delete;
     JournalVirtualDev(JournalVirtualDev&&) noexcept = delete;
     JournalVirtualDev& operator=(JournalVirtualDev&&) noexcept = delete;
-    virtual ~JournalVirtualDev() override = default;
+    virtual ~JournalVirtualDev();
 
-    /**
-     * @brief : allocate space specified by input size.
-     *
-     * @param size : size to be allocated
-     *
-     * @return : the start unique offset of the allocated space
-     *
-     * Possible calling sequence:
-     * offset_1 = reserve(size1);
-     * offset_2 = reserve(size2);
-     * write_at_offset(offset_2);
-     * write_at_offset(offset_1);
-     */
-    off_t alloc_next_append_blk(const size_t size);
+    // Initialize the journal vdev during reovery. Traverse all chunks
+    // and group chunks based on logdev_id and its list.
+    virtual void init() override;
 
-    /**
-     * @brief : writes up to count bytes from the buffer starting at buf. append advances seek cursor;
-     *
-     * @param buf : buffer to be written
-     * @param count : size of buffer in bytes
-     * @param req : async req;
-     *
-     * @return : On success, the number of bytes written is returned.  On error, -1 is returned.
-     */
-    folly::Future< std::error_code > async_append(const uint8_t* buf, size_t count);
-
-    /**
-     * @brief : writes up to count bytes from the buffer starting at buf at offset offset.
-     * The cursor is not changed.
-     * pwrite always use offset returned from alloc_next_append_blk to do the write;
-     * pwrite should not across chunk boundaries because alloc_next_append_blk guarantees offset returned always doesn't
-     * across chunk boundary;
-     *
-     * @param buf : buffer pointing to the data being written
-     * @param size : size of buffer to be written
-     * @param offset : offset to be written
-     * @param req : async req
-     *
-     * @return : On success, the number of bytes read or written is returned, or -1 on error.
-     */
-    folly::Future< std::error_code > async_pwrite(const uint8_t* buf, size_t size, off_t offset);
-
-    /**
-     * @brief : writes iovcnt buffers of data described by iov to the offset.
-     * pwritev doesn't advance curosr;
-     *
-     * @param iov : the iovec that holds vector of data buffers
-     * @param iovcnt : size of iov
-     * @param offset : offset to be written
-     * @param req : aync req.
-     * if req is not nullptr, it will be an async call.
-     * if req is nullptr, it will be a sync call.
-     *
-     * @return : On success, number of bytes written. On error, -1 is returned
-     */
-    folly::Future< std::error_code > async_pwritev(const iovec* iov, int iovcnt, off_t offset);
-
-    /// @brief writes up to count bytes from the buffer starting at buf at offset offset. The cursor is not
-    /// changed. pwrite always use offset returned from alloc_next_append_blk to do the write;pwrite should not across
-    /// chunk boundaries because alloc_next_append_blk guarantees offset returned always doesn't across chunk boundary;
-    ///
-    /// @param buf : buffer pointing to the data being written
-    /// @param size : size of buffer to be written
-    /// @param offset : offset to be written
-    /// @return : On success, the number of bytes written is returned, or -1 on error.
-    void sync_pwrite(const uint8_t* buf, size_t size, off_t offset);
-
-    void sync_pwritev(const iovec* iov, int iovcnt, off_t offset);
-
-    /**
-     * @brief : read up to count bytes into the buffer starting at buf.
-     * Only read the size before end of chunk and update m_seek_cursor to next chunk;
-     *
-     * @param buf : the buffer that points to read out data
-     * @param count : the size of buffer;
-     *
-     * @return : On success, the number of bytes read is returned (zero indicates end of file), and the cursor is
-     * advanced by this number. it is not an error if this number is smaller than the number requested, because it can
-     * be end of chunk, since read won't across chunk.
-     */
-    void sync_next_read(uint8_t* buf, size_t count_in);
-
-    /**
-     * @brief : reads up to count bytes at offset into the buffer starting at buf.
-     * The curosr is not updated.
-     *
-     * @param buf : the buffer that points to the read out data.
-     * @param count : size of buffer
-     * @param offset : the start offset to do read
-     *
-     * @return : return the error code of the read
-     */
-    std::error_code sync_pread(uint8_t* buf, size_t count_in, off_t offset);
-
-    /**
-     * @brief : read at offset and save output to iov.
-     * We don't have a use case for external caller of preadv now, meaning iov will always have only 1 element;
-     * if the len is acrossing chunk boundary,
-     * we only do read on one chunk and return the num of bytes read on this chunk;
-     *
-     * @param iov : the iovect to store the read out data
-     * @param iovcnt : size of iovev
-     * @param offset : the start offset to read
-     *
-     * @return : return the error code of the read
-     */
-    std::error_code sync_preadv(iovec* iov, int iovcnt, off_t offset);
-
-    /**
-     * @brief : repositions the cusor of the device to the argument offset
-     * according to the directive whence as follows:
-     * SEEK_SET
-     *     The curosr is set to offset bytes.
-     * SEEK_CUR
-     *     The cursor is set to its current location plus offset bytes.
-     * SEEK_END
-     *     Not supported yet. No use case for now.
-     *
-     * @param offset : the logical offset
-     * @param whence : see above
-     *
-     * @return :  Upon successful completion, lseek() returns the resulting offset
-     * location as measured in bytes from the beginning of the file.  On
-     * error, the value (off_t) -1 is returned
-     */
-    off_t lseek(off_t offset, int whence = SEEK_SET);
-
-    /**
-     * @brief : this API can be replaced by lseek(0, SEEK_CUR);
-     *
-     * @return : current curosr offset
-     */
-    off_t seeked_pos() const { return m_seek_cursor; }
-
-    /**
-     * @brief :- it returns the vdev offset after nbytes from start offset
-     */
-    off_t dev_offset(off_t nbytes) const;
-
-    /**
-     * @brief : get the start logical offset where data starts;
-     *
-     * @return : the start logical offset where data starts;
-     */
-    off_t data_start_offset() const { return m_data_start_offset; }
-
-    /**
-     * @brief : persist start logical offset to vdev's super block
-     * Supposed to be called when truncate happens;
-     *
-     * @param offset : the start logical offset to be persisted
-     */
-    void update_data_start_offset(off_t offset) { m_data_start_offset = offset; }
-
-    /**
-     * @brief : get the logical tail offset;
-     *
-     * @param reserve_space_include : include reserved space or not;
-     *
-     * @return : the logical tail offset;
-     */
-    off_t tail_offset(bool reserve_space_include = true) const;
-
-    /**
-     * @brief : update the tail to vdev, this API will be called during reboot and
-     * upper layer(logdev) has completed scanning all the valid records in vdev and then
-     * update the tail in vdev.
-     *
-     * @param tail : logical tail offset
-     */
-    void update_tail_offset(off_t tail);
-
-    /**
-     * @brief : truncate vdev to the provided logcial offset
-     *
-     * @param offset: logical offset that vdev needs to truncate to.
-     *
-     * Concurrency:
-     * 1. truncate and write can be received concurrently.
-     * 2. multiple truncate calls can be received concurently.
-     *
-     * Following things should happen for truncate:
-     * 1. update in-memory counter of total write size.
-     * 2. update vdev superblock of the new start logical offset that is being truncate to;
-     *
-     */
-    void truncate(off_t offset);
-
-    /**
-     * @brief : get the used size in vdev
-     *
-     * @return : the used space in vdev
-     */
-    uint64_t used_size() const override { return m_write_sz_in_total.load(std::memory_order_relaxed) + m_reserved_sz; }
-
-    /**
-     * @brief : get the free space left in vdev
-     *
-     * @return : free space left in vdev
-     */
-    uint64_t available_size() const { return size() - used_size(); }
-
-    /**
-     * @brief : get the free blks available in vdev, assuming page_size as a measure of blks
-     *
-     * @return : free number of pages/blks available.
-     */
-    uint64_t available_blks() const override { return available_size() / block_size(); }
+    // Create and return a journal descriptor. A journal descriptor has a list of chunks
+    // where log entries are stored. It also mantains offsets, size etc.
+    shared< Descriptor > open(logdev_id_t id);
 
     /**
      * @brief Get the status of the journal vdev and its internal structures
@@ -271,66 +396,21 @@ public:
      */
     nlohmann::json get_status(int log_level) const override;
 
+    uint64_t used_size() const override;
+    uint64_t available_blks() const override;
+
+    void update_chunk_private(shared< Chunk >& chunk, JournalChunkPrivate* chunk_private);
+    uint64_t get_end_of_chunk(shared< Chunk >& chunk) const;
+
 private:
-    /**
-     * @brief : convert logical offset to physical offset for pwrite/pwritev;
-     *
-     * @param len : len of data that is going to be written
-     * @param offset : logical offset to be written
-     * @param dev_id : the return value of device id
-     * @param chunk_id : the return value of chunk id
-     * @param req : async req
-     *
-     * @return : the unique offset
-     */
-    auto process_pwrite_offset(size_t len, off_t offset);
+    // Mapping of logdev id to its journal descriptors.
+    std::unordered_map< logdev_id_t, shared< Descriptor > > m_journal_descriptors;
+    std::mutex m_mutex;
 
-    /**
-     * @brief : convert logical offset in chunk to the physical device offset
-     *
-     * @param dev_id : the device id
-     * @param chunk_id : the chunk id;
-     * @param offset_in_chunk : the logical offset in chunk;
-     *
-     * @return : the physical device offset;
-     */
-    uint64_t get_offset_in_dev(uint32_t dev_id, uint32_t chunk_id, uint64_t offset_in_chunk) const;
-
-    /**
-     * @brief : get the physical start offset of the chunk;
-     *
-     * @param dev_id : the deivce id;
-     * @param chunk_id : the chunk id;
-     *
-     * @return : the physical start offset of the chunk;
-     */
-    uint64_t get_chunk_start_offset(uint32_t dev_id, uint32_t chunk_id) const;
-
-    /**
-     * @brief : Convert from logical offset to device offset.
-     * It handles device overloop, e.g. reach to end of the device then start from the beginning device
-     *
-     * @param log_offset : the logical offset
-     * @param dev_id     : the device id after convertion
-     * @param chunk_id   : the chunk id after convertion
-     * @param offset_in_chunk : the relative offset in chunk
-     *
-     * @return : the unique offset after converion;
-     */
-    // uint64_t logical_to_dev_offset(off_t log_offset, uint32_t& dev_id, uint32_t& chunk_id,
-    //                                off_t& offset_in_chunk) const;
-
-    std::pair< cshared< Chunk >&, off_t > offset_to_chunk(off_t log_offset) const;
-
-    bool validate_append_size(size_t count) const;
-
-    void high_watermark_check();
-
-    off_t alloc_next_append_blk_internal(size_t size);
-
-    bool is_alloc_accross_chunk(size_t size) const;
-
-    auto get_dev_details(size_t len, off_t offset);
+    // Cache the chunks. Getting a chunk from the pool causes a single write of the
+    // last chunk in the list to update its end_of_chunk and next_chunk.
+    std::unique_ptr< ChunkPool > m_chunk_pool;
+    std::shared_ptr< JournalChunkPrivate > init_private_data;
 };
 
 } // namespace homestore

--- a/src/lib/homestore.cpp
+++ b/src/lib/homestore.cpp
@@ -165,10 +165,10 @@ void HomeStore::format_and_start(std::map< uint32_t, hs_format_params >&& format
             m_meta_service->create_vdev(pct_to_size(fparams.size_pct, HSDevType::Fast), fparams.num_chunks);
         } else if ((svc_type & HS_SERVICE::LOG_REPLICATED) && has_log_service()) {
             futs.emplace_back(m_log_service->create_vdev(pct_to_size(fparams.size_pct, HSDevType::Fast),
-                                                         LogStoreService::DATA_LOG_FAMILY_IDX, fparams.num_chunks));
+                                                         LogStoreService::DATA_LOG_FAMILY_IDX, fparams.chunk_size));
         } else if ((svc_type & HS_SERVICE::LOG_LOCAL) && has_log_service()) {
             futs.emplace_back(m_log_service->create_vdev(pct_to_size(fparams.size_pct, HSDevType::Fast),
-                                                         LogStoreService::CTRL_LOG_FAMILY_IDX, fparams.num_chunks));
+                                                         LogStoreService::CTRL_LOG_FAMILY_IDX, fparams.chunk_size));
         } else if ((svc_type & HS_SERVICE::DATA) && has_data_service()) {
             m_data_service->create_vdev(pct_to_size(fparams.size_pct, HSDevType::Data), fparams.block_size,
                                         fparams.alloc_type, fparams.chunk_sel_type, fparams.num_chunks);

--- a/src/lib/logstore/log_store_service.cpp
+++ b/src/lib/logstore/log_store_service.cpp
@@ -43,7 +43,7 @@ LogStoreService::LogStoreService() :
                             std::make_unique< LogStoreFamily >(CTRL_LOG_FAMILY_IDX)} {}
 
 folly::Future< std::error_code > LogStoreService::create_vdev(uint64_t size, logstore_family_id_t family,
-                                                              uint32_t num_chunks) {
+                                                              uint32_t chunk_size) {
     const auto atomic_page_size = hs()->device_mgr()->atomic_page_size(HSDevType::Fast);
 
     hs_vdev_context hs_ctx;
@@ -62,9 +62,11 @@ folly::Future< std::error_code > LogStoreService::create_vdev(uint64_t size, log
     // future, we can let consumer set it by then;
     auto vdev =
         hs()->device_mgr()->create_vdev(vdev_parameters{.vdev_name = name,
-                                                        .vdev_size = size,
-                                                        .num_chunks = num_chunks,
+                                                        .size_type = vdev_size_type_t::VDEV_SIZE_DYNAMIC,
+                                                        .vdev_size = 0,
+                                                        .num_chunks = 0,
                                                         .blk_size = atomic_page_size,
+                                                        .chunk_size = chunk_size,
                                                         .dev_type = HSDevType::Fast,
                                                         .alloc_type = blk_allocator_type_t::none,
                                                         .chunk_sel_type = chunk_selector_type_t::ROUND_ROBIN,

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -138,6 +138,7 @@ void SoloReplDev::cp_flush(CP*) {
     m_rd_sb.write();
 }
 
-void SoloReplDev::cp_cleanup(CP*) { /* m_data_journal->truncate(m_rd_sb->checkpoint_lsn); */ }
+void SoloReplDev::cp_cleanup(CP*) { /* m_data_journal->truncate(m_rd_sb->checkpoint_lsn); */
+}
 
 } // namespace homestore

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -169,6 +169,8 @@ public:
         IndexServiceCallbacks* index_svc_cbs{nullptr};
         shared< ReplApplication > repl_app{nullptr};
         chunk_num_t num_chunks{1};
+        uint64_t chunk_size{32 * 1024 * 1024}; // Chunk size in MB.
+        vdev_size_type_t vdev_size_type{vdev_size_type_t::VDEV_SIZE_STATIC};
     };
 
 #if 0
@@ -249,24 +251,29 @@ public:
             hsi->start(hs_input_params{.devices = device_info, .app_mem_size = app_mem_size}, std::move(cb));
 
         if (need_format) {
-            hsi->format_and_start(
-                {{HS_SERVICE::META, {.size_pct = svc_params[HS_SERVICE::META].size_pct}},
-                 {HS_SERVICE::LOG_REPLICATED, {.size_pct = svc_params[HS_SERVICE::LOG_REPLICATED].size_pct}},
-                 {HS_SERVICE::LOG_LOCAL, {.size_pct = svc_params[HS_SERVICE::LOG_LOCAL].size_pct}},
-                 {HS_SERVICE::DATA,
-                  {.size_pct = svc_params[HS_SERVICE::DATA].size_pct,
-                   .num_chunks = svc_params[HS_SERVICE::DATA].num_chunks,
-                   .alloc_type = svc_params[HS_SERVICE::DATA].blkalloc_type,
-                   .chunk_sel_type = svc_params[HS_SERVICE::DATA].custom_chunk_selector
-                       ? chunk_selector_type_t::CUSTOM
-                       : chunk_selector_type_t::ROUND_ROBIN}},
-                 {HS_SERVICE::INDEX, {.size_pct = svc_params[HS_SERVICE::INDEX].size_pct}},
-                 {HS_SERVICE::REPLICATION,
-                  {.size_pct = svc_params[HS_SERVICE::REPLICATION].size_pct,
-                   .alloc_type = svc_params[HS_SERVICE::REPLICATION].blkalloc_type,
-                   .chunk_sel_type = svc_params[HS_SERVICE::REPLICATION].custom_chunk_selector
-                       ? chunk_selector_type_t::CUSTOM
-                       : chunk_selector_type_t::ROUND_ROBIN}}});
+            hsi->format_and_start({{HS_SERVICE::META, {.size_pct = svc_params[HS_SERVICE::META].size_pct}},
+                                   {HS_SERVICE::LOG_REPLICATED,
+                                    {.size_pct = 1,
+                                     .chunk_size = svc_params[HS_SERVICE::LOG_REPLICATED].chunk_size,
+                                     .vdev_size_type = svc_params[HS_SERVICE::LOG_REPLICATED].vdev_size_type}},
+                                   {HS_SERVICE::LOG_LOCAL,
+                                    {.size_pct = 1,
+                                     .chunk_size = svc_params[HS_SERVICE::LOG_LOCAL].chunk_size,
+                                     .vdev_size_type = svc_params[HS_SERVICE::LOG_LOCAL].vdev_size_type}},
+                                   {HS_SERVICE::DATA,
+                                    {.size_pct = svc_params[HS_SERVICE::DATA].size_pct,
+                                     .num_chunks = svc_params[HS_SERVICE::DATA].num_chunks,
+                                     .alloc_type = svc_params[HS_SERVICE::DATA].blkalloc_type,
+                                     .chunk_sel_type = svc_params[HS_SERVICE::DATA].custom_chunk_selector
+                                         ? chunk_selector_type_t::CUSTOM
+                                         : chunk_selector_type_t::ROUND_ROBIN}},
+                                   {HS_SERVICE::INDEX, {.size_pct = svc_params[HS_SERVICE::INDEX].size_pct}},
+                                   {HS_SERVICE::REPLICATION,
+                                    {.size_pct = svc_params[HS_SERVICE::REPLICATION].size_pct,
+                                     .alloc_type = svc_params[HS_SERVICE::REPLICATION].blkalloc_type,
+                                     .chunk_sel_type = svc_params[HS_SERVICE::REPLICATION].custom_chunk_selector
+                                         ? chunk_selector_type_t::CUSTOM
+                                         : chunk_selector_type_t::ROUND_ROBIN}}});
         }
     }
 

--- a/src/tests/test_log_store.cpp
+++ b/src/tests/test_log_store.cpp
@@ -436,8 +436,8 @@ public:
         test_common::HSTestHelper::start_homestore(
             "test_log_store",
             {{HS_SERVICE::META, {.size_pct = 5.0}},
-             {HS_SERVICE::LOG_REPLICATED, {.size_pct = 42.0}},
-             {HS_SERVICE::LOG_LOCAL, {.size_pct = 42.0}}},
+             {HS_SERVICE::LOG_REPLICATED, {.size_pct = 5.0, .chunk_size = 32 * 1024 * 1024}},
+             {HS_SERVICE::LOG_LOCAL, {.size_pct = 5.0, .chunk_size = 32 * 1024 * 1024}}},
             [this, restart, n_log_stores]() {
                 if (restart) {
                     for (uint32_t i{0}; i < n_log_stores; ++i) {


### PR DESCRIPTION
Ability to add chunks to a journal vdev dynamically. Create pool of chunks and maintain a list of chunks sliding window. Add api to create chunk. Chunks part of journal vdev are connected like singly linked list with next_chunk in private data. Chunks part of journal vdv have private data. Journal vdev can give independent descriptors to the user to do alloc write and truncate. Modified tests to support this.

Changes made.
1. Earlier only 2 journalvdev were there (data and control) and took fixed size and numchunks. Now user can only provide chunk size and we add chunks dynamically once vdev is full. Most of the state of the list of chunks and its offsets were maintained in the JournalVDev class now its moved to its inner class JournalVDev::Descriptor. Now a single JournalVDev can create multiple descriptors. Each descriptor now maintains the list of chunks, its offsets etc. User call open to create different descriptors.
2. Earlier the offsets of the sliding window could wrap around due to the fixed number of chunks. But now they only increase. Both the left and right side of the window increase. Truncate will increase the left and append blk will increase the right offset.
3. Add a chunk pool in journal vdev so that its faster to append a new chunk to the list.
4. Changes in device_manager is to support to start with zero chunks and api to create and remove single chunk.
5. Test code is almost same. Earlier the api were tested against a JournalVirtualDev but now its against a JournalVirtualDev::Descriptor. Added recovery test case.
6. JournalVDev ......................   Passed   38.81 sec