### PR TITLE
Restartability of ReplDev

### DIFF
--- a/src/include/homestore/checkpoint/cp_mgr.hpp
+++ b/src/include/homestore/checkpoint/cp_mgr.hpp
@@ -160,7 +160,13 @@ public:
     CPManager();
     virtual ~CPManager();
 
+    /// @brief Start the CPManager, which creates a first cp session.
+    /// @param first_time_boot
     void start(bool first_time_boot);
+
+    /// @brief Start the cp timer so that periodic cps are started
+    void start_timer();
+
     /// @brief Shutdown the checkpoint manager services. It will not trigger a flush, but cancels any existing
     /// checkpoint session abruptly. If caller needs clean shutdown, then they explicitly needs to trigger cp flush
     /// before calling shutdown.

--- a/src/include/homestore/logstore_service.hpp
+++ b/src/include/homestore/logstore_service.hpp
@@ -92,8 +92,7 @@ public:
      *
      * @return std::shared_ptr< HomeLogStore >
      */
-    std::shared_ptr< HomeLogStore > create_new_log_store(const logstore_family_id_t family_id,
-                                                         const bool append_mode = false);
+    shared< HomeLogStore > create_new_log_store(logstore_family_id_t family_id, bool append_mode = false);
 
     /**
      * @brief Open an existing log store and does a recovery. It then creates an instance of this logstore and
@@ -102,8 +101,8 @@ public:
      * @param store_id: Store ID of the log store to open
      * @return std::shared_ptr< HomeLogStore >
      */
-    void open_log_store(const logstore_family_id_t family_id, const logstore_id_t store_id, const bool append_mode,
-                        const log_store_opened_cb_t& on_open_cb);
+    folly::Future< shared< HomeLogStore > > open_log_store(logstore_family_id_t family_id, logstore_id_t store_id,
+                                                           bool append_mode);
 
     /**
      * @brief Close the log store instance and free-up the resources

--- a/src/include/homestore/replication/repl_decls.h
+++ b/src/include/homestore/replication/repl_decls.h
@@ -3,6 +3,8 @@
 #include <string>
 
 #include <folly/small_vector.h>
+#include <folly/futures/Future.h>
+
 #include <sisl/logging/logging.h>
 #include <homestore/homestore_decl.hpp>
 #include <homestore/blk.h>
@@ -13,6 +15,39 @@ SISL_LOGGING_DECL(replication)
 #define REPL_LOG_MODS grpc_server, HOMESTORE_LOG_MODS, nuraft_mesg, nuraft, replication
 
 namespace homestore {
+// clang-format off
+VENUM(ReplServiceError, int32_t,
+      OK = 0,         // Everything OK
+      CANCELLED = -1, // Request was cancelled
+      TIMEOUT = -2, 
+      NOT_LEADER = -3, 
+      BAD_REQUEST = -4, 
+      SERVER_ALREADY_EXISTS = -5, 
+      CONFIG_CHANGING = -6,
+      SERVER_IS_JOINING = -7, 
+      SERVER_NOT_FOUND = -8, 
+      CANNOT_REMOVE_LEADER = -9, 
+      SERVER_IS_LEAVING = -10,
+      TERM_MISMATCH = -11, 
+      RESULT_NOT_EXIST_YET = -10000, 
+      NOT_IMPLEMENTED = -10001,
+      NO_SPACE_LEFT = -20000,
+      DRIVE_WRITE_ERROR = -20001,
+      FAILED = -32768);
+// clang-format on
+
+template < typename V, typename E >
+using Result = folly::Expected< V, E >;
+
+template < class V >
+using ReplResult = Result< V, ReplServiceError >;
+
+template < class V, class E >
+using AsyncResult = folly::SemiFuture< Result< V, E > >;
+
+template < class V = folly::Unit >
+using AsyncReplResult = AsyncResult< V, ReplServiceError >;
+
 using blkid_list_t = folly::small_vector< BlkId, 4 >;
 
 // Fully qualified domain pba, unique pba id across replica set

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -4,47 +4,15 @@
 #include <string>
 #include <variant>
 
-#include <folly/futures/Future.h>
 #include <sisl/utility/enum.hpp>
 #include <homestore/replication/repl_decls.h>
 #include <homestore/meta_service.hpp>
 
 namespace homestore {
 
-// clang-format off
-VENUM(ReplServiceError, int32_t,
-      OK = 0,         // Everything OK
-      CANCELLED = -1, // Request was cancelled
-      TIMEOUT = -2, 
-      NOT_LEADER = -3, 
-      BAD_REQUEST = -4, 
-      SERVER_ALREADY_EXISTS = -5, 
-      CONFIG_CHANGING = -6,
-      SERVER_IS_JOINING = -7, 
-      SERVER_NOT_FOUND = -8, 
-      CANNOT_REMOVE_LEADER = -9, 
-      SERVER_IS_LEAVING = -10,
-      TERM_MISMATCH = -11, 
-      RESULT_NOT_EXIST_YET = -10000, 
-      NOT_IMPLEMENTED = -10001,
-      FAILED = -32768);
-// clang-format on
-
 class ReplDev;
 class ReplDevListener;
 struct hs_stats;
-
-template < typename V, typename E >
-using Result = folly::Expected< V, E >;
-
-template < class V >
-using ReplResult = Result< V, ReplServiceError >;
-
-template < class V, class E >
-using AsyncResult = folly::SemiFuture< Result< V, E > >;
-
-template < class V = folly::Unit >
-using AsyncReplResult = AsyncResult< V, ReplServiceError >;
 
 VENUM(repl_impl_type, uint8_t,
       server_side,     // Completely homestore controlled replication

--- a/src/lib/checkpoint/cp_mgr.cpp
+++ b/src/lib/checkpoint/cp_mgr.cpp
@@ -50,7 +50,9 @@ void CPManager::start(bool first_time_boot) {
         create_first_cp();
         m_sb.write();
     }
+}
 
+void CPManager::start_timer() {
     LOGINFO("cp timer is set to {} usec", HS_DYNAMIC_CONFIG(generic.cp_timer_us));
     m_cp_timer_hdl = iomanager.schedule_global_timer(
         HS_DYNAMIC_CONFIG(generic.cp_timer_us) * 1000, true, nullptr /*cookie*/, iomgr::reactor_regex::all_worker,

--- a/src/lib/logstore/log_store_service.cpp
+++ b/src/lib/logstore/log_store_service.cpp
@@ -103,18 +103,18 @@ void LogStoreService::stop() {
     }
 }
 
-std::shared_ptr< HomeLogStore > LogStoreService::create_new_log_store(const logstore_family_id_t family_id,
-                                                                      const bool append_mode) {
+shared< HomeLogStore > LogStoreService::create_new_log_store(const logstore_family_id_t family_id,
+                                                             const bool append_mode) {
     HS_REL_ASSERT_LT(family_id, num_log_families);
     COUNTER_INCREMENT(m_metrics, logstores_count, 1);
     return m_logstore_families[family_id]->create_new_log_store(append_mode);
 }
 
-void LogStoreService::open_log_store(const logstore_family_id_t family_id, const logstore_id_t store_id,
-                                     const bool append_mode, const log_store_opened_cb_t& on_open_cb) {
+folly::Future< shared< HomeLogStore > > LogStoreService::open_log_store(logstore_family_id_t family_id,
+                                                                        logstore_id_t store_id, bool append_mode) {
     HS_REL_ASSERT_LT(family_id, num_log_families);
     COUNTER_INCREMENT(m_metrics, logstores_count, 1);
-    return m_logstore_families[family_id]->open_log_store(store_id, append_mode, on_open_cb);
+    return m_logstore_families[family_id]->open_log_store(store_id, append_mode);
 }
 
 void LogStoreService::remove_log_store(const logstore_family_id_t family_id, const logstore_id_t store_id) {

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -38,11 +38,12 @@ RaftReplDev::RaftReplDev(RaftReplService& svc, superblk< raft_repl_dev_superblk 
         }
 
         if (m_rd_sb->is_timeline_consistent) {
-            logstore_service().open_log_store(LogStoreService::CTRL_LOG_FAMILY_IDX, m_rd_sb->free_blks_journal_id,
-                                              false, [this](shared< HomeLogStore > log_store) {
-                                                  m_free_blks_journal = std::move(log_store);
-                                                  m_rd_sb->free_blks_journal_id = m_free_blks_journal->get_store_id();
-                                              });
+            logstore_service()
+                .open_log_store(LogStoreService::CTRL_LOG_FAMILY_IDX, m_rd_sb->free_blks_journal_id, false)
+                .thenValue([this](auto log_store) {
+                    m_free_blks_journal = std::move(log_store);
+                    m_rd_sb->free_blks_journal_id = m_free_blks_journal->get_store_id();
+                });
         }
     } else {
         m_data_journal = std::make_shared< ReplLogStore >(*this, *m_state_machine);
@@ -66,6 +67,18 @@ RaftReplDev::RaftReplDev(RaftReplService& svc, superblk< raft_repl_dev_superblk 
     // m_msg_mgr.bind_data_service_request(FETCH_DATA, m_group_id, bind_this(RaftReplDev::on_fetch_data_received, 2));
 }
 
+bool RaftReplDev::join_group() {
+    auto raft_result =
+        m_msg_mgr.join_group(m_group_id, "homestore_replication",
+                             std::dynamic_pointer_cast< nuraft_mesg::mesg_state_mgr >(shared_from_this()));
+    if (!raft_result) {
+        HS_DBG_ASSERT(false, "Unable to join the group_id={} with error={}", boost::uuids::to_string(m_group_id),
+                      raft_result.error());
+        return false;
+    }
+    return true;
+}
+
 void RaftReplDev::use_config(json_superblk raft_config_sb) { m_raft_config_sb = std::move(raft_config_sb); }
 
 void RaftReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& key, sisl::sg_list const& value,
@@ -85,18 +98,29 @@ void RaftReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& 
         auto status = data_service().alloc_blks(uint32_cast(rreq->value.size),
                                                 m_listener->get_blk_alloc_hints(rreq->header, rreq->value.size),
                                                 rreq->local_blkid);
-        HS_REL_ASSERT_EQ(status, BlkAllocStatus::SUCCESS);
+        if (status != BlkAllocStatus::SUCCESS) {
+            HS_DBG_ASSERT_EQ(status, BlkAllocStatus::SUCCESS, "Unable to allocate blks");
+            handle_error(rreq, ReplServiceError::NO_SPACE_LEFT);
+            return;
+        }
+        rreq->state.fetch_or(uint32_cast(repl_req_state_t::BLK_ALLOCATED));
 
         // Write the data
         data_service().async_write(rreq->value, rreq->local_blkid).thenValue([this, rreq](auto&& err) {
-            HS_REL_ASSERT(!err, "Error in writing data"); // TODO: Find a way to return error to the Listener
-            rreq->state.fetch_or(uint32_cast(repl_req_state_t::DATA_WRITTEN));
-            m_state_machine->propose_to_raft(std::move(rreq));
+            if (!err) {
+                rreq->state.fetch_or(uint32_cast(repl_req_state_t::DATA_WRITTEN));
+                auto raft_status = m_state_machine->propose_to_raft(std::move(rreq));
+                if (raft_status != ReplServiceError::OK) { handle_error(rreq, raft_status); }
+            } else {
+                HS_DBG_ASSERT(false, "Error in writing data");
+                handle_error(rreq, ReplServiceError::DRIVE_WRITE_ERROR);
+            }
         });
     } else {
         RD_LOG(INFO, "Skipping data channel send since value size is 0");
         rreq->state.fetch_or(uint32_cast(repl_req_state_t::DATA_WRITTEN));
-        m_state_machine->propose_to_raft(std::move(rreq));
+        auto raft_status = m_state_machine->propose_to_raft(std::move(rreq));
+        if (raft_status != ReplServiceError::OK) { handle_error(rreq, raft_status); }
     }
 }
 
@@ -120,13 +144,58 @@ void RaftReplDev::push_data_to_all_followers(repl_req_ptr_t rreq) {
 
     group_msg_service()
         ->data_service_request_unidirectional(nuraft_mesg::role_regex::ALL, PUSH_DATA, rreq->pkts)
-        .via(&folly::InlineExecutor::instance())
-        .thenValue([this, rreq = std::move(rreq)](auto e) {
+        .deferValue([this, rreq = std::move(rreq)](auto e) {
+            if (e.hasError()) {
+                RD_LOG(ERROR, "Data Channel: Error in pushing data to all followers: rreq=[{}] error={}",
+                       rreq->to_compact_string(), e.error());
+                handle_error(rreq, RaftReplService::to_repl_error(e.error()));
+                return;
+            }
             // Release the buffer which holds the packets
             RD_LOG(INFO, "Data Channel: Data push completed for rreq=[{}]", rreq->to_compact_string());
             rreq->fb_builder.Release();
             rreq->pkts.clear();
         });
+}
+
+void RaftReplDev::handle_error(repl_req_ptr_t const& rreq, ReplServiceError err) {
+    if (err == ReplServiceError::OK) { return; }
+
+    auto s = rreq->state.load();
+    if ((s & uint32_cast(repl_req_state_t::ERRORED)) ||
+        !(rreq->state.compare_exchange_strong(s, s | uint32_cast(repl_req_state_t::ERRORED)))) {
+        RD_LOG(INFO, "Raft Channel: Error in processing rreq=[{}] error={} already errored", rreq->to_compact_string(),
+               err);
+        return;
+    }
+
+    // Free the blks which is allocated already
+    RD_LOG(INFO, "Raft Channel: Error in processing rreq=[{}] error={}", rreq->to_compact_string(), err);
+    if (rreq->state.load() & uint32_cast(repl_req_state_t::BLK_ALLOCATED)) {
+        auto blkid = rreq->local_blkid;
+        data_service().async_free_blk(blkid).thenValue([blkid](auto&& err) {
+            HS_LOG_ASSERT(!err, "freeing blkid={} upon error failed, potential to cause blk leak", blkid.to_string());
+        });
+    }
+
+    HS_DBG_ASSERT(!(rreq->state.load() & uint32_cast(repl_req_state_t::LOG_FLUSHED)),
+                  "Unexpected state, received error after log is flushed for rreq=[{}]", rreq->to_compact_string());
+
+    if (rreq->is_proposer) {
+        // Notify the proposer about the error
+        m_listener->on_error(err, rreq->header, rreq->key, rreq);
+        rreq->fb_builder.Release();
+        rreq->pkts.clear();
+    } else {
+        // Complete the response hence proposer can free up its resources
+        rreq->header = sisl::blob{};
+        rreq->key = sisl::blob{};
+        rreq->pkts = sisl::io_blob_list_t{};
+        if (rreq->rpc_data) {
+            rreq->rpc_data->send_response();
+            rreq->rpc_data = nullptr;
+        }
+    }
 }
 
 void RaftReplDev::on_push_data_received(intrusive< sisl::GenericRpcData >& rpc_data) {
@@ -171,10 +240,14 @@ void RaftReplDev::on_push_data_received(intrusive< sisl::GenericRpcData >& rpc_d
     data_service()
         .async_write(r_cast< const char* >(data), push_req->data_size(), rreq->local_blkid)
         .thenValue([this, rreq](auto&& err) {
-            RD_REL_ASSERT(!err, "Error in writing data"); // TODO: Find a way to return error to the Listener
-            rreq->state.fetch_or(uint32_cast(repl_req_state_t::DATA_WRITTEN));
-            rreq->data_written_promise.setValue();
-            RD_LOG(INFO, "Data Channel: Data Write completed rreq=[{}]", rreq->to_compact_string());
+            if (err) {
+                RD_DBG_ASSERT(false, "Error in writing data");
+                handle_error(rreq, ReplServiceError::DRIVE_WRITE_ERROR);
+            } else {
+                rreq->state.fetch_or(uint32_cast(repl_req_state_t::DATA_WRITTEN));
+                rreq->data_written_promise.setValue();
+                RD_LOG(INFO, "Data Channel: Data Write completed rreq=[{}]", rreq->to_compact_string());
+            }
         });
 }
 
@@ -287,6 +360,16 @@ void RaftReplDev::async_free_blks(int64_t, MultiBlkId const& bid) {
     // TODO: For timeline consistency required, we should retain the blkid that is changed and write that to another
     // journal.
     data_service().async_free_blk(bid);
+}
+
+AsyncReplResult<> RaftReplDev::become_leader() {
+    return m_msg_mgr.become_leader(m_group_id).deferValue([this](auto&& e) {
+        if (e.hasError()) {
+            RD_LOG(ERROR, "Error in becoming leader: {}", e.error());
+            return make_async_error<>(RaftReplService::to_repl_error(e.error()));
+        }
+        return make_async_success<>();
+    });
 }
 
 bool RaftReplDev::is_leader() const { return m_repl_svc_ctx->is_raft_leader(); }
@@ -418,6 +501,8 @@ void RaftReplDev::leave() {
 
 ///////////////////////////////////  Private metohds ////////////////////////////////////
 void RaftReplDev::report_committed(repl_req_ptr_t rreq) {
+    if (rreq->local_blkid.is_valid()) { data_service().commit_blk(rreq->local_blkid); }
+
     auto prev_lsn = m_commit_upto_lsn.exchange(rreq->lsn);
     RD_DBG_ASSERT_GT(rreq->lsn, prev_lsn, "Out of order commit of lsns, it is not expected in RaftReplDev");
 

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -31,7 +31,9 @@ using raft_buf_ptr_t = nuraft::ptr< nuraft::buffer >;
 
 class RaftReplService;
 class CP;
-class RaftReplDev : public ReplDev, public nuraft_mesg::mesg_state_mgr {
+class RaftReplDev : public ReplDev,
+                    public nuraft_mesg::mesg_state_mgr,
+                    public std::enable_shared_from_this< RaftReplDev > {
 private:
     shared< RaftStateMachine > m_state_machine;
     RaftReplService& m_repl_svc;
@@ -64,6 +66,7 @@ public:
     RaftReplDev(RaftReplService& svc, superblk< raft_repl_dev_superblk >&& rd_sb, bool load_existing);
     virtual ~RaftReplDev() = default;
 
+    bool join_group();
     void destroy();
 
     //////////////// All ReplDev overrides/implementation ///////////////////////
@@ -72,6 +75,7 @@ public:
     folly::Future< std::error_code > async_read(MultiBlkId const& blkid, sisl::sg_list& sgs, uint32_t size,
                                                 bool part_of_batch = false) override;
     void async_free_blks(int64_t lsn, MultiBlkId const& blkid) override;
+    AsyncReplResult<> become_leader() override;
     bool is_leader() const override;
     group_id_t group_id() const override { return m_group_id; }
     std::string group_id_str() const { return boost::uuids::to_string(m_group_id); }
@@ -113,6 +117,7 @@ private:
     shared< nuraft::log_store > data_journal() { return m_data_journal; }
     void push_data_to_all_followers(repl_req_ptr_t rreq);
     void on_push_data_received(intrusive< sisl::GenericRpcData >& rpc_data);
+    void handle_error(repl_req_ptr_t const& rreq, ReplServiceError err);
 };
 
 } // namespace homestore

--- a/src/lib/replication/repl_dev/raft_state_machine.h
+++ b/src/lib/replication/repl_dev/raft_state_machine.h
@@ -108,7 +108,7 @@ public:
     nuraft::ptr< nuraft::snapshot > last_snapshot() override { return nullptr; }
 
     ////////// APIs outside of nuraft::state_machine requirements ////////////////////
-    void propose_to_raft(repl_req_ptr_t rreq);
+    ReplServiceError propose_to_raft(repl_req_ptr_t rreq);
     repl_req_ptr_t transform_journal_entry(nuraft::ptr< nuraft::log_entry >& lentry);
     void link_lsn_to_req(repl_req_ptr_t rreq, int64_t lsn);
     repl_req_ptr_t lsn_to_req(int64_t lsn);

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -10,20 +10,19 @@ namespace homestore {
 SoloReplDev::SoloReplDev(superblk< repl_dev_superblk >&& rd_sb, bool load_existing) :
         m_rd_sb{std::move(rd_sb)}, m_group_id{m_rd_sb->group_id} {
     if (load_existing) {
-        logstore_service().open_log_store(LogStoreService::DATA_LOG_FAMILY_IDX, m_rd_sb->data_journal_id, true,
-                                          bind_this(SoloReplDev::on_data_journal_created, 1));
+        logstore_service()
+            .open_log_store(LogStoreService::DATA_LOG_FAMILY_IDX, m_rd_sb->data_journal_id, true /* append_mode */)
+            .thenValue([this](auto log_store) {
+                m_data_journal = std::move(log_store);
+                m_rd_sb->data_journal_id = m_data_journal->get_store_id();
+                m_data_journal->register_log_found_cb(bind_this(SoloReplDev::on_log_found, 3));
+            });
     } else {
         m_data_journal =
             logstore_service().create_new_log_store(LogStoreService::DATA_LOG_FAMILY_IDX, true /* append_mode */);
         m_rd_sb->data_journal_id = m_data_journal->get_store_id();
         m_rd_sb.write();
     }
-}
-
-void SoloReplDev::on_data_journal_created(shared< HomeLogStore > log_store) {
-    m_data_journal = std::move(log_store);
-    m_rd_sb->data_journal_id = m_data_journal->get_store_id();
-    m_data_journal->register_log_found_cb(bind_this(SoloReplDev::on_log_found, 3));
 }
 
 void SoloReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& key, sisl::sg_list const& value,

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -46,6 +46,7 @@ public:
 
     void async_free_blks(int64_t lsn, MultiBlkId const& blkid) override;
 
+    AsyncReplResult<> become_leader() override { return make_async_error(ReplServiceError::OK); }
     bool is_leader() const override { return true; }
 
     uuid_t group_id() const override { return m_group_id; }
@@ -56,7 +57,6 @@ public:
     void cp_cleanup(CP* cp);
 
 private:
-    void on_data_journal_created(shared< HomeLogStore > log_store);
     void write_journal(repl_req_ptr_t rreq);
     void on_log_found(logstore_seq_num_t lsn, log_buffer buf, void* ctx);
 };

--- a/src/lib/replication/service/generic_repl_svc.h
+++ b/src/lib/replication/service/generic_repl_svc.h
@@ -41,6 +41,7 @@ protected:
     std::shared_mutex m_rd_map_mtx;
     std::map< group_id_t, shared< ReplDev > > m_rd_map;
     replica_id_t m_my_uuid;
+    std::vector< std::pair< sisl::byte_view, void* > > m_sb_bufs;
 
 public:
     static std::shared_ptr< GenericReplService > create(cshared< ReplApplication >& repl_app);
@@ -65,6 +66,7 @@ class SoloReplService : public GenericReplService {
 public:
     SoloReplService(cshared< ReplApplication >& repl_app);
     void start() override;
+    void stop() override;
 
     AsyncReplResult< shared< ReplDev > > create_repl_dev(group_id_t group_id,
                                                          std::set< replica_id_t > const& members) override;

--- a/src/lib/replication/service/raft_repl_service.h
+++ b/src/lib/replication/service/raft_repl_service.h
@@ -37,6 +37,7 @@ class RaftReplService : public GenericReplService,
 private:
     shared< nuraft_mesg::Manager > m_msg_mgr;
     json_superblk m_config_sb;
+    std::vector< std::pair< sisl::byte_view, void* > > m_config_sb_bufs;
 
 public:
     RaftReplService(cshared< ReplApplication >& repl_app);
@@ -52,6 +53,8 @@ public:
 protected:
     ///////////////////// Overrides of GenericReplService ////////////////////
     void start() override;
+    void stop() override;
+
     AsyncReplResult< shared< ReplDev > > create_repl_dev(group_id_t group_id,
                                                          std::set< replica_id_t > const& members) override;
     void load_repl_dev(sisl::byte_view const& buf, void* meta_cookie) override;

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -171,12 +171,6 @@ public:
         chunk_num_t num_chunks{1};
     };
 
-#if 0
-    static void start_homestore(const std::string& test_name, float meta_pct, float data_log_pct, float ctrl_log_pct,
-                                float data_pct, float index_pct, hs_before_services_starting_cb_t cb,
-                                bool restart = false, std::unique_ptr< IndexServiceCallbacks > index_svc_cb = nullptr,
-                                bool default_data_svc_alloc_type = true);
-#endif
     static void start_homestore(const std::string& test_name, std::map< uint32_t, test_params >&& svc_params,
                                 hs_before_services_starting_cb_t cb = nullptr, bool restart = false) {
         auto const ndevices = SISL_OPTIONS["num_devs"].as< uint32_t >();
@@ -187,6 +181,7 @@ public:
 
         if (restart) {
             shutdown_homestore(false);
+            // sisl::GrpcAsyncClientWorker::shutdown_all();
             std::this_thread::sleep_for(std::chrono::seconds{5});
         }
 

--- a/src/tests/test_log_store.cpp
+++ b/src/tests/test_log_store.cpp
@@ -442,10 +442,9 @@ public:
                 if (restart) {
                     for (uint32_t i{0}; i < n_log_stores; ++i) {
                         SampleLogStoreClient* client = m_log_store_clients[i].get();
-                        logstore_service().open_log_store(client->m_family, client->m_store_id, false /* append_mode */,
-                                                          [i, this, client](std::shared_ptr< HomeLogStore > log_store) {
-                                                              client->set_log_store(log_store);
-                                                          });
+                        logstore_service()
+                            .open_log_store(client->m_family, client->m_store_id, false /* append_mode */)
+                            .thenValue([i, this, client](auto log_store) { client->set_log_store(log_store); });
                     }
                 }
             },

--- a/src/tests/test_solo_repl_dev.cpp
+++ b/src/tests/test_solo_repl_dev.cpp
@@ -121,6 +121,10 @@ public:
             return blk_alloc_hints{};
         }
 
+        void on_error(ReplServiceError error, const sisl::blob& header, const sisl::blob& key,
+                      cintrusive< repl_req_ctx >& ctx) override {
+            LOGINFO("Received error={} on repl_dev", enum_name(error));
+        }
         void on_replica_stop() override {}
     };
 


### PR DESCRIPTION
Following changes are done as part of this commit

1. Because of ordering of services, restart of homestore doesn't recover the ReplDev does not work. Fixed the ordering and also made logstore and data service start/stop inside ReplService start/stop.

2. Error handling was not present, as a result tests failure were hard to comprehend. Added error handling of propose, commit, write failures

3. Aesthetical change to have open_log_store to return future< logstore > instead of callback

4. Added become_leader() call to ReplDev and fixed test cases to utilize that to ensure write happens/issued on correct leader.

5. Added testing to restart, write after restart, validate of ReplDev