### PR TITLE
SDSTOR-12187 : PartitionUtilization Endpoint (multi volume version)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.6.13"
+    version = "3.6.14"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/api/vol_interface.hpp
+++ b/src/api/vol_interface.hpp
@@ -316,7 +316,7 @@ public:
 
     virtual const char* get_name(const VolumePtr& vol) = 0;
     virtual uint64_t get_size(const VolumePtr& vol) = 0;
-    virtual uint64_t get_used_size(const VolumePtr& vol) = 0;
+    virtual std::map<boost::uuids::uuid, uint64_t> get_used_size(const VolumePtr& vol) = 0;
     virtual uint64_t get_page_size(const VolumePtr& vol) = 0;
     virtual boost::uuids::uuid get_uuid(std::shared_ptr< Volume > vol) = 0;
     virtual sisl::blob at_offset(const boost::intrusive_ptr< BlkBuffer >& buf, uint32_t offset) = 0;

--- a/src/homeblks/home_blks.cpp
+++ b/src/homeblks/home_blks.cpp
@@ -634,9 +634,21 @@ bool HomeBlks::verify_index_bm() {
     return true;
 }
 
-uint64_t HomeBlks::get_used_size(const VolumePtr& vol) {
+std::map<boost::uuids::uuid, uint64_t> HomeBlks::get_used_size(const VolumePtr& vol) {
     /* Update per volume status */
-   return  vol->get_used_size().used_total_size;
+    std::map<boost::uuids::uuid, uint64_t> utils_map;
+    std::unique_lock< std::recursive_mutex > lg(m_vol_lock);
+    if (vol == nullptr){
+        auto it{m_volume_map.begin()};
+        while (it != m_volume_map.end()) {
+            const VolumePtr& vol{it->second};
+            utils_map[it->first] = vol->get_used_size().used_total_size;
+            ++it;
+        }
+    } else {
+        utils_map[vol->get_uuid()] = vol->get_used_size().used_total_size;
+    }
+   return  utils_map;
 }
 
 sisl::status_response HomeBlks::get_status(const sisl::status_request& request) {

--- a/src/homeblks/home_blks.hpp
+++ b/src/homeblks/home_blks.hpp
@@ -232,7 +232,7 @@ public:
     virtual const char* get_name(const VolumePtr& vol) override;
     virtual uint64_t get_page_size(const VolumePtr& vol) override;
     virtual uint64_t get_size(const VolumePtr& vol) override;
-    virtual uint64_t get_used_size(const VolumePtr& vol) override;
+    virtual std::map<boost::uuids::uuid, uint64_t> get_used_size(const VolumePtr& vol) override;
     virtual boost::uuids::uuid get_uuid(VolumePtr vol) override;
     virtual sisl::blob at_offset(const blk_buf_t& buf, uint32_t offset) override;
 

--- a/src/homeblks/homeblks_http_server.cpp
+++ b/src/homeblks/homeblks_http_server.cpp
@@ -77,6 +77,8 @@ void HomeBlksHttpServer::setup_routes() {
                                      Routes::bind(&HomeBlksHttpServer::get_status, this));
         http_server_ptr->setup_route(Http::Method::Get, "/api/v1/utilization/:volumeUUID",
                                      Routes::bind(&HomeBlksHttpServer::get_utilization, this));
+        http_server_ptr->setup_route(Http::Method::Get, "/api/v1/utilization",
+                                     Routes::bind(&HomeBlksHttpServer::get_utilization, this));
         http_server_ptr->setup_route(Http::Method::Get, "/api/v1/verifyBitmap",
                                      Routes::bind(&HomeBlksHttpServer::verify_bitmap, this), iomgr::url_t::localhost);
         http_server_ptr->setup_route(Http::Method::Get, "/api/v1/dumpDiskMetaBlks",
@@ -155,23 +157,24 @@ void HomeBlksHttpServer::set_log_level(const Pistache::Rest::Request& request,
 }
 void HomeBlksHttpServer::get_utilization(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response)
 {
-    const std::string vol_uuid{request.param(":volumeUUID").as<std::string>()};
-    if (vol_uuid.length() == 0) {
-        response.send(Pistache::Http::Code::Bad_Request, "empty vol_uuid!");
-        return;
-    }
+    const std::string vol_uuid = request.hasParam(":volumeUUID") ? request.param(":volumeUUID").as<std::string>():"";
 
-    boost::uuids::string_generator gen;
-    boost::uuids::uuid uuid = gen(vol_uuid);
-    const auto vol = VolInterface::get_instance()->lookup_volume(uuid);
-    if (!vol) {
-        response.send(Pistache::Http::Code::Bad_Request, "vol not found!");
-        return;
+    VolumePtr vol = nullptr;
+    if (vol_uuid.length() != 0) {
+        boost::uuids::string_generator gen;
+        boost::uuids::uuid uuid = gen(vol_uuid);
+        vol = VolInterface::get_instance()->lookup_volume(uuid);
+        if (!vol) {
+            response.send(Pistache::Http::Code::Bad_Request, "vol not found!");
+            return;
+        }
     }
+    nlohmann::json resp;
     const auto total_data_size = VolInterface::get_instance()->get_system_capacity().initial_total_data_meta_size;
-    const auto vol_used = VolInterface::get_instance()->get_used_size(vol);
-    auto resp = std::to_string(static_cast<double> (vol_used) / total_data_size);
-    response.send(Pistache::Http::Code::Ok, resp);
+    for (auto [uuid, vol_used] : VolInterface::get_instance()->get_used_size(vol)) {
+        resp[boost::uuids::to_string(uuid)] = std::to_string(static_cast<double> (vol_used)/ total_data_size);
+    }
+    response.send(Pistache::Http::Code::Ok, resp.dump());
 }
 void HomeBlksHttpServer::get_log_level(const Pistache::Rest::Request& request,
                                        Pistache::Http::ResponseWriter response) {


### PR DESCRIPTION
Expose PartitionUtilization as volume used size divided by AM total size

### Testing:
in one terminal, run
bin/test_volume --gtest_filter=VolTest.init_io_test --remove_file_on_shutdown=1 --delete_volume=1 --run_time=10000 --http_port=5000 --max_volume=1  --p_volume_size=100 --max_disk_capacity=1 

in another terminal, run the below command to get the volume uuid:
nublox-tools/AM/hs_http_cli_tool.py  get_object --name test_files/vol0

run the below API command:
curl http://localhost:5000/api/v1/utilization/[volumeUUID]
curl http://localhost:5000/api/v1/utilization
### example output:

> curl http://localhost:5000/api/v1/utilization | jq .

{
  "14db582f-fd5d-4f0c-996c-3e12d9978867": "0.000000",
  "2b4d26f0-e6a6-49c7-8cb5-55d2048c34f7": "0.000000",
  "3b229301-7c6f-4ef0-bd9b-9439c76b20af": "0.000001",
  "7780c654-5633-4dcd-ad68-4afd1accb15e": "0.000037"
}


curl http://localhost:5000/api/v1/utilization/7780c654-5633-4dcd-ad68-4afd1accb15e | jq .

{
  "7780c654-5633-4dcd-ad68-4afd1accb15e": "0.000037"
}
     

