### PR TITLE
Fix the wbcache dependency chain issue.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "5.0.5"
+    version = "5.0.6"
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")


### PR DESCRIPTION
Anytime a split of node happens, we create a dependency chain group1 right node -> left node -> parent node. If a split happens again on any of these nodes or they were dirty due to a write, we copy the buffer and create a new chain group2. This group2 should be flushed to disk after the group1. so we mark group2's dependency as group1.  We append the group2 to any node which is modified in group1.  Add the dependency to any dirty buffer which has modification. Either left or parent can be modified, add to the end of it.
