### PR TITLE
Error handling on pre-append et al. 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -55,9 +55,9 @@ class HomestoreConan(ConanFile):
         self.build_requires("gtest/1.14.0")
 
     def requirements(self):
-        self.requires("iomgr/[~=11, include_prerelease=True]@oss/master")
-        self.requires("sisl/[~=11, include_prerelease=True]@oss/master")
-        self.requires("nuraft_mesg/[~=3, include_prerelease=True]@oss/main")
+        self.requires("iomgr/[~=11.2, include_prerelease=True]@oss/master")
+        self.requires("sisl/[~=12, include_prerelease=True]@oss/master")
+        self.requires("nuraft_mesg/[~=3.3, include_prerelease=True]@oss/main")
 
         self.requires("farmhash/cci.20190513@")
         if self.settings.arch in ['x86', 'x86_64']:

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "5.1.15"
+    version = "6.0.1"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -92,6 +92,7 @@ public:
     //////////////// Replication state related section /////////////////
     std::mutex state_mtx;
     std::atomic< uint32_t > state{uint32_cast(repl_req_state_t::INIT)}; // State of the replication request
+    folly::Promise< folly::Unit > data_received_promise;                // Promise to be fulfilled when data is received
     folly::Promise< folly::Unit > data_written_promise;                 // Promise to be fulfilled when data is written
 
     //////////////// Communication packet/builder section /////////////////

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -7,6 +7,7 @@
 #include <flatbuffers/flatbuffers.h>
 #include <folly/futures/Future.h>
 #include <sisl/fds/buffer.hpp>
+#include <sisl/fds/utils.hpp>
 #include <sisl/grpc/generic_service.hpp>
 #include <homestore/replication/repl_decls.h>
 
@@ -54,6 +55,7 @@ struct repl_req_ctx : public boost::intrusive_ref_counter< repl_req_ctx, boost::
     friend class SoloReplDev;
 
 public:
+    repl_req_ctx() { start_time = Clock::now(); }
     virtual ~repl_req_ctx();
     int64_t get_lsn() const { return lsn; }
     MultiBlkId const& get_local_blkid() const { return local_blkid; }
@@ -66,13 +68,15 @@ public:
 
     std::string to_string() const;
     std::string to_compact_string() const;
+    Clock::time_point created_time() const { return start_time; }
 
 public:
-    repl_key rkey;           // Unique key for the request
-    sisl::blob header;       // User header
-    sisl::blob key;          // User supplied key for this req
-    int64_t lsn{-1};         // Lsn for this replication req
-    bool is_proposer{false}; // Is the repl_req proposed by this node
+    repl_key rkey;                // Unique key for the request
+    sisl::blob header;            // User header
+    sisl::blob key;               // User supplied key for this req
+    int64_t lsn{-1};              // Lsn for this replication req
+    bool is_proposer{false};      // Is the repl_req proposed by this node
+    Clock::time_point start_time; // Start time of the request
 
     //////////////// Value related section /////////////////
     sisl::sg_list value;       // Raw value - applicable only to leader req
@@ -83,6 +87,7 @@ public:
     //////////////// Journal/Buf related section /////////////////
     std::variant< std::unique_ptr< uint8_t[] >, raft_buf_ptr_t > journal_buf; // Buf for the journal entry
     repl_journal_entry* journal_entry{nullptr};                               // pointer to the journal entry
+    bool is_jentry_localize_pending{false}; // Is the journal entry needs to be localized from remote
 
     //////////////// Replication state related section /////////////////
     std::mutex state_mtx;
@@ -178,8 +183,10 @@ public:
     ///
     /// @param header Header originally passed with repl_dev::async_alloc_write() api on the leader
     /// @param data_size Size needed to be allocated for
-    /// @return Expected to return blk_alloc_hints for this write
-    virtual blk_alloc_hints get_blk_alloc_hints(sisl::blob const& header, uint32_t data_size) = 0;
+    /// @return Expected to return blk_alloc_hints for this write. If the hints are not available, then return the
+    /// error. It is to be noted this method should return error only in very abnornal cases as in some code flow, an
+    /// error would result in a crash or stall of the entire commit thread.
+    virtual ReplResult< blk_alloc_hints > get_blk_alloc_hints(sisl::blob const& header, uint32_t data_size) = 0;
 
     /// @brief Called when the replica set is being stopped
     virtual void on_replica_stop() = 0;
@@ -241,7 +248,7 @@ public:
     virtual bool is_leader() const = 0;
 
     /// @brief get the leader replica_id of given group
-    virtual const replica_id_t get_leader_id() const = 0;
+    virtual replica_id_t get_leader_id() const = 0;
 
     /// @brief get replication status. If called on follower member
     /// this API can return empty result.

--- a/src/lib/blkalloc/bitmap_blk_allocator.h
+++ b/src/lib/blkalloc/bitmap_blk_allocator.h
@@ -102,7 +102,7 @@ public:
 
 private:
     void do_init();
-    sisl::ThreadVector< BlkId >* get_alloc_blk_list();
+    sisl::ThreadVector< MultiBlkId >* get_alloc_blk_list();
     void on_meta_blk_found(void* mblk_cookie, sisl::byte_view const& buf, size_t size);
 
     // Acquire the underlying bitmap buffer and while the caller has acquired, all the new allocations
@@ -116,7 +116,7 @@ protected:
     blk_num_t m_blks_per_portion;
 
 private:
-    sisl::ThreadVector< BlkId >* m_alloc_blkid_list{nullptr};
+    sisl::ThreadVector< MultiBlkId >* m_alloc_blkid_list{nullptr};
     std::unique_ptr< BlkAllocPortion[] > m_blk_portions;
     std::unique_ptr< sisl::Bitset > m_disk_bm{nullptr};
     std::atomic< bool > m_is_disk_bm_dirty{true}; // initially disk_bm treated as dirty

--- a/src/lib/blkalloc/blk.cpp
+++ b/src/lib/blkalloc/blk.cpp
@@ -41,8 +41,7 @@ void BlkId::invalidate() { s.m_nblks = 0; }
 bool BlkId::is_valid() const { return (blk_count() > 0); }
 
 std::string BlkId::to_string() const {
-    return is_valid() ? fmt::format("BlkNum={} nblks={} chunk={}", blk_num(), blk_count(), chunk_num())
-                      : "Invalid_Blkid";
+    return is_valid() ? fmt::format("blk#={} count={} chunk={}", blk_num(), blk_count(), chunk_num()) : "Invalid_Blkid";
 }
 
 int BlkId::compare(const BlkId& one, const BlkId& two) {
@@ -126,12 +125,12 @@ bool MultiBlkId::has_room() const { return (n_addln_piece < max_addln_pieces); }
 MultiBlkId::iterator MultiBlkId::iterate() const { return MultiBlkId::iterator{*this}; }
 
 std::string MultiBlkId::to_string() const {
-    std::string str = "MultiBlks: {";
+    std::string str = "[";
     auto it = iterate();
     while (auto const b = it.next()) {
-        str += (b->to_string() + " ");
+        str += "{" + (b->to_string() + "},");
     }
-    str += std::string("}");
+    str += std::string("]");
     return str;
 }
 

--- a/src/lib/common/homestore_config.fbs
+++ b/src/lib/common/homestore_config.fbs
@@ -220,14 +220,14 @@ table Consensus {
     // Minimum log gap a replica has to be from leader before joining the replica set.
     min_log_gap_to_join: int32 = 30;
     
-    // amount of time in seconds to wait on data write before fetch data from remote;
-    wait_data_write_timer_sec: uint32 =  30 (hotswap);
+    // amount of time in millis to wait on data write before fetch data from remote;
+    wait_data_write_timer_ms: uint64 = 1500 (hotswap);
     
-    // Leadership expiry 120 seconds
-    leadership_expiry_ms: uint32 = 120000;
+    // Leadership expiry (=0 indicates 20 times heartbeat period), set -1 to never expire
+    leadership_expiry_ms: int32 = 0;
 
-    // data fetch max size limit in MB
-    data_fetch_max_size_mb: uint32 = 2;
+    // data fetch max size limit in KB (2MB by default)
+    data_fetch_max_size_kb: uint32 = 2048;
 }
 
 table HomeStoreSettings {

--- a/src/lib/common/homestore_config.fbs
+++ b/src/lib/common/homestore_config.fbs
@@ -228,6 +228,9 @@ table Consensus {
 
     // data fetch max size limit in KB (2MB by default)
     data_fetch_max_size_kb: uint32 = 2048;
+
+    // Timeout for data to be received after raft entry after which raft entry is rejected.
+    data_receive_timeout_ms: uint64 = 10000;
 }
 
 table HomeStoreSettings {

--- a/src/lib/replication/log_store/repl_log_store.cpp
+++ b/src/lib/replication/log_store/repl_log_store.cpp
@@ -61,9 +61,9 @@ void ReplLogStore::end_of_append_batch(ulong start_lsn, ulong count) {
         HomeRaftLogStore::end_of_append_batch(start_lsn, count);
 
         // Wait for the fetch and write to be completed successfully.
-        std::move(fut).get();
+        std::move(fut).wait();
 
-        // Mark all the pbas also completely written
+        // Mark all the reqs also completely written
         for (auto const& rreq : *reqs) {
             if (rreq) { rreq->state.fetch_or(uint32_cast(repl_req_state_t::LOG_FLUSHED)); }
         }

--- a/src/lib/replication/repl_dev/common.cpp
+++ b/src/lib/replication/repl_dev/common.cpp
@@ -44,8 +44,8 @@ std::string repl_req_ctx::to_string() const {
 }
 
 std::string repl_req_ctx::to_compact_string() const {
-    return fmt::format("dsn={} term={} lsn={} Blkid={} state=[{}]", rkey.dsn, rkey.term, lsn, local_blkid.to_string(),
-                       req_state_name(state.load()));
+    return fmt::format("dsn={} term={} lsn={} local_blkid={} state=[{}]", rkey.dsn, rkey.term, lsn,
+                       local_blkid.to_string(), req_state_name(state.load()));
 }
 
 } // namespace homestore

--- a/src/lib/replication/repl_dev/common.h
+++ b/src/lib/replication/repl_dev/common.h
@@ -22,8 +22,9 @@
 #include <homestore/superblk_handler.hpp>
 
 namespace homestore {
-VENUM(journal_type_t, uint16_t, HS_LARGE_DATA = 0, HS_HEADER_ONLY = 1)
+VENUM(journal_type_t, uint16_t, HS_DATA_LINKED = 0, HS_DATA_INLINED = 1)
 
+#pragma pack(1)
 struct repl_journal_entry {
     static constexpr uint16_t JOURNAL_ENTRY_MAJOR = 1;
     static constexpr uint16_t JOURNAL_ENTRY_MINOR = 1;
@@ -34,8 +35,8 @@ struct repl_journal_entry {
     uint16_t minor_version{JOURNAL_ENTRY_MINOR};
 
     journal_type_t code;
-    int32_t server_id;
-    uint64_t dsn; // Data seq number
+    int32_t server_id; // Server id from where journal entry is originated
+    uint64_t dsn;      // Data seq number
     uint32_t user_header_size;
     uint32_t key_size;
     uint32_t value_size;
@@ -53,7 +54,6 @@ struct repl_journal_entry {
     }
 };
 
-#pragma pack(1)
 struct repl_dev_superblk {
     static constexpr uint64_t REPL_DEV_SB_MAGIC = 0xABCDF00D;
     static constexpr uint32_t REPL_DEV_SB_VERSION = 1;

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -12,7 +12,6 @@
 #include <homestore/blkdata_service.hpp>
 #include <homestore/logstore_service.hpp>
 #include <homestore/superblk_handler.hpp>
-#include <homestore/crc.h>
 
 #include "common/homestore_assert.hpp"
 #include "common/homestore_config.hpp"
@@ -260,10 +259,6 @@ void RaftReplDev::on_fetch_data_received(intrusive< sisl::GenericRpcData >& rpc_
                 pkts.insert(pkts.end(), ret.begin(), ret.end());
             }
 
-            // TODO: Temporary code
-            crc32_t const crc = crc32_ieee(init_crc32, pkts.front().cbytes(), pkts.front().size());
-            RD_LOG(DEBUG, "Data Channel: FetchData data read completed for {} buffers, crc={}", sgs_vec.size(), crc);
-
             rpc_data->set_comp_cb([sgs_vec = std::move(sgs_vec)](boost::intrusive_ptr< sisl::GenericRpcData >&) {
                 for (auto const& sgs : sgs_vec) {
                     for (auto const& iov : sgs.iovs) {
@@ -368,10 +363,6 @@ void RaftReplDev::on_push_data_received(intrusive< sisl::GenericRpcData >& rpc_d
         std::memcpy(rreq->buf_for_unaligned_data.bytes(), data, push_req->data_size());
         data = rreq->buf_for_unaligned_data.cbytes();
     }
-
-    // TODO: Temporary
-    crc32_t const crc = crc32_ieee(init_crc32, data, push_req->data_size());
-    RD_LOG(DEBUG, "Data Channel: PushData received for rreq=[{}] crc={}", rreq->to_string(), crc);
 
     // Schedule a write and upon completion, mark the data as written.
     data_service()

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -153,6 +153,7 @@ private:
     void on_push_data_received(intrusive< sisl::GenericRpcData >& rpc_data);
     void on_fetch_data_received(intrusive< sisl::GenericRpcData >& rpc_data);
     void fetch_data_from_remote(std::vector< repl_req_ptr_t > rreqs);
+    void handle_fetch_data_response(sisl::GenericClientResponse response, std::vector< repl_req_ptr_t > rreqs);
     bool is_resync_mode() { return m_resync_mode; }
     void handle_error(repl_req_ptr_t const& rreq, ReplServiceError err);
     bool wait_for_data_receive(std::vector< repl_req_ptr_t > const& rreqs, uint64_t timeout_ms);

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -122,10 +122,10 @@ public:
     void use_config(json_superblk raft_config_sb);
     void report_committed(repl_req_ptr_t rreq);
     repl_req_ptr_t repl_key_to_req(repl_key const& rkey) const;
-    repl_req_ptr_t applier_create_req(repl_key const& rkey, sisl::blob const& user_header, sisl::blob const& user_key,
-                                      uint32_t data_size, bool is_data_channel);
-    AsyncNotify notify_after_data_written(std::vector< repl_req_ptr_t >* rreqs);
-    void check_and_fetch_remote_data(std::vector< repl_req_ptr_t > const& rreqs);
+    repl_req_ptr_t applier_create_req(repl_key const& rkey, sisl::blob const& user_header, uint32_t data_size,
+                                      bool is_data_channel);
+    folly::Future< folly::Unit > notify_after_data_written(std::vector< repl_req_ptr_t >* rreqs);
+    void check_and_fetch_remote_data(std::vector< repl_req_ptr_t > rreqs);
     void cp_flush(CP* cp);
     void cp_cleanup(CP* cp);
 
@@ -155,6 +155,7 @@ private:
     void fetch_data_from_remote(std::vector< repl_req_ptr_t > rreqs);
     bool is_resync_mode() { return m_resync_mode; }
     void handle_error(repl_req_ptr_t const& rreq, ReplServiceError err);
+    bool wait_for_data_receive(std::vector< repl_req_ptr_t > const& rreqs, uint64_t timeout_ms);
 };
 
 } // namespace homestore

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -105,7 +105,7 @@ public:
     void async_free_blks(int64_t lsn, MultiBlkId const& blkid) override;
     AsyncReplResult<> become_leader() override;
     bool is_leader() const override;
-    const replica_id_t get_leader_id() const override;
+    replica_id_t get_leader_id() const override;
     std::vector< peer_info > get_replication_status() const override;
     group_id_t group_id() const override { return m_group_id; }
     std::string group_id_str() const { return boost::uuids::to_string(m_group_id); }
@@ -123,8 +123,9 @@ public:
     void report_committed(repl_req_ptr_t rreq);
     repl_req_ptr_t repl_key_to_req(repl_key const& rkey) const;
     repl_req_ptr_t applier_create_req(repl_key const& rkey, sisl::blob const& user_header, sisl::blob const& user_key,
-                                      uint32_t data_size);
+                                      uint32_t data_size, bool is_data_channel);
     AsyncNotify notify_after_data_written(std::vector< repl_req_ptr_t >* rreqs);
+    void check_and_fetch_remote_data(std::vector< repl_req_ptr_t > const& rreqs);
     void cp_flush(CP* cp);
     void cp_cleanup(CP* cp);
 
@@ -143,13 +144,14 @@ protected:
     std::shared_ptr< nuraft::state_machine > get_state_machine() override;
     void permanent_destroy() override;
     void leave() override;
+    std::pair< bool, nuraft::cb_func::ReturnCode > handle_raft_event(nuraft::cb_func::Type,
+                                                                     nuraft::cb_func::Param*) override;
 
 private:
     shared< nuraft::log_store > data_journal() { return m_data_journal; }
     void push_data_to_all_followers(repl_req_ptr_t rreq);
     void on_push_data_received(intrusive< sisl::GenericRpcData >& rpc_data);
     void on_fetch_data_received(intrusive< sisl::GenericRpcData >& rpc_data);
-    void check_and_fetch_remote_data(std::vector< repl_req_ptr_t >* rreqs);
     void fetch_data_from_remote(std::vector< repl_req_ptr_t > rreqs);
     bool is_resync_mode() { return m_resync_mode; }
     void handle_error(repl_req_ptr_t const& rreq, ReplServiceError err);

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -79,8 +79,8 @@ repl_req_ptr_t RaftStateMachine::localize_journal_entry_prepare(nuraft::log_entr
     RELEASE_ASSERT_EQ(jentry->major_version, repl_journal_entry::JOURNAL_ENTRY_MAJOR,
                       "Mismatched version of journal entry received from RAFT peer");
 
-    RD_LOG(TRACE, "Raft Channel: Localizing Raft log_entry: term={}, journal_entry=[{}] ", jentry->server_id,
-           lentry.get_term(), jentry->dsn, jentry->to_string());
+    RD_LOG(TRACE, "Raft Channel: Localizing Raft log_entry: server_id={}, term={}, journal_entry=[{}] ",
+           jentry->server_id, lentry.get_term(), jentry->to_string());
 
     auto entry_to_hdr = [](repl_journal_entry* jentry) {
         return sisl::blob{uintptr_cast(jentry) + sizeof(repl_journal_entry), jentry->user_header_size};

--- a/src/lib/replication/repl_dev/raft_state_machine.h
+++ b/src/lib/replication/repl_dev/raft_state_machine.h
@@ -109,7 +109,8 @@ public:
 
     ////////// APIs outside of nuraft::state_machine requirements ////////////////////
     ReplServiceError propose_to_raft(repl_req_ptr_t rreq);
-    repl_req_ptr_t transform_journal_entry(nuraft::ptr< nuraft::log_entry >& lentry);
+    repl_req_ptr_t localize_journal_entry_prepare(nuraft::log_entry& lentry);
+    repl_req_ptr_t localize_journal_entry_finish(nuraft::log_entry& lentry);
     void link_lsn_to_req(repl_req_ptr_t rreq, int64_t lsn);
     repl_req_ptr_t lsn_to_req(int64_t lsn);
     nuraft_mesg::repl_service_ctx* group_msg_service();

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -49,11 +49,10 @@ public:
 
     AsyncReplResult<> become_leader() override { return make_async_error(ReplServiceError::OK); }
     bool is_leader() const override { return true; }
-    const replica_id_t get_leader_id() const override { return m_group_id; }
-    std::vector<peer_info> get_replication_status() const override {
-        return std::vector<peer_info>{peer_info {.id_ = m_group_id, .replication_idx_ = 0, .last_succ_resp_us_ = 0}};
+    replica_id_t get_leader_id() const override { return m_group_id; }
+    std::vector< peer_info > get_replication_status() const override {
+        return std::vector< peer_info >{peer_info{.id_ = m_group_id, .replication_idx_ = 0, .last_succ_resp_us_ = 0}};
     }
-
 
     uuid_t group_id() const override { return m_group_id; }
 
@@ -61,7 +60,6 @@ public:
 
     void cp_flush(CP* cp);
     void cp_cleanup(CP* cp);
-
 
 private:
     void write_journal(repl_req_ptr_t rreq);

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -313,9 +313,9 @@ void RaftReplService::stop_reaper_thread() {
     iomanager.run_on_wait(m_reaper_fiber, [] { iomanager.stop_io_loop(); });
 }
 
-void RaftReplService::add_to_fetch_queue(cshared< RaftReplDev >& rdev, std::vector< repl_req_ptr_t > const& rreqs) {
+void RaftReplService::add_to_fetch_queue(cshared< RaftReplDev >& rdev, std::vector< repl_req_ptr_t > rreqs) {
     std::unique_lock lg(m_pending_fetch_mtx);
-    m_pending_fetch_batches.push(std::make_pair(rdev, rreqs));
+    m_pending_fetch_batches.push(std::make_pair(rdev, std::move(rreqs)));
 }
 
 void RaftReplService::fetch_pending_data() {
@@ -330,7 +330,7 @@ void RaftReplService::fetch_pending_data() {
         m_pending_fetch_batches.pop();
         lg.unlock();
 
-        rdev->check_and_fetch_remote_data(next_batch);
+        rdev->check_and_fetch_remote_data(std::move(next_batch));
         lg.lock();
     }
 }

--- a/src/lib/replication/service/raft_repl_service.h
+++ b/src/lib/replication/service/raft_repl_service.h
@@ -56,7 +56,7 @@ public:
     std::shared_ptr< nuraft_mesg::mesg_state_mgr > create_state_mgr(int32_t srv_id,
                                                                     nuraft_mesg::group_id_t const& group_id) override;
     nuraft_mesg::Manager& msg_manager() { return *m_msg_mgr; }
-    void add_to_fetch_queue(cshared< RaftReplDev >& rdev, std::vector< repl_req_ptr_t > const& rreqs);
+    void add_to_fetch_queue(cshared< RaftReplDev >& rdev, std::vector< repl_req_ptr_t > rreqs);
 
 protected:
     ///////////////////// Overrides of GenericReplService ////////////////////

--- a/src/lib/replication/service/raft_repl_service.h
+++ b/src/lib/replication/service/raft_repl_service.h
@@ -14,6 +14,7 @@
  *********************************************************************************/
 #pragma once
 #include <map>
+#include <queue>
 #include <set>
 #include <string>
 #include <shared_mutex>
@@ -31,6 +32,8 @@
 namespace homestore {
 
 struct repl_dev_superblk;
+class RaftReplDev;
+
 class RaftReplService : public GenericReplService,
                         public nuraft_mesg::MessagingApplication,
                         public std::enable_shared_from_this< RaftReplService > {
@@ -38,6 +41,10 @@ private:
     shared< nuraft_mesg::Manager > m_msg_mgr;
     json_superblk m_config_sb;
     std::vector< std::pair< sisl::byte_view, void* > > m_config_sb_bufs;
+    std::mutex m_pending_fetch_mtx;
+    std::queue< std::pair< shared< RaftReplDev >, std::vector< repl_req_ptr_t > > > m_pending_fetch_batches;
+    iomgr::timer_handle_t m_rdev_fetch_timer_hdl;
+    iomgr::io_fiber_t m_reaper_fiber;
 
 public:
     RaftReplService(cshared< ReplApplication >& repl_app);
@@ -49,6 +56,7 @@ public:
     std::shared_ptr< nuraft_mesg::mesg_state_mgr > create_state_mgr(int32_t srv_id,
                                                                     nuraft_mesg::group_id_t const& group_id) override;
     nuraft_mesg::Manager& msg_manager() { return *m_msg_mgr; }
+    void add_to_fetch_queue(cshared< RaftReplDev >& rdev, std::vector< repl_req_ptr_t > const& rreqs);
 
 protected:
     ///////////////////// Overrides of GenericReplService ////////////////////
@@ -63,6 +71,9 @@ protected:
 
 private:
     void raft_group_config_found(sisl::byte_view const& buf, void* meta_cookie);
+    void start_reaper_thread();
+    void stop_reaper_thread();
+    void fetch_pending_data();
 };
 
 class RaftReplServiceCPHandler : public CPCallbacks {

--- a/src/tests/test_blk_read_tracker.cpp
+++ b/src/tests/test_blk_read_tracker.cpp
@@ -26,7 +26,7 @@
 using namespace homestore;
 
 SISL_LOGGING_INIT(HOMESTORE_LOG_MODS)
-SISL_OPTIONS_ENABLE(logging, test_blk_read_tracker)
+SISL_OPTIONS_ENABLE(logging, test_blk_read_tracker, nuraft_mesg)
 
 VENUM(op_type_t, uint8_t, insert = 0, remove = 1, wait_on = 2, max_op = 3);
 class BlkReadTrackerTest : public testing::Test {

--- a/src/tests/test_blkid.cpp
+++ b/src/tests/test_blkid.cpp
@@ -8,7 +8,7 @@
 #include <homestore/blk.h>
 
 SISL_LOGGING_INIT(HOMESTORE_LOG_MODS)
-SISL_OPTIONS_ENABLE(logging, test_blkid)
+SISL_OPTIONS_ENABLE(logging, test_blkid, nuraft_mesg)
 
 SISL_OPTION_GROUP(test_blkid,
                   (num_iterations, "", "num_iterations", "number of iterations",
@@ -65,7 +65,7 @@ TEST(BlkIdTest, SingleBlkIdInMap) {
 TEST(BlkIdTest, MultiBlkIdTest) {
     MultiBlkId mb1;
     ASSERT_EQ(mb1.is_valid(), false);
-    ASSERT_EQ(mb1.to_string(), "MultiBlks: {}");
+    ASSERT_EQ(mb1.to_string(), "[]");
     ASSERT_EQ(mb1.is_multi(), true);
     ASSERT_EQ(mb1.num_pieces(), 0);
 

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -186,7 +186,7 @@ public:
 
         if (fake_restart) {
             shutdown_homestore(false);
-            // sisl::GrpcAsyncClientWorker::shutdown_all();
+            sisl::GrpcAsyncClientWorker::shutdown_all();
             std::this_thread::sleep_for(std::chrono::seconds{shutdown_delay_sec});
         }
 

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -186,7 +186,6 @@ public:
 
         if (fake_restart) {
             shutdown_homestore(false);
-            sisl::GrpcAsyncClientWorker::shutdown_all();
             std::this_thread::sleep_for(std::chrono::seconds{shutdown_delay_sec});
         }
 

--- a/src/tests/test_raft_repl_dev.cpp
+++ b/src/tests/test_raft_repl_dev.cpp
@@ -24,6 +24,8 @@
 #include <sisl/fds/buffer.hpp>
 #include <folly/init/Init.h>
 #include <folly/executors/GlobalExecutor.h>
+#include <boost/uuid/nil_generator.hpp>
+
 #include <gtest/gtest.h>
 #include <iomgr/iomgr_flip.hpp>
 #include <homestore/blk.h>
@@ -115,12 +117,13 @@ public:
         Value v{
             .lsn_ = lsn, .data_size_ = jheader->data_size, .data_pattern_ = jheader->data_pattern, .blkid_ = blkids};
 
-        LOGINFO("[Replica={}] Received commit on lsn={} key={} value[blkid={} pattern={}]", g_helper->replica_num(),
-                lsn, k.id_, v.blkid_.to_string(), v.data_pattern_);
+        LOGINFOMOD(replication, "[Replica={}] Received commit on lsn={} dsn={} key={} value[blkid={} pattern={}]",
+                   g_helper->replica_num(), lsn, ctx->dsn(), k.id_, v.blkid_.to_string(), v.data_pattern_);
 
         {
             std::unique_lock lk(db_mtx_);
             inmem_db_.insert_or_assign(k, v);
+            ++commit_count_;
         }
 
         if (ctx->is_proposer) { g_helper->runner().next_task(); }
@@ -128,22 +131,23 @@ public:
 
     bool on_pre_commit(int64_t lsn, const sisl::blob& header, const sisl::blob& key,
                        cintrusive< repl_req_ctx >& ctx) override {
-        LOGINFO("[Replica={}] Received pre-commit on lsn={}", g_helper->replica_num(), lsn);
+        LOGINFOMOD(replication, "[Replica={}] Received pre-commit on lsn={} dsn={}", g_helper->replica_num(), lsn,
+                   ctx->dsn());
         return true;
     }
 
     void on_rollback(int64_t lsn, const sisl::blob& header, const sisl::blob& key,
                      cintrusive< repl_req_ctx >& ctx) override {
-        LOGINFO("[Replica={}] Received rollback on lsn={}", g_helper->replica_num(), lsn);
+        LOGINFOMOD(replication, "[Replica={}] Received rollback on lsn={}", g_helper->replica_num(), lsn);
     }
 
     void on_error(ReplServiceError error, const sisl::blob& header, const sisl::blob& key,
                   cintrusive< repl_req_ctx >& ctx) override {
-        LOGINFO("[Replica={}] Received error={} on key={}", g_helper->replica_num(), enum_name(error),
-                *(r_cast< uint64_t const* >(key.cbytes())));
+        LOGINFOMOD(replication, "[Replica={}] Received error={} on key={}", g_helper->replica_num(), enum_name(error),
+                   *(r_cast< uint64_t const* >(key.cbytes())));
     }
 
-    blk_alloc_hints get_blk_alloc_hints(sisl::blob const& header, uint32_t data_size) override {
+    ReplResult< blk_alloc_hints > get_blk_alloc_hints(sisl::blob const& header, uint32_t data_size) override {
         return blk_alloc_hints{};
     }
 
@@ -167,8 +171,8 @@ public:
     void validate_db_data() {
         g_helper->runner().set_num_tasks(inmem_db_.size());
 
-        LOGINFO("[{}]: Total {} keys committed, validating them", boost::uuids::to_string(repl_dev()->group_id()),
-                inmem_db_.size());
+        LOGINFOMOD(replication, "[{}]: Total {} keys committed, validating them",
+                   boost::uuids::to_string(repl_dev()->group_id()), inmem_db_.size());
         auto it = inmem_db_.begin();
         g_helper->runner().set_task([this, &it]() {
             Key k;
@@ -191,8 +195,8 @@ public:
                                                                      v.data_pattern_);
                         iomanager.iobuf_free(uintptr_cast(iov.iov_base));
                     }
-                    LOGINFO("Validated successfully key={} value[blkid={} pattern={}]", k.id_, v.blkid_.to_string(),
-                            v.data_pattern_);
+                    LOGINFOMOD(replication, "Validated successfully key={} value[blkid={} pattern={}]", k.id_,
+                               v.blkid_.to_string(), v.data_pattern_);
                     g_helper->runner().next_task();
                 });
             } else {
@@ -202,7 +206,10 @@ public:
         g_helper->runner().execute().get();
     }
 
-    uint64_t db_num_writes() const { return m_num_commits.load(std::memory_order_relaxed); }
+    uint64_t db_commit_count() const {
+        std::shared_lock lk(db_mtx_);
+        return commit_count_;
+    }
 
     uint64_t db_size() const {
         std::shared_lock lk(db_mtx_);
@@ -211,6 +218,7 @@ public:
 
 private:
     std::map< Key, Value > inmem_db_;
+    uint64_t commit_count_{0};
     std::shared_mutex db_mtx_;
     std::atomic< uint64_t > m_num_commits;
 };
@@ -230,19 +238,23 @@ public:
         pick_one_db().db_write(data_size, max_size_per_iov);
     }
 
-    void wait_for_all_writes(uint64_t exp_writes) {
+    void wait_for_all_commits() { wait_for_commits(written_entries_); }
+
+    void wait_for_commits(uint64_t exp_writes) {
+        uint64_t total_writes{0};
         while (true) {
-            uint64_t total_writes{0};
+            total_writes = 0;
             for (auto const& db : dbs_) {
-                total_writes += db->db_num_writes();
+                total_writes += db->db_commit_count();
             }
 
             if (total_writes >= exp_writes) { break; }
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
+        LOGINFO("Replica={} has received {} commits as expected", g_helper->replica_num(), total_writes);
     }
 
-    void validate_all_data() {
+    void validate_data() {
         for (auto const& db : dbs_) {
             db->validate_db_data();
         }
@@ -251,187 +263,199 @@ public:
     TestReplicatedDB& pick_one_db() { return *dbs_[0]; }
 
 #ifdef _PRERELEASE
-    void set_flip_point(const std::string flip_name) {
+    void set_basic_flip(const std::string flip_name, uint32_t count = 1, uint32_t percent = 100) {
         flip::FlipCondition null_cond;
         flip::FlipFrequency freq;
-        freq.set_count(1);
-        freq.set_percent(100);
+        freq.set_count(count);
+        freq.set_percent(percent);
         m_fc.inject_noreturn_flip(flip_name, {null_cond}, freq);
+        LOGDEBUG("Flip {} set", flip_name);
+    }
+
+    void set_delay_flip(const std::string flip_name, uint64_t delay_usec, uint32_t count = 1, uint32_t percent = 100) {
+        flip::FlipCondition null_cond;
+        flip::FlipFrequency freq;
+        freq.set_count(count);
+        freq.set_percent(percent);
+        m_fc.inject_delay_flip(flip_name, {null_cond}, freq, delay_usec);
         LOGDEBUG("Flip {} set", flip_name);
     }
 #endif
 
-    void switch_all_db_leader() {
-        for (auto const& db : dbs_) {
-            do {
-                auto result = db->repl_dev()->become_leader().get();
-                if (result.hasError()) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-                } else {
-                    break;
+    void assign_leader(uint16_t replica) {
+        LOGINFO("Switch the leader to replica_num = {}", replica);
+        if (g_helper->replica_num() == replica) {
+            for (auto const& db : dbs_) {
+                do {
+                    auto result = db->repl_dev()->become_leader().get();
+                    if (result.hasError()) {
+                        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+                    } else {
+                        break;
+                    }
+                } while (true);
+            }
+        } else {
+            for (auto const& db : dbs_) {
+                homestore::replica_id_t leader_uuid;
+                while (true) {
+                    leader_uuid = db->repl_dev()->get_leader_id();
+                    if (!leader_uuid.is_nil() && (g_helper->member_id(leader_uuid) == replica)) { break; }
+
+                    LOGINFO("Waiting for replica={} to become leader", replica);
+                    std::this_thread::sleep_for(std::chrono::milliseconds{500});
                 }
-            } while (true);
+            }
+        }
+    }
+
+    void write_on_leader(uint32_t num_entries, bool wait_for_commit = true) {
+        auto leader_uuid = dbs_[0]->repl_dev()->get_leader_id();
+
+        if (!leader_uuid.is_nil() && (leader_uuid == g_helper->my_replica_id())) {
+            LOGINFO("Writing {} entries since I am the leader my_uuid={}", num_entries,
+                    boost::uuids::to_string(g_helper->my_replica_id()));
+            auto const block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
+            g_helper->runner().set_num_tasks(num_entries);
+
+            LOGINFO("Run on worker threads to schedule append on repldev for {} Bytes.", block_size);
+            g_helper->runner().set_task([this, block_size]() {
+                static std::normal_distribution<> num_blks_gen{3.0, 2.0};
+                this->generate_writes(std::abs(std::round(num_blks_gen(g_re))) * block_size, block_size);
+            });
+            g_helper->runner().execute().get();
+        } else {
+            LOGINFO("{} entries were written on the leader_uuid={} my_uuid={}", num_entries,
+                    boost::uuids::to_string(leader_uuid), boost::uuids::to_string(g_helper->my_replica_id()));
+        }
+        written_entries_ += num_entries;
+        if (wait_for_commit) { this->wait_for_all_commits(); }
+    }
+
+    void restart_replica(uint16_t replica, uint32_t shutdown_delay_sec = 5u) {
+        if (g_helper->replica_num() == replica) {
+            LOGINFO("Restart homestore: replica_num = {}", replica);
+            g_helper->restart(shutdown_delay_sec);
+            // g_helper->sync_for_test_start();
+        } else {
+            LOGINFO("Wait for replica={} to completely go down and removed from alive raft-groups", replica);
+            std::this_thread::sleep_for(std::chrono::seconds{5});
         }
     }
 
 private:
     std::vector< std::shared_ptr< TestReplicatedDB > > dbs_;
+    uint32_t written_entries_{0};
+
 #ifdef _PRERELEASE
     flip::FlipClient m_fc{iomgr_flip::instance()};
 #endif
 };
 
-TEST_F(RaftReplDevTest, All_Append_Restart_Append) {
+TEST_F(RaftReplDevTest, Write_Restart_Write) {
     LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
     g_helper->sync_for_test_start();
 
-    uint64_t exp_entries = SISL_OPTIONS["num_io"].as< uint64_t >();
-    if (g_helper->replica_num() == 0) {
-        auto block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
-        LOGINFO("Run on worker threads to schedule append on repldev for {} Bytes.", block_size);
-        g_helper->runner().set_task([this, block_size]() {
-            static std::normal_distribution<> num_blks_gen{3.0, 2.0};
-            this->generate_writes(std::abs(std::round(num_blks_gen(g_re))) * block_size, block_size);
-        });
-        g_helper->runner().execute().get();
-    }
-    this->wait_for_all_writes(exp_entries);
+    uint64_t entries_per_attempt = SISL_OPTIONS["num_io"].as< uint64_t >();
+    this->write_on_leader(entries_per_attempt, true /* wait_for_commit */);
 
     g_helper->sync_for_verify_start();
     LOGINFO("Validate all data written so far by reading them");
-    this->validate_all_data();
+    this->validate_data();
     g_helper->sync_for_cleanup_start();
 
     LOGINFO("Restart all the homestore replicas");
     g_helper->restart();
     g_helper->sync_for_test_start();
 
-    exp_entries += SISL_OPTIONS["num_io"].as< uint64_t >();
-    if (g_helper->replica_num() == 0) {
-        LOGINFO("Switch the leader to replica_num = 0");
-        this->switch_all_db_leader();
+    // Reassign the leader to replica 0, in case restart switched leaders
+    this->assign_leader(0);
 
-        LOGINFO("Post restart write the data again");
-        auto block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
-        g_helper->runner().set_task([this, block_size]() {
-            static std::normal_distribution<> num_blks_gen{3.0, 2.0};
-            this->generate_writes(std::abs(std::round(num_blks_gen(g_re))) * block_size, block_size);
-        });
-        g_helper->runner().execute().get();
-    }
-    this->wait_for_all_writes(exp_entries);
+    LOGINFO("Post restart write the data again on the leader");
+    this->write_on_leader(entries_per_attempt, true /* wait_for_commit */);
 
     LOGINFO("Validate all data written (including pre-restart data) by reading them");
-    this->validate_all_data();
+    this->validate_data();
     g_helper->sync_for_cleanup_start();
 }
-
-TEST_F(RaftReplDevTest, All_Append_Fetch_Remote_Data) {
-    LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
-    g_helper->sync_for_test_start();
 
 #ifdef _PRERELEASE
-    set_flip_point("simulate_fetch_remote_data");
-#endif
-
-    if (g_helper->replica_num() == 0) {
-        // g_helper->sync_dataset_size(SISL_OPTIONS["num_io"].as< uint64_t >());
-        g_helper->sync_dataset_size(100);
-        auto block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
-        LOGINFO("Run on worker threads to schedule append on repldev for {} Bytes.", block_size);
-        g_helper->runner().set_task([this, block_size]() {
-            this->generate_writes(block_size /* data_size */, block_size /* max_size_per_iov */);
-        });
-        g_helper->runner().execute().get();
-    }
-
-    this->wait_for_all_writes(g_helper->dataset_size());
-
-    g_helper->sync_for_verify_start();
-
-    LOGINFO("Validate all data written so far by reading them");
-    this->validate_all_data();
-
-    g_helper->sync_for_cleanup_start();
-}
-
-// do some io before restart;
-TEST_F(RaftReplDevTest, All_restart_one_follower_inc_resync) {
+TEST_F(RaftReplDevTest, Follower_Fetch_OnActive_ReplicaGroup) {
     LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
     g_helper->sync_for_test_start();
 
-    // step-0: do some IO before restart one member;
-    uint64_t exp_entries = 20;
-    if (g_helper->replica_num() == 0) {
-        g_helper->runner().set_num_tasks(exp_entries);
-        auto block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
-        LOGINFO("Run on worker threads to schedule append on repldev for {} Bytes.", block_size);
-        g_helper->runner().set_task([this, block_size]() {
-            this->generate_writes(block_size /* data_size */, block_size /* max_size_per_iov */);
-        });
-        g_helper->runner().execute().get();
-    }
-
-    // step-1: wait for all writes to be completed
-    this->wait_for_all_writes(exp_entries);
-
-    // step-2: restart one non-leader replica
-    if (g_helper->replica_num() == 1) {
-        LOGINFO("Restart homestore: replica_num = 1");
-        g_helper->restart(10 /* shutdown_delay_sec */);
-        // g_helper->sync_for_test_start();
-    }
-
-    exp_entries += SISL_OPTIONS["num_io"].as< uint64_t >();
-    // step-3: on leader, wait for a while for replica-1 to finish shutdown so that it can be removed from raft-groups
-    // and following I/O issued by leader won't be pushed to relica-1;
-    if (g_helper->replica_num() == 0) {
-        LOGINFO("Wait for grpc connection to replica-1 to expire and removed from raft-groups.");
-        std::this_thread::sleep_for(std::chrono::seconds{5});
-
-        g_helper->runner().set_num_tasks(SISL_OPTIONS["num_io"].as< uint64_t >());
-
-        // before replica-1 started, issue I/O so that replica-1 is lagging behind;
-        auto block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
-        LOGINFO("Run on worker threads to schedule append on repldev for {} Bytes.", block_size);
-        g_helper->runner().set_task([this, block_size]() {
-            this->generate_writes(block_size /* data_size */, block_size /* max_size_per_iov */);
-        });
-        g_helper->runner().execute().get();
-    }
-
-    this->wait_for_all_writes(exp_entries);
+    set_basic_flip("drop_push_data_request");
+    this->write_on_leader(100, true /* wait_for_commit */);
 
     g_helper->sync_for_verify_start();
+
     LOGINFO("Validate all data written so far by reading them");
-    this->validate_all_data();
+    this->validate_data();
+
     g_helper->sync_for_cleanup_start();
 }
+#endif
+
+// do some io before restart;
+TEST_F(RaftReplDevTest, Follower_Incremental_Resync) {
+    LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
+    g_helper->sync_for_test_start();
+
+    // step-0: do some IO before restart one member and wait for all writes to be completed
+    this->write_on_leader(20, true /* wait for commit on all */);
+
+    // step-1: Modify the settings to force multiple fetch batches
+    uint32_t prev_max{2 * 1024 * 1024};
+
+    LOGINFO("Set the max fetch to be fairly small to force multiple batches")
+    HS_SETTINGS_FACTORY().modifiable_settings([&prev_max](auto& s) {
+        prev_max = s.consensus.data_fetch_max_size_kb;
+        s.consensus.data_fetch_max_size_kb = SISL_OPTIONS["block_size"].as< uint32_t >() * 2; // Make it max 2 blocks
+    });
+    HS_SETTINGS_FACTORY().save();
+
+    // step-2: restart one non-leader replica
+    this->restart_replica(1, 10 /* shutdown_delay_sec */);
+
+    // step-3 before replica-1 started, issue I/O so that replica-1 is lagging behind and get resynced
+    this->write_on_leader(SISL_OPTIONS["num_io"].as< uint64_t >(), true /* wait for commit on all*/);
+
+    // step-4 validate for all the data writes
+    g_helper->sync_for_verify_start();
+    LOGINFO("Validate all data written so far by reading them");
+    this->validate_data();
+
+    // step-5: Set the settings back and save. This is needed (if we ever give a --config in the test)
+    LOGINFO("Set the max fetch back to previous value={}", prev_max);
+    HS_SETTINGS_FACTORY().modifiable_settings([prev_max](auto& s) {
+        s.consensus.data_fetch_max_size_kb = prev_max; //
+    });
+    HS_SETTINGS_FACTORY().save();
+
+    g_helper->sync_for_cleanup_start();
+}
+
+#if 0
 //
 // staging the fetch remote data with flip point;
 //
-TEST_F(RaftReplDevTest, All_restart_one_follower_inc_resync_with_staging) {
+TEST_F(RaftReplDevTest, Follower_Incr_Resync_With_Staging) {
     LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
     g_helper->sync_for_test_start();
 
 #ifdef _PRERELEASE
-    set_flip_point("simulate_staging_fetch_data");
+    set_basic_flip("simulate_staging_fetch_data");
 #endif
 
     // step-0: do some IO before restart one member;
     uint64_t exp_entries = 20;
     if (g_helper->replica_num() == 0) {
         g_helper->runner().set_num_tasks(20);
-        auto block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
-        LOGINFO("Run on worker threads to schedule append on repldev for {} Bytes.", block_size);
-        g_helper->runner().set_task([this, block_size]() {
-            this->generate_writes(block_size /* data_size */, block_size /* max_size_per_iov */);
-        });
-        g_helper->runner().execute().get();
+        this->write_on_leader();
     }
 
     // step-1: wait for all writes to be completed
-    this->wait_for_all_writes(exp_entries);
+    this->wait_for_all_commits();
 
     // step-2: restart one non-leader replica
     if (g_helper->replica_num() == 1) {
@@ -450,80 +474,117 @@ TEST_F(RaftReplDevTest, All_restart_one_follower_inc_resync_with_staging) {
         g_helper->runner().set_num_tasks(SISL_OPTIONS["num_io"].as< uint64_t >());
 
         // before replica-1 started, issue I/O so that replica-1 is lagging behind;
-        auto block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
-        LOGINFO("Run on worker threads to schedule append on repldev for {} Bytes.", block_size);
-        g_helper->runner().set_task([this, block_size]() {
-            this->generate_writes(block_size /* data_size */, block_size /* max_size_per_iov */);
-        });
-        g_helper->runner().execute().get();
+        this->write_on_leader();
     }
 
-    this->wait_for_all_writes(exp_entries);
+    this->wait_for_all_commits();
 
     g_helper->sync_for_verify_start();
     LOGINFO("Validate all data written so far by reading them");
-    this->validate_all_data();
+    this->validate_data();
     g_helper->sync_for_cleanup_start();
 }
+#endif
 
-// do some io before restart;
-TEST_F(RaftReplDevTest, All_restart_leader) {
+#ifdef _PRERELEASE
+TEST_F(RaftReplDevTest, Follower_Reject_Append) {
     LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
     g_helper->sync_for_test_start();
 
-    // step-0: do some IO before restart one member;
-    uint64_t exp_entries = 20;
-    if (g_helper->replica_num() == 0) {
-        g_helper->runner().set_num_tasks(exp_entries);
-        auto block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
-        LOGINFO("Run on worker threads to schedule append on repldev for {} Bytes.", block_size);
-        g_helper->runner().set_task([this, block_size]() {
-            this->generate_writes(block_size /* data_size */, block_size /* max_size_per_iov */);
-        });
-        g_helper->runner().execute().get();
-    }
+    LOGINFO("Set flip to fake reject append entries in both data and raft channels. We slow down data channel "
+            "occassionally so that raft channel reject can be hit");
+    set_basic_flip("fake_reject_append_data_channel", 5, 10);
+    set_basic_flip("fake_reject_append_raft_channel", 10, 100);
+    set_delay_flip("slow_down_data_channel", 10000ull, 10, 10);
 
-    // step-1: wait for all writes to be completed
-    this->wait_for_all_writes(exp_entries);
-
-    // step-2: restart leader replica
-    if (g_helper->replica_num() == 0) {
-        LOGINFO("Restart homestore: replica_num = 0");
-        g_helper->restart(10 /* shutdown_delay_sec */);
-        // g_helper->sync_for_test_start();
-    }
-
-    exp_entries += SISL_OPTIONS["num_io"].as< uint64_t >();
-    // step-3: on leader, wait for a while for replica-1 to finish shutdown so that it can be removed from raft-groups
-    // and following I/O issued by leader won't be pushed to relica-1;
-    if (g_helper->replica_num() == 1) {
-        LOGINFO("Wait for grpc connection to replica-0 to be removed from raft-groups, and wait for awhile before "
-                "sending new I/O.");
-        std::this_thread::sleep_for(std::chrono::seconds{5});
-
-        LOGINFO("Switch the leader to replica_num = 1");
-        switch_all_db_leader();
-
-        g_helper->runner().set_num_tasks(SISL_OPTIONS["num_io"].as< uint64_t >());
-
-        // before replica-1 started, issue I/O so that replica-1 is lagging behind;
-        auto block_size = SISL_OPTIONS["block_size"].as< uint32_t >();
-        LOGINFO("Run on worker threads to schedule append on repldev for {} Bytes.", block_size);
-        g_helper->runner().set_task([this, block_size]() {
-            this->generate_writes(block_size /* data_size */, block_size /* max_size_per_iov */);
-        });
-        g_helper->runner().execute().get();
-    }
-
-    this->wait_for_all_writes(exp_entries);
-
-    if (g_helper->replica_num() != 0) { std::this_thread::sleep_for(std::chrono::seconds{10}); }
+    LOGINFO("Write to leader and then wait for all the commits on all replica despite drop/slow_down");
+    this->write_on_leader(SISL_OPTIONS["num_io"].as< uint64_t >(), true /* wait_for_all_commits */);
 
     g_helper->sync_for_verify_start();
     LOGINFO("Validate all data written so far by reading them");
-    this->validate_all_data();
+    this->validate_data();
     g_helper->sync_for_cleanup_start();
 }
+#endif
+
+TEST_F(RaftReplDevTest, Resync_From_Non_Originator) {
+    LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
+    g_helper->sync_for_test_start();
+
+    // Step 1: Fill up entries on all replicas
+    uint64_t entries_per_attempt = SISL_OPTIONS["num_io"].as< uint64_t >();
+    this->write_on_leader(entries_per_attempt, true /* wait for commit on all */);
+
+    // Step 2: Restart replica-2 (follower) with a very long delay so that it is lagging behind
+    this->restart_replica(2, 10 /* shutdown_delay_sec */);
+
+    // Step 3: While one follower is down, insert more entries on remaining replicas
+    LOGINFO("After one follower is shutdown, insert more entries");
+    this->write_on_leader(entries_per_attempt, true /* no need to wait for commit */);
+
+    // Step 4: Switch to a new leader (replica-1)  and then add more entries
+    LOGINFO("Switch to a new leader and insert more entries");
+    this->assign_leader(1); // Assign replica-1 as new leader
+    this->write_on_leader(entries_per_attempt, true /* no need to wait for commit */);
+
+    g_helper->sync_for_verify_start();
+    LOGINFO("Validate all data written so far by reading them");
+    this->validate_data();
+    g_helper->sync_for_cleanup_start();
+}
+
+TEST_F(RaftReplDevTest, Leader_Restart) {
+    LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
+    g_helper->sync_for_test_start();
+
+    // Step 1: Fill up entries on all replicas
+    uint64_t entries_per_attempt = SISL_OPTIONS["num_io"].as< uint64_t >();
+    this->write_on_leader(entries_per_attempt, true /* wait for commit on all replicas */);
+
+    // Step 2: Restart replica-0 (Leader) with a very long delay so that it is lagging behind
+    this->restart_replica(0, 10 /* shutdown_delay_sec */);
+
+    // Step 3: While the original leader is down, write entries into the new leader
+    LOGINFO("After original leader is shutdown, insert more entries into the new leader");
+    this->write_on_leader(entries_per_attempt, true /* wait for commit on all replicas */);
+
+    g_helper->sync_for_verify_start();
+    LOGINFO("Validate all data written so far by reading them");
+    this->validate_data();
+    g_helper->sync_for_cleanup_start();
+}
+
+#if 0
+TEST_F(RaftReplDevTest, Drop_Raft_Entry_Switch_Leader) {
+    LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
+    g_helper->sync_for_test_start();
+
+    LOGINFO("Aim of this test is to drop raft entry and ensure that they are retried. In addition, we drop raft entry  "
+            "and we also switch leader to ensure that the dropped entry is retried by the new leader");
+
+    if (g_helper->replica_num() == 2) {
+        LOGINFO("Set flip to fake drop append entries in raft channel of replica=2");
+        set_basic_flip("fake_drop_append_raft_channel", 2, 75);
+    }
+
+    uint64_t exp_entries = SISL_OPTIONS["num_io"].as< uint64_t >();
+    if (g_helper->replica_num() == 0) { this->write_on_leader(); }
+    LOGINFO(
+        "Even after drop on replica=2, lets validate that data written is synced on all members (after retry to 2)");
+    this->wait_for_all_commits();
+
+    if (g_helper->replica_num() == 2) {
+        LOGINFO("Set flip to fake drop append entries in raft channel of replica=2 again");
+        set_basic_flip("fake_drop_append_raft_channel", 1, 100);
+    } else {
+        g_helper->sync_dataset_size(1);
+        if (g_helper->replica_num() == 0) { this->write_on_leader(); }
+
+        exp_entries += 1;
+        this->wait_for_all_commits();
+    }
+}
+#endif
 
 // TODO
 // double restart:
@@ -534,20 +595,34 @@ TEST_F(RaftReplDevTest, All_restart_leader) {
 //
 
 int main(int argc, char* argv[]) {
-    int parsed_argc{argc};
+    int parsed_argc = argc;
     char** orig_argv = argv;
+
+    // Save the args for replica use
+    std::vector< std::string > args;
+    for (int i = 0; i < argc; ++i) {
+        args.emplace_back(argv[i]);
+    }
 
     ::testing::InitGoogleTest(&parsed_argc, argv);
 
     SISL_OPTIONS_LOAD(parsed_argc, argv, logging, config, test_raft_repl_dev, iomgr, test_common_setup,
                       test_repl_common_setup);
 
+    // Entire test suite assumes that once a replica takes over as leader, it stays until it is explicitly yielded.
+    // Otherwise it is very hard to control or accurately test behavior. Hence we forcibly override the
+    // leadership_expiry time.
+    HS_SETTINGS_FACTORY().modifiable_settings([](auto& s) { s.consensus.leadership_expiry_ms = -1; });
+    HS_SETTINGS_FACTORY().save();
+
     FLAGS_folly_global_cpu_executor_threads = 4;
-    g_helper = std::make_unique< test_common::HSReplTestHelper >("test_raft_repl_dev", argc, orig_argv);
+    g_helper = std::make_unique< test_common::HSReplTestHelper >("test_raft_repl_dev", args, orig_argv);
     g_helper->setup();
 
+#if 0
     (g_helper->replica_num() == 0) ? ::testing::GTEST_FLAG(filter) = "*Primary_*:*All_*"
                                    : ::testing::GTEST_FLAG(filter) = "*Secondary_*::*All_*";
+#endif
 
     auto ret = RUN_ALL_TESTS();
     g_helper->teardown();

--- a/src/tests/test_solo_repl_dev.cpp
+++ b/src/tests/test_solo_repl_dev.cpp
@@ -117,7 +117,7 @@ public:
         void on_rollback(int64_t lsn, const sisl::blob& header, const sisl::blob& key,
                          cintrusive< repl_req_ctx >& ctx) override {}
 
-        blk_alloc_hints get_blk_alloc_hints(sisl::blob const& header, uint32_t data_size) override {
+        ReplResult< blk_alloc_hints > get_blk_alloc_hints(sisl::blob const& header, uint32_t data_size) override {
             return blk_alloc_hints{};
         }
 


### PR DESCRIPTION
Major changes in this PR includes:

* At present, there is no provision for consumer of replication to prevent the follower
from appending the logs. In case of linked data, its possible for followers to not have
enough space among other reasons to reject. This PR introduces pre-append and allow
consumers to return back error, which then again retried later. Not just allocation of
blocks for indirect data, but also this PR ensures that data is pulled, before accepting
pre-append on the follower that, there is no network related failures before writing the
log entry.

* In case of log entry has arrived first in raft channel, before data channel, at present
we start the timer then to wait. Instead this PR starts a global reaper thread, which wakes
up often to look for any pending fetches and thus data path, just put the fetch request to
the queue. This avoids expensive timer creation in data path.

* Added several robustness, error injection test cases to ensure stability under all conditions.

* These tests, exposes quiet a few errors in-terms of deadlocks between fetch, wait and grpc client
threads. Fixed all of them.

* Streamlined the test_raft_repl_dev testing, to be able to write the tests seamlessly.