### PR TITLE
Enable clean restart for index UTs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "5.0.6"
+    version = "5.0.7"
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")

--- a/src/include/homestore/btree/btree.hpp
+++ b/src/include/homestore/btree/btree.hpp
@@ -91,6 +91,7 @@ public:
 
     void print_tree(const std::string& file = "") const;
     void print_tree_keys() const;
+    uint64_t count_keys(bnodeid_t bnodeid) const;
 
     nlohmann::json get_metrics_in_json(bool updated = true);
     bnodeid_t root_node_id() const;

--- a/src/tests/btree_helpers/btree_test_helper.hpp
+++ b/src/tests/btree_helpers/btree_test_helper.hpp
@@ -78,7 +78,6 @@ protected:
     std::vector< iomgr::io_fiber_t > m_fibers;
     std::mutex m_test_done_mtx;
     std::condition_variable m_test_done_cv;
-
     std::random_device m_re;
     std::atomic< uint32_t > m_num_ops{0};
 
@@ -298,8 +297,8 @@ public:
         }
     }
 
-    void multi_op_execute(const std::vector< std::pair< std::string, int > >& op_list) {
-        preload(SISL_OPTIONS["preload_size"].as< uint32_t >());
+    void multi_op_execute(const std::vector< std::pair< std::string, int > >& op_list, bool skip_preload = false) {
+        if (!skip_preload) { preload(SISL_OPTIONS["preload_size"].as< uint32_t >()); }
         run_in_parallel(op_list);
     }
 
@@ -389,7 +388,7 @@ protected:
                                [](const auto& pair) { return pair.second; });
 
                 double progress_interval = (double)num_iters_this_fiber / 20; // 5% of the total number of iterations
-                double progress_thresh = progress_interval;                  // threshold for progress interval
+                double progress_thresh = progress_interval;                   // threshold for progress interval
                 double elapsed_time, progress_percent, last_progress_time = 0;
 
                 // Construct a weighted distribution based on the input frequencies

--- a/src/tests/btree_helpers/btree_test_kvs.hpp
+++ b/src/tests/btree_helpers/btree_test_kvs.hpp
@@ -122,6 +122,13 @@ public:
         return os;
     }
 
+    friend std::istream& operator>>(std::istream& is, TestFixedKey& k) {
+        uint64_t key;
+        is >> key;
+        k = TestFixedKey{key};
+        return is;
+    }
+
     bool operator<(const TestFixedKey& o) const { return (compare(o) < 0); }
     bool operator==(const TestFixedKey& other) const { return (compare(other) == 0); }
 
@@ -222,6 +229,13 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const TestVarLenKey& k) {
         os << k.to_string();
         return os;
+    }
+
+    friend std::istream& operator>>(std::istream& is, TestVarLenKey& k) {
+        uint64_t key;
+        is >> key;
+        k = TestVarLenKey{key};
+        return is;
     }
 
     bool operator<(const TestVarLenKey& o) const { return (compare(o) < 0); }
@@ -355,6 +369,15 @@ public:
         os << k.to_string();
         return os;
     }
+
+    friend std::istream& operator>>(std::istream& is, TestIntervalKey& k) {
+        uint32_t m_base;
+        uint32_t m_offset;
+        char dummy;
+        is >> m_base >> dummy >> m_offset;
+        k = TestIntervalKey{m_base, m_offset};
+        return is;
+    }
 };
 
 class TestFixedValue : public BtreeValue {
@@ -388,6 +411,13 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const TestFixedValue& v) {
         os << v.to_string();
         return os;
+    }
+
+    friend std::istream& operator>>(std::istream& is, TestFixedValue& v) {
+        uint32_t value;
+        is >> value;
+        v = TestFixedValue{value};
+        return is;
     }
 
     // This is not mandatory overridden method for BtreeValue, but for testing comparision
@@ -436,6 +466,13 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const TestVarLenValue& v) {
         os << v.to_string();
         return os;
+    }
+
+    friend std::istream& operator>>(std::istream& is, TestVarLenValue& v) {
+        std::string value;
+        is >> value;
+        v = TestVarLenValue{value};
+        return is;
     }
 
     // This is not mandatory overridden method for BtreeValue, but for testing comparision
@@ -487,6 +524,15 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const TestIntervalValue& v) {
         os << v.to_string();
         return os;
+    }
+
+    friend std::istream& operator>>(std::istream& is, TestIntervalValue& v) {
+        uint32_t m_base_val;
+        uint16_t m_offset;
+        char dummy;
+        is >> m_base_val >> dummy >> m_offset;
+        v = TestIntervalValue{m_base_val, m_offset};
+        return is;
     }
 
     ///////////////////////////// Overriding methods of BtreeIntervalValue //////////////////////////

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -180,14 +180,15 @@ public:
                                 bool default_data_svc_alloc_type = true);
 #endif
     static void start_homestore(const std::string& test_name, std::map< uint32_t, test_params >&& svc_params,
-                                hs_before_services_starting_cb_t cb = nullptr, bool restart = false) {
+                                hs_before_services_starting_cb_t cb = nullptr, bool fake_restart = false,
+                                bool init_device = true) {
         auto const ndevices = SISL_OPTIONS["num_devs"].as< uint32_t >();
         auto const dev_size = SISL_OPTIONS["dev_size_mb"].as< uint64_t >() * 1024 * 1024;
         auto num_threads = SISL_OPTIONS["num_threads"].as< uint32_t >();
         auto num_fibers = SISL_OPTIONS["num_fibers"].as< uint32_t >();
         auto is_spdk = SISL_OPTIONS["spdk"].as< bool >();
 
-        if (restart) {
+        if (fake_restart) {
             shutdown_homestore(false);
             std::this_thread::sleep_for(std::chrono::seconds{5});
         }
@@ -210,7 +211,7 @@ public:
                 s_dev_names.emplace_back(std::string{"/tmp/" + test_name + "_" + std::to_string(i + 1)});
             }
 
-            if (!restart) { init_files(s_dev_names, dev_size); }
+            if (!fake_restart && init_device) { init_files(s_dev_names, dev_size); }
             for (const auto& fname : s_dev_names) {
                 device_info.emplace_back(std::filesystem::canonical(fname).string(), homestore::HSDevType::Data);
             }


### PR DESCRIPTION
Load and save shadow map and also enable `init_device `and `cleanup_after_shutdown` in index table. 

### Sample commands for clean restarts:

First run with init device
`bin/test_index_btree --gtest_filter=*/0.ConcurrentAllOps --gtest_break_on_failure  --num_entries=40000 --num_threads=5 --num_fibers=5 --preload_size=20000 --init_device=true --cleanup_after_shutdown=false `

Run the command multiple times
`bin/test_index_btree --gtest_filter=*/0.ConcurrentAllOps --gtest_break_on_failure  --num_entries=40000 --num_threads=5 --num_fibers=5 --preload_size=20000 --init_device=false --cleanup_after_shutdown=false --num_iters=80000`