### PR TITLE
Fix log store ut

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -107,7 +107,7 @@ if (${io_tests})
 
     can_build_epoll_io_tests(epoll_tests)
     if(${epoll_tests})
-        # add_test(NAME LogStore-Epoll COMMAND ${CMAKE_BINARY_DIR}/bin/test_log_store)
+        add_test(NAME LogStore-Epoll COMMAND ${CMAKE_BINARY_DIR}/bin/test_log_store)
         add_test(NAME MetaBlkMgr-Epoll COMMAND ${CMAKE_BINARY_DIR}/bin/test_meta_blk_mgr)
         # add_test(NAME DataService-Epoll COMMAND ${CMAKE_BINARY_DIR}/bin/test_data_service)
 


### PR DESCRIPTION
Issue
The rollback was randomly failing because after truncation it expected no rollback records. But the test was writing to only one logstore. Because of other test cases in same file, other log store also have some log entries. Here truncate will truncate all logstores but device truncate will pick a logstore with the least idx and that value was smaller than the rollback records. This is because init was writing to only 1 store. 

Fix.
Write to all logstores equally. Write rollback to one of the logstore(logstore 1). Truncate on all and should make all the logstores move forward together and delete those rollback records