### PR TITLE
fix dirty buf uninit issue

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "4.9.2"
+    version = "4.9.3"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/blkalloc/append_blk_allocator.cpp
+++ b/src/lib/blkalloc/append_blk_allocator.cpp
@@ -41,6 +41,10 @@ AppendBlkAllocator::AppendBlkAllocator(const BlkAllocConfig& cfg, bool need_form
     m_sb->last_append_offset = m_last_append_offset;
     m_sb->freeable_nblks = m_freeable_nblks;
 
+    for (auto i = 0ul; i < m_dirty_sb.size(); ++i) {
+        m_dirty_sb[i].is_dirty = false;
+    }
+
     // for recovery boot, fields will also be recovered from metablks;
 }
 


### PR DESCRIPTION
The bug is without initialization of the dirty buffer, it is left with garbage data. 
when cp flushes, it could mistakenly treating it is dirty and flushing garbage offset into metablk.