### PR TITLE
Remove std::move() in async_alloc_write.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "5.1.11"
+    version = "5.1.12"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -121,7 +121,7 @@ void RaftReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& 
         // Write the data
         data_service().async_write(rreq->value, rreq->local_blkid).thenValue([this, rreq](auto&& err) {
             if (!err) {
-                auto raft_status = m_state_machine->propose_to_raft(std::move(rreq));
+                auto raft_status = m_state_machine->propose_to_raft(rreq);
                 if (raft_status != ReplServiceError::OK) { handle_error(rreq, raft_status); }
             } else {
                 HS_DBG_ASSERT(false, "Error in writing data");
@@ -131,7 +131,7 @@ void RaftReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& 
     } else {
         rreq->value_inlined = true;
         RD_LOG(DEBUG, "Skipping data channel send since value size is 0");
-        auto raft_status = m_state_machine->propose_to_raft(std::move(rreq));
+        auto raft_status = m_state_machine->propose_to_raft(rreq);
         if (raft_status != ReplServiceError::OK) { handle_error(rreq, raft_status); }
     }
 }


### PR DESCRIPTION
Previously we do move() for rreq which
1. has no effect on write_with_data path as rreq is captured by value which is a const.
2. make rreq (intrusive_ptr) to NULL after move and causing panic in handle_error(rreq) later.

Removing the move() to fix the bug, though with a cost of extra atomic_inc/dec