### PR TITLE
Revert "inject flip into io path to simulate io error and stuck io"

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.7"
+    version = "6.4.6"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"


### PR DESCRIPTION
Reverts eBay/HomeStore#416, since we already have flip injections for all IO issue in IOManager level, no need to add more injection in homestore level 