### PR TITLE
SDSTOR-12187 :  PartitionUtilization Endpoint

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.6.12"
+    version = "3.6.13"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/api/vol_interface.hpp
+++ b/src/api/vol_interface.hpp
@@ -316,6 +316,7 @@ public:
 
     virtual const char* get_name(const VolumePtr& vol) = 0;
     virtual uint64_t get_size(const VolumePtr& vol) = 0;
+    virtual uint64_t get_used_size(const VolumePtr& vol) = 0;
     virtual uint64_t get_page_size(const VolumePtr& vol) = 0;
     virtual boost::uuids::uuid get_uuid(std::shared_ptr< Volume > vol) = 0;
     virtual sisl::blob at_offset(const boost::intrusive_ptr< BlkBuffer >& buf, uint32_t offset) = 0;

--- a/src/homeblks/home_blks.cpp
+++ b/src/homeblks/home_blks.cpp
@@ -634,6 +634,11 @@ bool HomeBlks::verify_index_bm() {
     return true;
 }
 
+uint64_t HomeBlks::get_used_size(const VolumePtr& vol) {
+    /* Update per volume status */
+   return  vol->get_used_size().used_total_size;
+}
+
 sisl::status_response HomeBlks::get_status(const sisl::status_request& request) {
     sisl::status_response response;
     /* Update per volume status */

--- a/src/homeblks/home_blks.hpp
+++ b/src/homeblks/home_blks.hpp
@@ -232,6 +232,7 @@ public:
     virtual const char* get_name(const VolumePtr& vol) override;
     virtual uint64_t get_page_size(const VolumePtr& vol) override;
     virtual uint64_t get_size(const VolumePtr& vol) override;
+    virtual uint64_t get_used_size(const VolumePtr& vol) override;
     virtual boost::uuids::uuid get_uuid(VolumePtr vol) override;
     virtual sisl::blob at_offset(const blk_buf_t& buf, uint32_t offset) override;
 

--- a/src/homeblks/homeblks_http_server.hpp
+++ b/src/homeblks/homeblks_http_server.hpp
@@ -51,6 +51,7 @@ public:
     void verify_metablk_store(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void wakeup_init(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void copy_vol(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
+    void get_utilization(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
 
 #ifdef _PRERELEASE
     void set_safe_mode(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);


### PR DESCRIPTION
Expose PartitionUtilization as volume used size divided by AM total size

### Testing: 
in one terminal, run 
`bin/test_volume --gtest_filter=VolTest.init_io_test --remove_file_on_shutdown=1 --delete_volume=1 --run_time=10000 --http_port=5000 --max_volume=1  --p_volume_size=100 --max_disk_capacity=1 `

in another terminal, run the below command to get the volume uuid:
`nublox-tools/AM/hs_http_cli_tool.py  get_object --name test_files/vol0`

run the below API command:
`curl http://localhost:5000/api/v1/utilization/[volumeUUID]`
