### PR TITLE
Fix raft repl test case for destroying logdev and remove group.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.17"
+    version = "6.4.18"
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")

--- a/src/lib/device/journal_vdev.cpp
+++ b/src/lib/device/journal_vdev.cpp
@@ -208,6 +208,10 @@ void JournalVirtualDev::destroy(logdev_id_t logdev_id) {
 void JournalVirtualDev::Descriptor::append_chunk() {
     // Get a new chunk from the pool.
     auto new_chunk = m_vdev.m_chunk_pool->dequeue();
+#if 0
+    auto* pdev = new_chunk->physical_dev_mutable();
+    pdev->sync_write_zero(new_chunk->size(), new_chunk->start_offset());
+#endif
 
     // Increase the right window and total size.
     m_total_size += new_chunk->size();

--- a/src/lib/logstore/log_stream.cpp
+++ b/src/lib/logstore/log_stream.cpp
@@ -70,6 +70,16 @@ read_again:
         return ret_buf;
     }
 
+    if (header->logdev_id != m_vdev_jd->logdev_id()) {
+        LOGINFOMOD(logstore, "Entries found for different logdev {} at pos {}, must have come to end of log_dev={}",
+                   header->logdev_id, m_vdev_jd->dev_offset(m_cur_read_bytes), m_vdev_jd->logdev_id());
+        *out_dev_offset = m_vdev_jd->dev_offset(m_cur_read_bytes);
+        // move it by dma boundary if header is not valid
+        m_prev_crc = 0;
+        m_cur_read_bytes += m_read_size_multiple;
+        return ret_buf;
+    }
+
     // Because reuse chunks without cleaning up, we could get chunks used by other logdev's
     // and it can happen that log group headers couldnt match. In that case check we dont error
     // if its the last chunk or not with is_offset_at_last_chunk else raise assert.

--- a/src/lib/replication/log_store/repl_log_store.cpp
+++ b/src/lib/replication/log_store/repl_log_store.cpp
@@ -8,7 +8,12 @@ namespace homestore {
 
 uint64_t ReplLogStore::append(nuraft::ptr< nuraft::log_entry >& entry) {
     // We don't want to transform anything that is not an app log
-    if (entry->get_val_type() != nuraft::log_val_type::app_log) { return HomeRaftLogStore::append(entry); }
+    if (entry->get_val_type() != nuraft::log_val_type::app_log) {
+        ulong lsn = HomeRaftLogStore::append(entry);
+        RD_LOGD("append entry term={}, log_val_type={} lsn={} size={}", entry->get_term(),
+                static_cast< uint32_t >(entry->get_val_type()), lsn, entry->get_buf().size());
+        return lsn;
+    }
 
     repl_req_ptr_t rreq = m_sm.localize_journal_entry_finish(*entry);
     ulong lsn = HomeRaftLogStore::append(entry);

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -32,7 +32,7 @@ struct raft_repl_dev_superblk : public repl_dev_superblk {
 
 using raft_buf_ptr_t = nuraft::ptr< nuraft::buffer >;
 
-ENUM(repl_dev_stage_t, uint8_t, INIT, ACTIVE, DESTROYING, DESTROYED);
+ENUM(repl_dev_stage_t, uint8_t, INIT, ACTIVE, DESTROYING, DESTROYED, PERMANENT_DESTROYED);
 
 class RaftReplDevMetrics : public sisl::MetricsGroup {
 public:
@@ -128,6 +128,7 @@ public:
     uint32_t get_blk_size() const override;
     repl_lsn_t get_last_commit_lsn() const { return m_commit_upto_lsn.load(); }
     bool is_destroy_pending() const;
+    bool is_destroyed() const;
     Clock::time_point destroyed_time() const { return m_destroyed_time; }
 
     //////////////// Accessor/shortcut methods ///////////////////////

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -184,8 +184,10 @@ raft_buf_ptr_t RaftStateMachine::pre_commit_ext(nuraft::state_machine::ext_op_pa
 
 raft_buf_ptr_t RaftStateMachine::commit_ext(nuraft::state_machine::ext_op_params const& params) {
     int64_t lsn = s_cast< int64_t >(params.log_idx);
-
+    RD_LOGD("Raft channel: Received Commit message lsn {} store {} logdev {} size {}", lsn,
+            m_rd.m_data_journal->logstore_id(), m_rd.m_data_journal->logdev_id(), params.data->size());
     repl_req_ptr_t rreq = lsn_to_req(lsn);
+    if (!rreq) { RD_LOGD("Raft channel got null rreq"); }
     RD_LOGD("Raft channel: Received Commit message rreq=[{}]", rreq->to_compact_string());
     if (rreq->is_proposer()) {
         // This is the time to ensure flushing of journal happens in the proposer

--- a/src/lib/replication/service/generic_repl_svc.h
+++ b/src/lib/replication/service/generic_repl_svc.h
@@ -56,7 +56,6 @@ public:
 
     hs_stats get_cap_stats() const override;
     replica_id_t get_my_repl_uuid() const { return m_my_uuid; }
-
     // void resource_audit() override;
 
 protected:

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -141,6 +141,9 @@ void RaftReplService::start() {
 
     // Step 8: Start a reaper thread which wakes up time-to-time and fetches pending data or cleans up old requests etc
     start_reaper_thread();
+
+    // Delete any unopened logstores.
+    hs()->logstore_service().delete_unopened_logdevs();
 }
 
 void RaftReplService::stop() {

--- a/src/lib/replication/service/raft_repl_service.h
+++ b/src/lib/replication/service/raft_repl_service.h
@@ -74,7 +74,6 @@ protected:
 
 private:
     void raft_group_config_found(sisl::byte_view const& buf, void* meta_cookie);
-
     void start_reaper_thread();
     void stop_reaper_thread();
     void fetch_pending_data();

--- a/src/tests/test_log_dev.cpp
+++ b/src/tests/test_log_dev.cpp
@@ -436,6 +436,8 @@ TEST_F(LogDevTest, DeleteUnopenedLogDev) {
     LOGINFO("Restart homestore");
     restart();
 
+    // Explicitly call delete for unopened ones.
+    hs()->logstore_service().delete_unopened_logdevs();
     auto log_devs = logstore_service().get_all_logdevs();
     ASSERT_EQ(log_devs.size(), id_set.size() / 2);
     for (auto& logdev : log_devs) {


### PR DESCRIPTION
1.Add logstore service metablk for storing last logdev id. logdev id's are always increasing. Because chunks are reused and we get garbage during recovery. We use logdev id to validate if its garbage log entries or not.
2. Test needs to wait till the raft repl is permanently destroyed, as it takes few seconds to do consensus on replica's. Added a new state.
