### PR TITLE
Fix log dev load issue.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,8 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "5.1.1"
+    version = "5.1.2"
+
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")

--- a/src/include/homestore/homestore.hpp
+++ b/src/include/homestore/homestore.hpp
@@ -125,7 +125,7 @@ private:
 
     HS_SERVICE m_services; // Services homestore is starting with
     hs_before_services_starting_cb_t m_before_services_starting_cb{nullptr};
-    bool m_init_done{false};
+    std::atomic< bool > m_init_done{false};
 
 public:
     HomeStore() = default;

--- a/src/lib/device/journal_vdev.cpp
+++ b/src/lib/device/journal_vdev.cpp
@@ -419,7 +419,7 @@ off_t JournalVirtualDev::Descriptor::lseek(off_t offset, int whence) {
  * @brief :- it returns the vdev offset after nbytes from start offset
  */
 off_t JournalVirtualDev::Descriptor::dev_offset(off_t nbytes) const {
-    if (m_journal_chunks.empty()) { return 0; }
+    if (m_journal_chunks.empty()) { return data_start_offset(); }
 
     off_t vdev_offset = data_start_offset();
     uint32_t dev_id{0}, chunk_id{0};

--- a/src/lib/device/virtual_dev.cpp
+++ b/src/lib/device/virtual_dev.cpp
@@ -125,8 +125,8 @@ void VirtualDev::add_chunk(cshared< Chunk >& chunk, bool is_fresh_chunk) {
 
 void VirtualDev::remove_chunk(cshared< Chunk >& chunk) {
     std::unique_lock lg{m_mgmt_mutex};
-    auto iter = std::remove_if(m_all_chunks.begin(), m_all_chunks.end(), [chunk](auto c) { return c == chunk; });
-    m_all_chunks.erase(iter, m_all_chunks.end());
+    m_all_chunks[chunk->chunk_id()].reset();
+    m_all_chunks[chunk->chunk_id()] = nullptr;
     m_chunk_selector->remove_chunk(chunk);
 }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -111,7 +111,7 @@ if (${io_tests})
         add_test(NAME MetaBlkMgr-Epoll COMMAND ${CMAKE_BINARY_DIR}/bin/test_meta_blk_mgr)
         add_test(NAME DataService-Epoll COMMAND ${CMAKE_BINARY_DIR}/bin/test_data_service)
 
-        #add_test(NAME SoloReplDev-Epoll COMMAND ${CMAKE_BINARY_DIR}/bin/test_solo_repl_dev)
+        add_test(NAME SoloReplDev-Epoll COMMAND ${CMAKE_BINARY_DIR}/bin/test_solo_repl_dev)
         # add_test(NAME HomeRaftLogStore-Epoll COMMAND ${CMAKE_BINARY_DIR}/bin/test_home_raft_logstore)
         # add_test(NAME RaftReplDev-Epoll COMMAND ${CMAKE_BINARY_DIR}/bin/test_raft_repl_dev)
     endif()


### PR DESCRIPTION
Issue.
Getting asserts in logdev during recovery with mismatch in logdev idx and complaining header corrupted.

Cause
One of the logdev family 1 was not used for writes in UT and has no chunks. During recovery, when we read m_vdev_jd->sync_next_read(), we ignored the return value whether we read anything or not. On build machines, the return buffer contained garbage values, which later was considered as invalid header and end of log. log_stream_reader::next_group() line 58. For some reason on github actions, we get a proper loggroup header(from logdev family 0, because crc was matching with sequence number) as garbage value and causing it validate against a invalid header and doing a assert. This issue didnt happen before dynamic logdev changes because we had fixed number chunks for both logdev families and it read some junk and returned  error with no more logdev data. Now we have situation of 0 chunks and no garbage data.

Fix
handle the return code m_vdev_jd->sync_next_read() and handle case where then is no data needs to be read.