### PR TITLE
Fix varsizeBlkAllocator panic when initilized with small size.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,8 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.43"
+    version = "6.4.45"
+
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")

--- a/src/lib/blkalloc/blk_cache_queue.cpp
+++ b/src/lib/blkalloc/blk_cache_queue.cpp
@@ -36,6 +36,10 @@ FreeBlkCacheQueue::FreeBlkCacheQueue(const SlabCacheConfig& cfg, BlkAllocMetrics
         blk_num_t sum{0};
         for (const auto& p : slab_cfg.m_level_distribution_pct) {
             const blk_num_t limit{static_cast< blk_num_t >((static_cast< double >(slab_cfg.max_entries) * p) / 100.0)};
+            if (limit == 0) {
+                BLKALLOC_LOG(WARN, "Slab config distribution is zero, skipping this layer");
+                continue;
+            }
             sum += limit;
             level_limits.push_back(limit);
         }


### PR DESCRIPTION
When the allocator size is small, it is possible we have a size 0 level in slab, which will crash in constructing SlabCacheQueue