### PR TITLE
Possible fix for refresh node lock problem

### DIFF
--- a/.jenkins/jenkinsfile_nightly
+++ b/.jenkins/jenkinsfile_nightly
@@ -40,7 +40,7 @@ pipeline {
                 }
                 stage("Build") {
                     steps {
-                        sh "conan create --build missing -o sisl:prerelease=True -o homestore:sanitize=True -o homestore:skip_testing=True -pr debug . ${PROJECT}/${VER}@"
+                        sh "conan create --build missing -o homestore:sanitize=True -o homestore:skip_testing=True -pr debug . ${PROJECT}/${VER}@"
                         sh "find ${CONAN_USER_HOME} -type f -wholename '*bin/test_index_btree' -exec cp {} .jenkins/test_index_btree \\;"
                         sh "find ${CONAN_USER_HOME} -type f -wholename '*bin/test_meta_blk_mgr' -exec cp {} .jenkins/test_meta_blk_mgr \\;"
                         sh "find ${CONAN_USER_HOME} -type f -wholename '*bin/test_log_store' -exec cp {} .jenkins/test_log_store \\;"

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "5.1.7"
+    version = "5.1.9"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/tests/btree_helpers/btree_decls.h
+++ b/src/tests/btree_helpers/btree_decls.h
@@ -35,11 +35,11 @@ struct VarKeySizeBtree {
 };
 
 struct VarValueSizeBtree {
-    using BtreeType = IndexTable< TestVarLenKey, TestVarLenValue >;
-    using KeyType = TestVarLenKey;
+    using BtreeType = IndexTable< TestFixedKey, TestVarLenValue >;
+    using KeyType = TestFixedKey;
     using ValueType = TestVarLenValue;
-    static constexpr btree_node_type leaf_node_type = btree_node_type::VAR_OBJECT;
-    static constexpr btree_node_type interior_node_type = btree_node_type::VAR_OBJECT;
+    static constexpr btree_node_type leaf_node_type = btree_node_type::VAR_VALUE;
+    static constexpr btree_node_type interior_node_type = btree_node_type::FIXED;
 };
 
 struct VarObjSizeBtree {


### PR DESCRIPTION
 Test failure happens when a fiber is slow. This triggers `idx_node->m_last_mod_cp_id > cp_ctx->id()`, hence returns put/remove returns `btree_status_t::cp_mismatch`. One possible solution is that the caller performs retries. Having said that, in the UT, if it `cp_mismatch` happens, the caller retries until it happens.
###  Testing
In order to hit the problem, the number of fibers increases to 100 per thread and 10 threads (1000 fibers in total)
`bin/test_index_btree --gtest_filter=*/0.ConcurrentAllOps --preload_size=400000 --num_entries=800000 --num_iters=50000 --gtest_break_on_failure --num_fibers=100  --num_threads=10`