### PR TITLE
Issue 388: don't truncate on if compact_lsn is zero

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.3.1"
+    version = "6.3.3"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/log_store/home_raft_log_store.cpp
+++ b/src/lib/replication/log_store/home_raft_log_store.cpp
@@ -66,11 +66,13 @@ void HomeRaftLogStore::truncate(uint32_t num_reserved_cnt, repl_lsn_t compact_ls
     auto const last_lsn = last_index();
     auto const start_lsn = start_index();
 
-    if (start_lsn + num_reserved_cnt >= last_lsn) {
+    // compact_lsn will be zero on first time boot, so we should not truncate in that case.
+    if (compact_lsn == 0 || (start_lsn + num_reserved_cnt >= last_lsn)) {
         REPL_STORE_LOG(DEBUG,
-                       "Store={} LogDev={}: Skipping truncating because of reserved logs entries is not enough. "
-                       "start_lsn={}, resv_cnt={}, last_lsn={}",
-                       m_logstore_id, m_logdev_id, start_lsn, num_reserved_cnt, last_lsn);
+                       "Store={} LogDev={}: Skipping truncating because of reserved logs entries is not enough or "
+                       "compact_lsn is zero. "
+                       "start_lsn={}, resv_cnt={}, last_lsn={}, compact_lsn={}",
+                       m_logstore_id, m_logdev_id, start_lsn, num_reserved_cnt, last_lsn, compact_lsn);
         return;
     } else {
         //


### PR DESCRIPTION
On first time boot, compact_lsn is defaulted to zero 0, which means nothing to truncate. 
We should skip truncation if compact_lsn is zero. 