### PR TITLE
add more detail info for metablk debug

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.9"
+    version = "6.4.10"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/meta/meta_blk_service.cpp
+++ b/src/lib/meta/meta_blk_service.cpp
@@ -201,7 +201,7 @@ void MetaBlkService::write_ssb() {
         // the offset and buffer length is printed in the error messages of iomgr.
         // buf address here is to show whether the buffer is aligned or not.
         // TODO: hanle this error properly
-        HS_REL_ASSERT(false, "error happens happen during write ssb: {}, buf address: {}", error.what(),
+        HS_REL_ASSERT(false, "error happens happen during write ssb: {}, buf address: {}", error.value(),
                       (const char*)m_ssb);
     }
 
@@ -446,7 +446,7 @@ void MetaBlkService::write_ovf_blk_to_disk(meta_blk_ovf_hdr* ovf_hdr, const uint
         // the offset and buffer length is printed in the error messages of iomgr.
         // buf address here is to show whether the buffer is aligned or not.
         // TODO: hanle this error properly
-        HS_REL_ASSERT(false, "error happens happen during write: {}, buf address: {}", error.what(),
+        HS_REL_ASSERT(false, "error happens happen during write: {}, buf address: {}", error.value(),
                       (const char*)ovf_hdr);
     }
 
@@ -503,7 +503,7 @@ void MetaBlkService::write_ovf_blk_to_disk(meta_blk_ovf_hdr* ovf_hdr, const uint
             // the offset and buffer length is printed in the error messages of iomgr.
             // buf address here is to show whether the buffer is aligned or not.
             // TODO: hanle this error properly
-            HS_REL_ASSERT(false, "error happens happen during write: {}, buf address: {}", error.what(),
+            HS_REL_ASSERT(false, "error happens happen during write: {}, buf address: {}", error.value(),
                           r_cast< const char* >(cur_ptr));
         }
     }
@@ -521,7 +521,7 @@ void MetaBlkService::write_meta_blk_to_disk(meta_blk* mblk) {
         // the offset and buffer length is printed in the error messages of iomgr.
         // buf address here is to show whether the buffer is aligned or not.
         // TODO: hanle this error properly
-        HS_REL_ASSERT(false, "error happens happen during write_meta_blk_to_disk: {}, buf address: {}", error.what(),
+        HS_REL_ASSERT(false, "error happens happen during write_meta_blk_to_disk: {}, buf address: {}", error.value(),
                       (const char*)mblk);
     }
 }

--- a/src/lib/meta/meta_blk_service.cpp
+++ b/src/lib/meta/meta_blk_service.cpp
@@ -1122,11 +1122,8 @@ void MetaBlkService::recover_meta_block(meta_blk* mblk) {
         // if subsystem registered crc protection, verify crc before sending to subsystem;
         if (itr->second.do_crc) {
             const auto crc = crc32_ieee(init_crc32, buf->cbytes(), mblk->hdr.h.context_sz);
-
-            HS_REL_ASSERT_EQ(crc, uint32_cast(mblk->hdr.h.crc),
-                             "[type={}], CRC mismatch: {}/{}, on mblk bid: {}, context_sz: {}", mblk->hdr.h.type, crc,
-                             uint32_cast(mblk->hdr.h.crc), mblk->hdr.h.bid.to_string(),
-                             uint64_cast(mblk->hdr.h.context_sz));
+            HS_REL_ASSERT_EQ(crc, uint32_cast(mblk->hdr.h.crc), "CRC mismatch: {}/{}, meta_blk details: {}", crc,
+                             uint32_cast(mblk->hdr.h.crc), mblk->hdr.h.to_string());
         } else {
             HS_LOG(DEBUG, metablk, "[type={}] meta blk found with bypassing crc.", mblk->hdr.h.type);
         }

--- a/src/lib/meta/meta_blk_service.cpp
+++ b/src/lib/meta/meta_blk_service.cpp
@@ -196,9 +196,14 @@ void MetaBlkService::format_ssb() {
 // m_meta_lock should be while calling this function;
 void MetaBlkService::write_ssb() {
     // write current ovf blk to disk;
-    try {
-        m_sb_vdev->sync_write((const char*)m_ssb, block_size(), m_ssb->bid);
-    } catch (std::exception& e) { HS_REL_ASSERT(false, "exception happen during write {}", e.what()); }
+    auto error = m_sb_vdev->sync_write((const char*)m_ssb, block_size(), m_ssb->bid);
+    if (error.value()) {
+        // the offset and buffer length is printed in the error messages of iomgr.
+        // buf address here is to show whether the buffer is aligned or not.
+        // TODO: hanle this error properly
+        HS_REL_ASSERT(false, "error happens happen during write ssb: {}, buf address: {}", error.what(),
+                      (const char*)m_ssb);
+    }
 
     LOGINFO("Successfully write m_ssb to disk: {}", m_ssb->to_string());
 
@@ -436,9 +441,14 @@ void MetaBlkService::write_ovf_blk_to_disk(meta_blk_ovf_hdr* ovf_hdr, const uint
     HS_DBG_ASSERT_LE(ovf_hdr->h.context_sz + offset, sz);
 
     // write current ovf blk to disk;
-    try {
-        m_sb_vdev->sync_write((const char*)ovf_hdr, block_size(), ovf_hdr->h.bid);
-    } catch (std::exception& e) { HS_REL_ASSERT(false, "exception happen during write {}", e.what()); }
+    auto error = m_sb_vdev->sync_write((const char*)ovf_hdr, block_size(), ovf_hdr->h.bid);
+    if (error.value()) {
+        // the offset and buffer length is printed in the error messages of iomgr.
+        // buf address here is to show whether the buffer is aligned or not.
+        // TODO: hanle this error properly
+        HS_REL_ASSERT(false, "error happens happen during write: {}, buf address: {}", error.what(),
+                      (const char*)ovf_hdr);
+    }
 
     // NOTE: The start write pointer which is context data pointer plus offset must be dma boundary aligned
     // TO DO: Might need to differentiate based on data or fast type
@@ -488,9 +498,14 @@ void MetaBlkService::write_ovf_blk_to_disk(meta_blk_ovf_hdr* ovf_hdr, const uint
             size_written += (ovf_hdr->h.context_sz - size_written);
         }
 
-        try {
-            m_sb_vdev->sync_write(r_cast< const char* >(cur_ptr), cur_size, data_bid[i]);
-        } catch (std::exception& e) { HS_REL_ASSERT(false, "exception happen during write {}", e.what()); }
+        auto error = m_sb_vdev->sync_write(r_cast< const char* >(cur_ptr), cur_size, data_bid[i]);
+        if (error.value()) {
+            // the offset and buffer length is printed in the error messages of iomgr.
+            // buf address here is to show whether the buffer is aligned or not.
+            // TODO: hanle this error properly
+            HS_REL_ASSERT(false, "error happens happen during write: {}, buf address: {}", error.what(),
+                          r_cast< const char* >(cur_ptr));
+        }
     }
 
     if (data_buf) { hs_utils::iobuf_free(data_buf, sisl::buftag::metablk); }
@@ -501,9 +516,14 @@ void MetaBlkService::write_ovf_blk_to_disk(meta_blk_ovf_hdr* ovf_hdr, const uint
 
 void MetaBlkService::write_meta_blk_to_disk(meta_blk* mblk) {
     // write current ovf blk to disk;
-    try {
-        m_sb_vdev->sync_write((const char*)mblk, block_size(), mblk->hdr.h.bid);
-    } catch (std::exception& e) { HS_REL_ASSERT(false, "exception happen during write {}", e.what()); }
+    auto error = m_sb_vdev->sync_write((const char*)mblk, block_size(), mblk->hdr.h.bid);
+    if (error.value()) {
+        // the offset and buffer length is printed in the error messages of iomgr.
+        // buf address here is to show whether the buffer is aligned or not.
+        // TODO: hanle this error properly
+        HS_REL_ASSERT(false, "error happens happen during write_meta_blk_to_disk: {}, buf address: {}", error.what(),
+                      (const char*)mblk);
+    }
 }
 
 //

--- a/src/lib/meta/meta_sb.hpp
+++ b/src/lib/meta/meta_sb.hpp
@@ -134,10 +134,11 @@ struct meta_blk_hdr_s {
     uint8_t pad[7];
 
     std::string to_string() const {
-        return fmt::format("type: {}, version: {}, magic: {}, crc: {}, next_bid: {}, prev_bid: {}, ovf_bid: {}, "
-                           "self_bid: {}, compressed: {}",
-                           type, version, magic, crc, next_bid.to_string(), prev_bid.to_string(), ovf_bid.to_string(),
-                           bid.to_string(), compressed);
+        return fmt::format(
+            "magic: {}, type: {}, version: {}, gen_cnt: {}, crc: {}, next_bid: {}, prev_bid: {}, "
+            "ovf_bid: {}, self_bid: {}, context_sz: {}, compressed_sz: {}, src_context_sz : {}, compressed: {} ",
+            magic, type, version, gen_cnt, crc, next_bid.to_string(), prev_bid.to_string(), ovf_bid.to_string(),
+            bid.to_string(), context_sz, compressed_sz, src_context_sz, compressed);
     }
 };
 #pragma pack()


### PR DESCRIPTION
the metablk crc mismatch issue is not easy to be reproduced, and one most possible reason is write failure, which will lead to crc mismatch.
as we discussed in homestore meeting,   this PR add more detail debug info which will be helpful when the issue occurs. also in this PR, we will terminate the process with an assert failure so that it will not lead to later CRC mismatch when recovery

the strategy of handling write failures of different service of homestore will be written up to a doc and discussed later on