### PR TITLE
apply drives num assert only on TestRestartWithMissingDrive

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.19"
+    version = "6.4.20"
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -267,13 +267,6 @@ public:
             }
         }
 
-        if (!fake_restart && token.name_ == "test_data_service")
-            HS_REL_ASSERT_EQ(
-                token.devs_.size() > 2, true,
-                "if not fake restart, we need at least 3 device to run the data_service ut of simulating restart with "
-                "missing drive. current device num is {}",
-                token.devs_.size());
-
         if (is_spdk) {
             LOGINFO("Spdk with more than 2 threads will cause overburden test systems, changing nthreads to 2");
             num_threads = 2;


### PR DESCRIPTION
drive num assertion check will only kick in when running BlkDataServiceTest#TestRestartWithMissingDrive