### PR TITLE
prevent chunk_size overflow.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.2.3"
+    version = "6.2.4"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"


### PR DESCRIPTION
The default num_chunks is 1, if upper layer doesnt set num_chunk properly,  the
chunk_size(uint32) = device_size(uint64) / num_chunks(uint32)

can be overlow.