### PR TITLE
Create chunks according to the capacity of pdev

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.12"
+    version = "6.4.13"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"


### PR DESCRIPTION
if we have different devices withe different capacity, there might be an error when createing vdev.
```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from VMetaBlkMgrTest
[ RUN      ] VMetaBlkMgrTest.CompressionBackoff
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [homestore_test_common.hpp:198:start_homestore] Taking input dev_list: /dev/data1,/dev/data2,/dev/data3,/dev/index
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [homestore_test_common.hpp:219:start_homestore] Successfully zeroed the 1st 4194304 of device /dev/data1
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [homestore_test_common.hpp:219:start_homestore] Successfully zeroed the 1st 4194304 of device /dev/data2
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [homestore_test_common.hpp:219:start_homestore] Successfully zeroed the 1st 4194304 of device /dev/data3
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [homestore_test_common.hpp:219:start_homestore] Successfully zeroed the 1st 4194304 of device /dev/index
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [homestore_test_common.hpp:246:start_homestore] Starting iomgr with 2 threads, spdk: false
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [iomgr_config.hpp:48:operator()] Default Pools is not initialized, possibly first boot - setting with defaults
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [iomgr.cpp:111:start] Starting IOManager version 11.3.2-35 with 2 threads [is_spdk=false] [mem_limit=512mb, hugepage=0]
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [12] [reactor.hpp:50:IOThreadMetrics] Registring metrics group name = IOThreadMetrics, thread_name = iomgr_thread_0
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [13] [reactor.hpp:50:IOThreadMetrics] Registring metrics group name = IOThreadMetrics, thread_name = iomgr_thread_1
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [12] [iomgr_timer.cpp:179:setup_timer_fd] Creating non-recurring per-thread timer fd 9 and adding it into fd poll list
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [13] [iomgr_timer.cpp:179:setup_timer_fd] Creating non-recurring per-thread timer fd 14 and adding it into fd poll list
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [12] [iomgr.cpp:347:reactor_started] All Worker reactors started, moving iomanager to sys_init state
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [iomgr_timer.cpp:179:setup_timer_fd] Creating non-recurring global timer fd 17 and adding it into fd poll list
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [iomgr_timer.cpp:179:setup_timer_fd] Creating non-recurring global timer fd 18 and adding it into fd poll list
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [iomgr.cpp:172:start] IOManager is ready and move to running state
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [homestore_test_common.hpp:69:set_fixed_http_port] http port = 5000
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [homestore_test_common.hpp:257:start_homestore] Initialize and start HomeStore with app_mem_size = 307.20mb
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [homestore_config.hpp:93:operator()] Free Blks Slab distribution is not initialized, possibly first boot - setting with defaults
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [homestore_config.hpp:105:init_settings_default] Some settings are defaultted or overridden explicitly in the code, saving the new settings
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [homestore.cpp:123:start] Homestore is loading with following services: meta,
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [cp_mgr.cpp:357:CPWatchdog] CP watchdog timer setting to : 10 seconds
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [iomgr_timer.cpp:179:setup_timer_fd] Creating recurring global timer fd 24 and adding it into fd poll list
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [52] [reactor.hpp:50:IOThreadMetrics] Registring metrics group name = IOThreadMetrics, thread_name = cp_io
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [52] [iomgr_timer.cpp:179:setup_timer_fd] Creating non-recurring per-thread timer fd 27 and adding it into fd poll list
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [drive_interface.cpp:220:get_drive_type] Drive=/dev/data1 is detected to be drive_type=block_hdd
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [device_manager.cpp:78:DeviceManager] Overridding HDD open flags from DIRECT_IO to BUFFERED_IO
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [drive_interface.cpp:220:get_drive_type] Drive=/dev/data2 is detected to be drive_type=block_hdd
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [drive_interface.cpp:220:get_drive_type] Drive=/dev/data3 is detected to be drive_type=block_hdd
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [drive_interface.cpp:220:get_drive_type] Drive=/dev/index is detected to be drive_type=block_nvme
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [physical_dev.cpp:87:PhysicalDev] Opening device /dev/data1 with BUFFERED_IO mode.
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [physical_dev.cpp:108:PhysicalDev] Device /dev/data1 opened with dev_id=30 size=5.46tb
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [device_manager.cpp:125:format_devices] Formatting Homestore on Device=/dev/data1 with first block as: [magic=0xceeddeeb, checksum=2706801898, first_blk_header=[gen_number=1, version=4, product_name=OmStore system_uuid=1e95d85c-f4cc-4571-aadf-73bdd831c056], this_pdev_info=[data_offset=183.19mb, size=5.46tb, pdev_id=0 max_pdev_chunks=357664 dev_attr=[phys_page_size=4kb, align_size=512, atomic_phys_page_size=4kb, num_streams=1] mirror_super_block?=true]] total_super_blk_size=183697408
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [physical_dev.cpp:87:PhysicalDev] Opening device /dev/data2 with BUFFERED_IO mode.
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [physical_dev.cpp:108:PhysicalDev] Device /dev/data2 opened with dev_id=31 size=5.46tb
[05/29/24 17:41:33-07:00] [info] [test_meta_blk_mgr] [9] [device_manager.cpp:125:format_devices] Formatting Homestore on Device=/dev/data2 with first block as: [magic=0xceeddeeb, checksum=3753274083, first_blk_header=[gen_number=1, version=4, product_name=OmStore system_uuid=1e95d85c-f4cc-4571-aadf-73bdd831c056], this_pdev_info=[data_offset=183.19mb, size=5.46tb, pdev_id=1 max_pdev_chunks=357664 dev_attr=[phys_page_size=4kb, align_size=512, atomic_phys_page_size=4kb, num_streams=1] mirror_super_block?=true]] total_super_blk_size=183697408
[05/29/24 17:41:34-07:00] [info] [test_meta_blk_mgr] [9] [physical_dev.cpp:87:PhysicalDev] Opening device /dev/data3 with BUFFERED_IO mode.
[05/29/24 17:41:34-07:00] [info] [test_meta_blk_mgr] [9] [physical_dev.cpp:108:PhysicalDev] Device /dev/data3 opened with dev_id=32 size=5.46tb
[05/29/24 17:41:34-07:00] [info] [test_meta_blk_mgr] [9] [device_manager.cpp:125:format_devices] Formatting Homestore on Device=/dev/data3 with first block as: [magic=0xceeddeeb, checksum=1553422584, first_blk_header=[gen_number=1, version=4, product_name=OmStore system_uuid=1e95d85c-f4cc-4571-aadf-73bdd831c056], this_pdev_info=[data_offset=183.19mb, size=5.46tb, pdev_id=2 max_pdev_chunks=357664 dev_attr=[phys_page_size=4kb, align_size=512, atomic_phys_page_size=4kb, num_streams=1] mirror_super_block?=true]] total_super_blk_size=183697408
[05/29/24 17:41:34-07:00] [info] [test_meta_blk_mgr] [9] [physical_dev.cpp:87:PhysicalDev] Opening device /dev/index with DIRECT_IO mode.
[05/29/24 17:41:34-07:00] [info] [test_meta_blk_mgr] [9] [physical_dev.cpp:108:PhysicalDev] Device /dev/index opened with dev_id=33 size=465.75gb
[05/29/24 17:41:34-07:00] [info] [test_meta_blk_mgr] [9] [device_manager.cpp:125:format_devices] Formatting Homestore on Device=/dev/index with first block as: [magic=0xceeddeeb, checksum=3683111033, first_blk_header=[gen_number=1, version=4, product_name=OmStore system_uuid=1e95d85c-f4cc-4571-aadf-73bdd831c056], this_pdev_info=[data_offset=23.06mb, size=465.73gb, pdev_id=3 max_pdev_chunks=29809 dev_attr=[phys_page_size=4kb, align_size=512, atomic_phys_page_size=4kb, num_streams=1] mirror_super_block?=false]] total_super_blk_size=15794688
[05/29/24 17:41:34-07:00] [info] [test_meta_blk_mgr] [9] [device_manager.cpp:227:create_vdev] meta Virtual device is attempted to be created with num_chunks=4, it needs to be adjust to new_num_chunks=3.58kb
[05/29/24 17:41:34-07:00] [info] [test_meta_blk_mgr] [9] [device_manager.cpp:235:create_vdev] meta Virtual device is attempted to be created with size=15725628325888, it needs to be rounded to new_size=15725620314112 to be the multiple of 14.30mb (num_chunks 3662 * blk_size 4kb).
[05/29/24 17:41:34-07:00] [info] [test_meta_blk_mgr] [9] [device_manager.cpp:290:create_vdev] New Virtal Dev=meta of size=14.30tb with id=0 is attempted to be created with multi_pdev_opts=ALL_PDEV_STRIPED. The params are adjusted as follows: VDev_Size=14.30tb Num_pdevs=4 Total_chunks_across_all_pdevs=3662 Each_Chunk_Size=4.00gb
[05/29/24 17:41:36-07:00] [error] [test_meta_blk_mgr] [9] [physical_dev.cpp:266:create_chunks] Creation of chunks failed because of space, removing 116 partially created chunks
unknown file: Failure
C++ exception with description "Physical dev has no room for additional chunk" thrown in SetUp().
```

the explanation is as flowing :
```
[05/29/24 17:41:34-07:00] [info] [test_meta_blk_mgr] [9] [device_manager.cpp:290:create_vdev] New Virtal Dev=meta of size=14.30tb with id=0 is attempted to be created with multi_pdev_opts=ALL_PDEV_STRIPED. The params are adjusted as follows: VDev_Size=14.30tb Num_pdevs=4 Total_chunks_across_all_pdevs=3662 Each_Chunk_Size=4.00gb
```
for this log, we can see meta vdev will have 3662 chunks in 4 physical dev. since chunks spread evenly across all the 4 drives, so each pdev will have 3662/4 = 915.5 = 915 chunks.
so at least , each pdev should have a space of 915 * 4gb = 3660 gb.

```
[05/29/24 17:41:34-07:00] [info] [test_meta_blk_mgr] [9] [physical_dev.cpp:108:PhysicalDev] Device /dev/index opened with dev_id=33 size=465.75gb
```
however, from this line we can see that /dev/index only have the space of 465.75.  so when homestore is trying to allocate 915 chunks(3660 gb) in /dev/index, this errror will happen "Physical dev has no room for additional chunk"
