### PR TITLE
Remove logdev which are unopened during recovery.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.1"
+    version = "6.4.2"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/logstore_service.hpp
+++ b/src/include/homestore/logstore_service.hpp
@@ -92,6 +92,13 @@ public:
     void open_logdev(logdev_id_t logdev_id);
 
     /**
+     * @brief Destroy a log dev.
+     *
+     * @param logdev_id: Logdev ID
+     */
+    void destroy_log_dev(logdev_id_t logdev_id);
+
+    /**
      * @brief Create a brand new log store (both in-memory and on device) and returns its instance. It also book
      * keeps the created log store and user can get this instance of log store by using logstore_id
      *
@@ -168,6 +175,7 @@ public:
 
 private:
     std::shared_ptr< LogDev > create_new_logdev_internal(logdev_id_t logdev_id);
+    void delete_unopened_logdevs();
     void logdev_super_blk_found(const sisl::byte_view& buf, void* meta_cookie);
     void rollback_super_blk_found(const sisl::byte_view& buf, void* meta_cookie);
     void start_threads();
@@ -182,6 +190,7 @@ private:
     iomgr::io_fiber_t m_truncate_fiber;
     iomgr::io_fiber_t m_flush_fiber;
     LogStoreServiceMetrics m_metrics;
+    std::unordered_set< logdev_id_t > m_unopened_logdev;
 };
 
 extern LogStoreService& logstore_service();

--- a/src/lib/device/journal_vdev.hpp
+++ b/src/lib/device/journal_vdev.hpp
@@ -401,6 +401,9 @@ public:
     // where log entries are stored. It also mantains offsets, size etc.
     shared< Descriptor > open(logdev_id_t id);
 
+    // Destroy a logdev and release all the chunks related to the logdev.
+    void destroy(logdev_id_t id);
+
     /**
      * @brief Get the status of the journal vdev and its internal structures
      * @param log_level: Log level to do verbosity.
@@ -410,7 +413,9 @@ public:
 
     uint64_t used_size() const override;
     uint64_t available_blks() const override;
+    uint64_t num_descriptors() const { return m_journal_descriptors.size(); }
 
+    void remove_journal_chunks(std::vector< shared< Chunk > >& chunks);
     void update_chunk_private(shared< Chunk >& chunk, JournalChunkPrivate* chunk_private);
     uint64_t get_end_of_chunk(shared< Chunk >& chunk) const;
 

--- a/src/lib/device/physical_dev.cpp
+++ b/src/lib/device/physical_dev.cpp
@@ -246,7 +246,7 @@ std::vector< shared< Chunk > > PhysicalDev::create_chunks(const std::vector< uin
 
                 auto chunk = std::make_shared< Chunk >(this, *cinfo, cslot);
                 ret_chunks.push_back(chunk);
-                get_stream(chunk).m_chunks_map.insert(std::pair{chunk_ids[cit], std::move(chunk)});
+                get_stream(chunk).m_chunks_map.insert(std::pair{chunk_ids[cit], chunk});
                 HS_LOG(INFO, device, "Creating chunk {}", chunk->to_string());
                 cinfo->~chunk_info();
             }

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -901,8 +901,7 @@ void RaftReplDev::permanent_destroy() {
     m_rd_sb.destroy();
     m_raft_config_sb.destroy();
     m_data_journal->remove_store();
-
-    // TODO: Add remove_log_dev from logstore_service() here once its implemented
+    logstore_service().destroy_log_dev(m_data_journal->logdev_id());
 }
 
 void RaftReplDev::leave() {


### PR DESCRIPTION
Removing repl dev will remove the logdev. If logdev or log store are not opened during, they are marked as ununsed and deleted. Remove chunks from the journal descriptor. Remove the logdev metablk.
1. Fix a regression in device manager where vdev size was not zero. Use after move.
2. Add UT to delete the logdev and delete it if its unopened during recovery.
3. logdev can be called during delete of repldev. If repl dev is marked for delete, repldev wont open logdev's during recovery and those are deleted. We first release all chunks and then  metablks related to logdev. 