### PR TITLE
fix restartability bug for upper layer

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "5.1.6"
+    version = "5.1.7"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/homestore.cpp
+++ b/src/lib/homestore.cpp
@@ -126,6 +126,7 @@ bool HomeStore::start(const hs_input_params& input, hs_before_services_starting_
     if (has_repl_data_service()) {
         m_log_service = std::make_unique< LogStoreService >();
         m_data_service = std::make_unique< BlkDataService >(std::move(s_custom_chunk_selector));
+        m_repl_service = GenericReplService::create(std::move(s_repl_app));
     } else {
         if (has_log_service()) { m_log_service = std::make_unique< LogStoreService >(); }
         if (has_data_service()) {
@@ -191,11 +192,6 @@ void HomeStore::format_and_start(std::map< uint32_t, hs_format_params >&& format
 }
 
 void HomeStore::do_start() {
-    // when coming here:
-    // 1 if this is the first_time_boot, , the repl app already gets its uuid from upper layer
-    // 2 if this is not the first_time_boot, the repl app already gets its uuid from the metaservice
-    // now , we can safely initialize GenericReplService , which will get a correct uuid through get_my_repl_uuid()
-    if (has_repl_data_service()) m_repl_service = GenericReplService::create(std::move(s_repl_app));
     const auto& inp_params = HomeStoreStaticConfig::instance().input;
 
     uint64_t cache_size = resource_mgr().get_cache_size();

--- a/src/lib/replication/service/generic_repl_svc.cpp
+++ b/src/lib/replication/service/generic_repl_svc.cpp
@@ -35,8 +35,7 @@ std::shared_ptr< GenericReplService > GenericReplService::create(cshared< ReplAp
     }
 }
 
-GenericReplService::GenericReplService(cshared< ReplApplication >& repl_app) :
-        m_repl_app{repl_app}, m_my_uuid{repl_app->get_my_repl_id()} {
+GenericReplService::GenericReplService(cshared< ReplApplication >& repl_app) : m_repl_app{repl_app} {
     m_sb_bufs.reserve(100);
     meta_service().register_handler(
         get_meta_blk_name(),

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -71,6 +71,7 @@ RaftReplService::RaftReplService(cshared< ReplApplication >& repl_app) : Generic
 
 void RaftReplService::start() {
     // Step 1: Initialize the Nuraft messaging service, which starts the nuraft service
+    m_my_uuid = m_repl_app->get_my_repl_id();
     auto params = nuraft_mesg::Manager::Params{
         .server_uuid_ = m_my_uuid,
         .mesg_port_ = m_repl_app->lookup_peer(m_my_uuid).second,
@@ -270,8 +271,6 @@ AsyncReplResult<> RaftReplService::replace_member(group_id_t group_id, replica_i
                                                   replica_id_t member_in) const {
     return make_async_error<>(ReplServiceError::NOT_IMPLEMENTED);
 }
-
-
 
 ///////////////////// RaftReplService CP Callbacks /////////////////////////////
 std::unique_ptr< CPContext > RaftReplServiceCPHandler::on_switchover_cp(CP* cur_cp, CP* new_cp) { return nullptr; }


### PR DESCRIPTION
if it is not first-time-boot, the uuid of HO is saved in metaservice. so we need to get the uuid after metaservice is started, otherwise we will get a new default uuid