### PR TITLE
fix logstore recovery issue

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.5"
+    version = "6.4.6"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/logstore/log_store_service.cpp
+++ b/src/lib/logstore/log_store_service.cpp
@@ -237,13 +237,9 @@ void LogStoreService::rollback_super_blk_found(const sisl::byte_view& buf, void*
         auto id = rollback_sb->logdev_id;
         LOGDEBUGMOD(logstore, "Log dev rollback superblk found logdev={}", id);
         const auto it = m_id_logdev_map.find(id);
-        if (it != m_id_logdev_map.end()) {
-            logdev = it->second;
-        } else {
-            logdev = std::make_shared< LogDev >(id, m_logdev_vdev.get());
-            m_id_logdev_map.emplace(id, logdev);
-        }
-
+        HS_REL_ASSERT((it != m_id_logdev_map.end()),
+                      "found a rollback_super_blk of logdev id {}, but the logdev with id {} doesnt exist", id);
+        logdev = it->second;
         logdev->log_dev_meta().rollback_super_blk_found(buf, meta_cookie);
     }
 }

--- a/src/lib/replication/log_store/home_raft_log_store.h
+++ b/src/lib/replication/log_store/home_raft_log_store.h
@@ -188,11 +188,14 @@ public:
      */
     void truncate(uint32_t num_reserved_cnt, repl_lsn_t compact_lsn);
 
+    void wait_for_log_store_ready();
+
 private:
     logstore_id_t m_logstore_id;
     logdev_id_t m_logdev_id;
     shared< HomeLogStore > m_log_store;
     nuraft::ptr< nuraft::log_entry > m_dummy_log_entry;
     store_lsn_t m_last_durable_lsn{-1};
+    folly::Future< folly::Unit > m_log_store_future;
 };
 } // namespace homestore

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -171,6 +171,8 @@ public:
 
     nuraft::ptr< nuraft::snapshot > get_last_snapshot() { return m_last_snapshot; }
 
+    void wait_for_logstore_ready() { m_data_journal->wait_for_log_store_ready(); }
+
 protected:
     //////////////// All nuraft::state_mgr overrides ///////////////////////
     nuraft::ptr< nuraft::cluster_config > load_config() override;

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -128,6 +128,7 @@ void RaftReplService::start() {
     // Step 6: Iterate all the repl dev and ask each one of the join the raft group.
     for (auto it = m_rd_map.begin(); it != m_rd_map.end();) {
         auto rdev = std::dynamic_pointer_cast< RaftReplDev >(it->second);
+        rdev->wait_for_logstore_ready();
         if (!rdev->join_group()) {
             it = m_rd_map.erase(it);
         } else {


### PR DESCRIPTION
the recovery issue is caused by the logdev metablk recovery callback `rollback_super_blk_found`, it will put all the log dev to `m_unopened_logdev` , which will be destroyed when logservice start.

in this pr :

1 change the logic about `m_unopened_logdev` to make sure only those log devs which are not opened before logservice#start will be destroyed.

2 change the metablk dependency , so that `rollback_super_blk_found` will be called after all the log dev metablk are recovered

3 add logic to make sure the logstore of a repldev is ready before it is going to join raft group. now , we use a future to open logstore, so there might be a small case that logstore is not ready when repldev is joining raft group