### PR TITLE
SDSTOR-13146 : Update AM's /api/v1/utilization endpoint

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.8.1"
+    version = "3.8.2"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/homeblks/homeblks_http_server.cpp
+++ b/src/homeblks/homeblks_http_server.cpp
@@ -155,12 +155,13 @@ void HomeBlksHttpServer::set_log_level(const Pistache::Rest::Request& request,
 
     response.send(Pistache::Http::Code::Ok, resp);
 }
-void HomeBlksHttpServer::get_utilization(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response)
-{
-    const std::string vol_uuid = request.hasParam(":volumeUUID") ? request.param(":volumeUUID").as<std::string>():"";
+void HomeBlksHttpServer::get_utilization(const Pistache::Rest::Request& request,
+                                         Pistache::Http::ResponseWriter response) {
+    const std::string vol_uuid =
+        request.hasParam(":volumeUUID") ? request.param(":volumeUUID").as< std::string >() : "";
 
     VolumePtr vol = nullptr;
-    if (vol_uuid.length() != 0) {
+    if (vol_uuid.length()) {
         boost::uuids::string_generator gen;
         boost::uuids::uuid uuid = gen(vol_uuid);
         vol = VolInterface::get_instance()->lookup_volume(uuid);
@@ -170,10 +171,14 @@ void HomeBlksHttpServer::get_utilization(const Pistache::Rest::Request& request,
         }
     }
     nlohmann::json resp;
-    const auto total_data_size = VolInterface::get_instance()->get_system_capacity().initial_total_data_meta_size;
+    nlohmann::json partitions = nlohmann::json::array();
     for (auto [uuid, vol_used] : VolInterface::get_instance()->get_used_size(vol)) {
-        resp[boost::uuids::to_string(uuid)] = std::to_string(static_cast<double> (vol_used)/ total_data_size);
+        nlohmann::json partition;
+        partition["id"] = boost::uuids::to_string(uuid);
+        partition["usedCapacity"] = vol_used;
+        partitions.push_back(partition);
     }
+    resp["partitions"] = partitions;
     response.send(Pistache::Http::Code::Ok, resp.dump());
 }
 void HomeBlksHttpServer::get_log_level(const Pistache::Rest::Request& request,


### PR DESCRIPTION
change utilization format:

`curl http://localhost:5000/api/v1/utilization | jq .`

Sample output:

```
{
  "partitions": [
    {
      "id": "09a5cba0-49d6-4398-97ed-f85972a30087",
      "usedCapacity": 4943872
    },
    {
      "id": "32eb6671-42ca-4452-8592-05a1dfe108e1",
      "usedCapacity": 333242368
    },
    {
      "id": "600a0834-be08-414a-a8c4-d7b47469e5a5",
      "usedCapacity": 5619712
    },
    {
      "id": "ba7a1236-1a79-4cf7-8d40-cb3c38b10c81",
      "usedCapacity": 339243008
    }
  ]
}
```