### PR TITLE
add lsof to Jenkins

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -10,6 +10,7 @@ RUN set -eux; \
     apt-get upgrade -y; \
     apt-get install iputils-ping; \
     apt-get install net-tools; \
+    apt-get install lsof; \
     rm -rf /var/lib/apt/lists/*;
 
 COPY test_index_btree /usr/local/bin/test_index_btree


### PR DESCRIPTION
`lsof` is used to identify whether the ports(default 4000, 4001 , 4002) for raft_repl_dev_test are occupied by other processes(ussually the previous raft_repl_dev_test which is ended abnormally, and the legacy process will occupy these port)