### PR TITLE
issue 329: RafReplDev Metrics and Restart Leader Test

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "5.1.6"
+    version = "5.1.7"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -28,7 +28,8 @@ RaftReplDev::RaftReplDev(RaftReplService& svc, superblk< raft_repl_dev_superblk 
         m_group_id{rd_sb->group_id},
         m_my_repl_id{svc.get_my_repl_uuid()},
         m_raft_server_id{nuraft_mesg::to_server_id(m_my_repl_id)},
-        m_rd_sb{std::move(rd_sb)} {
+        m_rd_sb{std::move(rd_sb)},
+        m_metrics{fmt::format("{}_{}", group_id_str(), m_raft_server_id).c_str()} {
     m_state_machine = std::make_shared< RaftStateMachine >(*this);
 
     if (load_existing) {
@@ -213,7 +214,11 @@ void RaftReplDev::on_fetch_data_received(intrusive< sisl::GenericRpcData >& rpc_
             sgs_vec.push_back(sgs);
 
             async_read(local_blkid, sgs, total_size).thenValue([this, &ctx](auto&& err) {
-                RD_REL_ASSERT(!err, "Error in reading data"); // TODO: Find a way to return error to the Listener
+                if (err) {
+                    COUNTER_INCREMENT(m_metrics, read_err_cnt, 1);
+                    RD_REL_ASSERT(false, "Error in reading data"); // TODO: Find a way to return error to the Listener
+                }
+
                 {
                     std::unique_lock< std::mutex > lk{ctx->mtx};
                     --(ctx->outstanding_read_cnt);
@@ -334,6 +339,7 @@ void RaftReplDev::on_push_data_received(intrusive< sisl::GenericRpcData >& rpc_d
         .async_write(r_cast< const char* >(data), push_req->data_size(), rreq->local_blkid)
         .thenValue([this, rreq](auto&& err) {
             if (err) {
+                COUNTER_INCREMENT(m_metrics, write_err_cnt, 1);
                 RD_DBG_ASSERT(false, "Error in writing data");
                 handle_error(rreq, ReplServiceError::DRIVE_WRITE_ERROR);
             } else {
@@ -471,6 +477,8 @@ void RaftReplDev::fetch_data_from_remote(std::vector< repl_req_ptr_t > rreqs) {
     builder->FinishSizePrefixed(
         CreateFetchData(*builder, CreateFetchDataRequest(*builder, builder->CreateVector(entries))));
 
+    COUNTER_INCREMENT(m_metrics, fetch_rreq_cnt, 1);
+
     // leader can change, on the receiving side, we need to check if the leader is still the one who originated the
     // blkid;
     group_msg_service()
@@ -487,11 +495,14 @@ void RaftReplDev::fetch_data_from_remote(std::vector< repl_req_ptr_t > rreqs) {
                        "Not able to fetching data from originator={}, error={}, probably originator is down. Will "
                        "retry when new leader start appending log entries",
                        rreqs.front()->remote_blkid.server_id, e.error());
+                COUNTER_INCREMENT(m_metrics, fetch_err_cnt, 1);
                 for (auto const& rreq : rreqs) {
                     handle_error(rreq, RaftReplService::to_repl_error(e.error()));
                 }
                 return;
             }
+
+            COUNTER_INCREMENT(m_metrics, fetch_rreq_cnt, 1);
 
             auto raw_data = e.value().response_blob().cbytes();
             auto total_size = e.value().response_blob().size();
@@ -575,6 +586,7 @@ void RaftReplDev::fetch_data_from_remote(std::vector< repl_req_ptr_t > rreqs) {
                 for (auto const& err_c : vf) {
                     if (sisl_unlikely(err_c.value())) {
                         auto ec = err_c.value();
+                        COUNTER_INCREMENT(m_metrics, write_err_cnt, 1);
                         RD_LOG(ERROR, "Error in writing data: {}", ec.value());
                         // TODO: actually will never arrive here as iomgr will assert (should not assert but
                         // to raise alert and leave the raft group);

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -522,7 +522,6 @@ void RaftReplDev::fetch_data_from_remote(std::vector< repl_req_ptr_t > rreqs) {
             auto raw_data = e.value().response_blob().cbytes();
             auto total_size = e.value().response_blob().size();
 
-            COUNTER_INCREMENT(m_metrics, fetch_rreq_cnt, 1);
             COUNTER_INCREMENT(m_metrics, fetch_total_blk_size, total_size);
 
             RD_DBG_ASSERT_GT(total_size, 0, "Empty response from remote");

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -37,6 +37,9 @@ public:
         REGISTER_COUNTER(fetch_err_cnt, "total fetch data error count", "fetch_err_cnt", {"op", "fetch"});
 
         REGISTER_COUNTER(fetch_rreq_cnt, "total fetch data count", "fetch_data_req_cnt", {"op", "fetch"});
+        REGISTER_COUNTER(fetch_total_blk_size, "total fetch data blocks size", "fetch_total_blk_size", {"op", "fetch"});
+        REGISTER_COUNTER(fetch_total_entries_cnt, "total fetch total entries count", "fetch_total_entries_cnt",
+                         {"op", "fetch"});
 
         register_me_to_farm();
     }

--- a/src/tests/test_common/hs_repl_test_common.hpp
+++ b/src/tests/test_common/hs_repl_test_common.hpp
@@ -81,11 +81,9 @@ protected:
                 phase_ = new_phase;
                 cv_.notify_all();
             } else {
-                LOGINFO("Waiting for all replicas to reach phase={}, count={}", new_phase, count);
                 cv_.wait(lg, [this, new_phase]() { return (phase_ == new_phase); });
             }
 
-            LOGINFO("All replicas reached phase={}", new_phase);
             count = 0;
         }
     };
@@ -185,7 +183,7 @@ public:
 
     void teardown() {
         LOGINFO("Stopping Homestore replica={}", replica_num_);
-        sisl::GrpcAsyncClientWorker::shutdown_all();
+        // sisl::GrpcAsyncClientWorker::shutdown_all();
         test_common::HSTestHelper::shutdown_homestore();
     }
 

--- a/src/tests/test_common/hs_repl_test_common.hpp
+++ b/src/tests/test_common/hs_repl_test_common.hpp
@@ -81,8 +81,11 @@ protected:
                 phase_ = new_phase;
                 cv_.notify_all();
             } else {
+                LOGINFO("Waiting for all replicas to reach phase={}, count={}", new_phase, count);
                 cv_.wait(lg, [this, new_phase]() { return (phase_ == new_phase); });
             }
+
+            LOGINFO("All replicas reached phase={}", new_phase);
             count = 0;
         }
     };

--- a/src/tests/test_raft_repl_dev.cpp
+++ b/src/tests/test_raft_repl_dev.cpp
@@ -111,7 +111,7 @@ public:
         ASSERT_EQ(header.size(), sizeof(test_req::journal_header));
 
         auto jheader = r_cast< test_req::journal_header const* >(header.cbytes());
-        Key k{.id_ = static_cast< uint64_t >(lsn)};
+        Key k{.id_ = *(r_cast< uint64_t const* >(key.cbytes()))};
         Value v{
             .lsn_ = lsn, .data_size_ = jheader->data_size, .data_pattern_ = jheader->data_pattern, .blkid_ = blkids};
 

--- a/src/tests/test_raft_repl_dev.cpp
+++ b/src/tests/test_raft_repl_dev.cpp
@@ -273,7 +273,7 @@ private:
     flip::FlipClient m_fc{iomgr_flip::instance()};
 #endif
 };
-#if 0
+
 TEST_F(RaftReplDevTest, All_Append_Restart_Append) {
 
     LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
@@ -453,8 +453,7 @@ TEST_F(RaftReplDevTest, All_restart_one_follower_inc_resync_with_staging) {
     this->validate_all_data();
     g_helper->sync_for_cleanup_start();
 }
-#endif
-#if 1
+
 // do some io before restart;
 TEST_F(RaftReplDevTest, All_restart_leader) {
     LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
@@ -513,7 +512,7 @@ TEST_F(RaftReplDevTest, All_restart_leader) {
     this->validate_all_data();
     g_helper->sync_for_cleanup_start();
 }
-#endif
+
 // TODO
 // double restart:
 // 1. restart one follower(F1) while I/O keep running.

--- a/src/tests/test_raft_repl_dev.cpp
+++ b/src/tests/test_raft_repl_dev.cpp
@@ -103,10 +103,13 @@ public:
 
     void on_commit(int64_t lsn, sisl::blob const& header, sisl::blob const& key, MultiBlkId const& blkids,
                    cintrusive< repl_req_ctx >& ctx) override {
+
+        m_num_commits.fetch_add(1, std::memory_order_relaxed);
+
         ASSERT_EQ(header.size(), sizeof(test_req::journal_header));
 
         auto jheader = r_cast< test_req::journal_header const* >(header.cbytes());
-        Key k{.id_ = *(r_cast< uint64_t const* >(key.cbytes()))};
+        Key k{.id_ = static_cast< uint64_t >(lsn)};
         Value v{
             .lsn_ = lsn, .data_size_ = jheader->data_size, .data_pattern_ = jheader->data_pattern, .blkid_ = blkids};
 
@@ -192,6 +195,8 @@ public:
         g_helper->runner().execute().get();
     }
 
+    uint64_t db_num_writes() const { return m_num_commits.load(std::memory_order_relaxed); }
+
     uint64_t db_size() const {
         std::shared_lock lk(db_mtx_);
         return inmem_db_.size();
@@ -200,6 +205,7 @@ public:
 private:
     std::map< Key, Value > inmem_db_;
     std::shared_mutex db_mtx_;
+    std::atomic< uint64_t > m_num_commits;
 };
 
 class RaftReplDevTest : public testing::Test {
@@ -221,7 +227,7 @@ public:
         while (true) {
             uint64_t total_writes{0};
             for (auto const& db : dbs_) {
-                total_writes += db->db_size();
+                total_writes += db->db_num_writes();
             }
 
             if (total_writes >= exp_writes) { break; }
@@ -267,7 +273,7 @@ private:
     flip::FlipClient m_fc{iomgr_flip::instance()};
 #endif
 };
-
+#if 0
 TEST_F(RaftReplDevTest, All_Append_Restart_Append) {
 
     LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
@@ -361,7 +367,7 @@ TEST_F(RaftReplDevTest, All_restart_one_follower_inc_resync) {
     if (g_helper->replica_num() == 1) {
         LOGINFO("Restart homestore: replica_num = 1");
         g_helper->restart(10 /* shutdown_delay_sec */);
-        g_helper->sync_for_test_start();
+        // g_helper->sync_for_test_start();
     }
 
     exp_entries += SISL_OPTIONS["num_io"].as< uint64_t >();
@@ -389,7 +395,6 @@ TEST_F(RaftReplDevTest, All_restart_one_follower_inc_resync) {
     this->validate_all_data();
     g_helper->sync_for_cleanup_start();
 }
-
 //
 // staging the fetch remote data with flip point;
 //
@@ -420,7 +425,7 @@ TEST_F(RaftReplDevTest, All_restart_one_follower_inc_resync_with_staging) {
     if (g_helper->replica_num() == 1) {
         LOGINFO("Restart homestore: replica_num = 1");
         g_helper->restart(10 /* shutdown_delay_sec */);
-        g_helper->sync_for_test_start();
+        // g_helper->sync_for_test_start();
     }
 
     exp_entries += SISL_OPTIONS["num_io"].as< uint64_t >();
@@ -448,7 +453,67 @@ TEST_F(RaftReplDevTest, All_restart_one_follower_inc_resync_with_staging) {
     this->validate_all_data();
     g_helper->sync_for_cleanup_start();
 }
+#endif
+#if 1
+// do some io before restart;
+TEST_F(RaftReplDevTest, All_restart_leader) {
+    LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
+    g_helper->sync_for_test_start();
 
+    // step-0: do some IO before restart one member;
+    uint64_t exp_entries = 20;
+    if (g_helper->replica_num() == 0) {
+        g_helper->runner().set_num_tasks(exp_entries);
+        auto block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
+        LOGINFO("Run on worker threads to schedule append on repldev for {} Bytes.", block_size);
+        g_helper->runner().set_task([this, block_size]() {
+            this->generate_writes(block_size /* data_size */, block_size /* max_size_per_iov */);
+        });
+        g_helper->runner().execute().get();
+    }
+
+    // step-1: wait for all writes to be completed
+    this->wait_for_all_writes(exp_entries);
+
+    // step-2: restart leader replica
+    if (g_helper->replica_num() == 0) {
+        LOGINFO("Restart homestore: replica_num = 0");
+        g_helper->restart(10 /* shutdown_delay_sec */);
+        // g_helper->sync_for_test_start();
+    }
+
+    exp_entries += SISL_OPTIONS["num_io"].as< uint64_t >();
+    // step-3: on leader, wait for a while for replica-1 to finish shutdown so that it can be removed from raft-groups
+    // and following I/O issued by leader won't be pushed to relica-1;
+    if (g_helper->replica_num() == 1) {
+        LOGINFO("Wait for grpc connection to replica-0 to be removed from raft-groups, and wait for awhile before "
+                "sending new I/O.");
+        std::this_thread::sleep_for(std::chrono::seconds{5});
+
+        LOGINFO("Switch the leader to replica_num = 1");
+        switch_all_db_leader();
+
+        g_helper->runner().set_num_tasks(SISL_OPTIONS["num_io"].as< uint64_t >());
+
+        // before replica-1 started, issue I/O so that replica-1 is lagging behind;
+        auto block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
+        LOGINFO("Run on worker threads to schedule append on repldev for {} Bytes.", block_size);
+        g_helper->runner().set_task([this, block_size]() {
+            this->generate_writes(block_size /* data_size */, block_size /* max_size_per_iov */);
+        });
+        g_helper->runner().execute().get();
+    }
+
+    this->wait_for_all_writes(exp_entries);
+
+    if (g_helper->replica_num() != 0) { std::this_thread::sleep_for(std::chrono::seconds{10}); }
+
+    g_helper->sync_for_verify_start();
+    LOGINFO("Validate all data written so far by reading them");
+    this->validate_all_data();
+    g_helper->sync_for_cleanup_start();
+}
+#endif
 // TODO
 // double restart:
 // 1. restart one follower(F1) while I/O keep running.


### PR DESCRIPTION
1. add some metrics around read/write/fetch for error cases. 
2. add restart leader test case. 

Testing:
=======
1. Wrote a script to run restart leader for 100 times and passed. Verified leader changed to replica-1 after replica-0 (original leader) restarted with I/O running.