### PR TITLE
sync_flush should wait is_completed not is_active.

### DIFF
--- a/src/include/homestore/logstore/log_store.hpp
+++ b/src/include/homestore/logstore/log_store.hpp
@@ -368,6 +368,7 @@ private:
     // Sync flush sections
     std::atomic< logstore_seq_num_t > m_sync_flush_waiter_lsn{invalid_lsn()};
     std::mutex m_sync_flush_mtx;
+    std::mutex m_single_sync_flush_mtx;
     std::condition_variable m_sync_flush_cv;
 
     std::vector< seq_ld_key_pair > m_truncation_barriers; // List of truncation barriers

--- a/src/lib/common/homestore_config.fbs
+++ b/src/lib/common/homestore_config.fbs
@@ -212,7 +212,7 @@ table Consensus {
     rpc_backoff_ms: uint32 = 250;
 
     // Frequency of Raft heartbeat
-    heartbeat_period_ms: uint32 = 250;
+    heartbeat_period_ms: uint32 = 500;
 
     // Re-election timeout low and high mark
     elect_to_low_ms: uint32 = 800;

--- a/src/lib/replication/log_store/repl_log_store.cpp
+++ b/src/lib/replication/log_store/repl_log_store.cpp
@@ -41,18 +41,26 @@ void ReplLogStore::end_of_append_batch(ulong start_lsn, ulong count) {
 
     // Start fetch the batch of data for this lsn range from remote if its not available yet.
     auto reqs = sisl::VectorPool< repl_req_ptr_t >::alloc();
+    auto proposer_reqs = sisl::VectorPool< repl_req_ptr_t >::alloc();
+    bool flush_log = false;
     for (int64_t lsn = int64_cast(start_lsn); lsn <= end_lsn; ++lsn) {
         auto rreq = m_sm.lsn_to_req(lsn);
         // Skip this call in proposer, since this method will synchronously flush the data, which is not required for
         // leader. Proposer will call the flush as part of commit after receiving quorum, upon which time, there is a
         // high possibility the log entry is already flushed. Skip it for rreq == nullptr which is the case for raft
         // config entries.
-        if ((rreq == nullptr) || rreq->is_proposer()) { continue; }
-        reqs->emplace_back(std::move(rreq));
+        if ((rreq == nullptr) /*|| rreq->is_proposer()*/)  { continue; }
+	else if (rreq->is_proposer()) { proposer_reqs->emplace_back(std::move(rreq)); }
+	else {reqs->emplace_back(std::move(rreq));}
     }
 
     RD_LOGT("Raft Channel: end_of_append_batch start_lsn={} count={} num_data_to_be_written={}", start_lsn, count,
             reqs->size());
+
+    for (auto const& rreq : *reqs) {
+        if ((rreq == nullptr) || (!rreq->has_linked_data())) { continue; }
+        LOGINFO("Raft Channel: Data before future wait: rreq=[{}]", rreq->to_compact_string());
+    }
 
     // All requests are from proposer for data write, so as mentioned above we can skip the flush for now
     if (!reqs->empty()) {
@@ -73,8 +81,21 @@ void ReplLogStore::end_of_append_batch(ulong start_lsn, ulong count) {
         for (auto const& rreq : *reqs) {
             if (rreq) { rreq->add_state(repl_req_state_t::LOG_FLUSHED); }
         }
+
+        for (auto const& rreq : *reqs) {
+            if ((rreq == nullptr) || (!rreq->has_linked_data())) { continue; }
+            LOGINFO("Raft Channel: Data after future wait: rreq=[{}]", rreq->to_compact_string());
+        }
+    } else if (!proposer_reqs->empty()) {
+        LOGINFO("Raft Channel: end_of_append_batch, I am proposer, only flush log s from {} , count {}", start_lsn, count);
+        // Mark all the reqs also completely written
+        HomeRaftLogStore::end_of_append_batch(start_lsn, count);
+        for (auto const& rreq : *proposer_reqs) {
+            if (rreq) { rreq->add_state(repl_req_state_t::LOG_FLUSHED); }
+        }
     }
     sisl::VectorPool< repl_req_ptr_t >::free(reqs);
+    sisl::VectorPool< repl_req_ptr_t >::free(proposer_reqs);
 }
 
 std::string ReplLogStore::rdev_name() const { return m_rd.rdev_name(); }

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -190,6 +190,7 @@ raft_buf_ptr_t RaftStateMachine::commit_ext(nuraft::state_machine::ext_op_params
     if (!rreq) { RD_LOGD("Raft channel got null rreq"); }
     RD_LOGD("Raft channel: Received Commit message rreq=[{}]", rreq->to_compact_string());
     if (rreq->is_proposer()) {
+	RD_LOGD("Leader Raft channel: Received Commit message rreq=[{}]", rreq->to_compact_string());
         // This is the time to ensure flushing of journal happens in the proposer
         if (m_rd.m_data_journal->last_durable_index() < uint64_cast(lsn)) { m_rd.m_data_journal->flush(); }
         rreq->add_state(repl_req_state_t::LOG_FLUSHED);

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -181,10 +181,8 @@ public:
         do_start_homestore(false /* fake_restart */, init_device);
     }
 
-
     virtual void restart_homestore(uint32_t shutdown_delay_sec = 5) {
         do_start_homestore(true /* fake_restart*/, false /* init_device */, shutdown_delay_sec);
-
     }
 
     virtual void shutdown_homestore(bool cleanup = true) {
@@ -346,6 +344,14 @@ private:
             // Fake restart, device list is unchanged.
             shutdown_homestore(false);
             std::this_thread::sleep_for(std::chrono::seconds{shutdown_delay_sec});
+        } else if (!m_token.devs_.empty()) {
+            // For those UTs already process device list, like test_raft_repl_dev.
+            LOGINFO("Using passed in dev_list: {}",
+                    std::accumulate(m_token.devs_.begin(), m_token.devs_.end(), std::string(""),
+                                    [](const std::string& s, const homestore::dev_info& dinfo) {
+                                        return s.empty() ? dinfo.dev_name : s + "," + dinfo.dev_name;
+                                    }));
+
         } else if (SISL_OPTIONS.count("device_list")) {
             // User has provided explicit device list, use that and initialize them
             auto const devs = SISL_OPTIONS["device_list"].as< std::vector< std::string > >();
@@ -427,6 +433,9 @@ private:
             set_min_chunk_size(m_token.svc_params_[HS_SERVICE::LOG].min_chunk_size);
         }
 
+        // in UT we assume first drive is FAST, rest are DATA.
+        bool has_data_drive = m_token.devs_.size() > 1;
+
         if (need_format) {
             auto svc_params = m_token.svc_params_;
             hsi->format_and_start(
@@ -446,7 +455,8 @@ private:
                        : chunk_selector_type_t::ROUND_ROBIN}},
                  {HS_SERVICE::INDEX, {.size_pct = svc_params[HS_SERVICE::INDEX].size_pct}},
                  {HS_SERVICE::REPLICATION,
-                  {.size_pct = svc_params[HS_SERVICE::REPLICATION].size_pct,
+                  {.dev_type = has_data_drive ? homestore::HSDevType::Data : homestore::HSDevType::Fast,
+                   .size_pct = svc_params[HS_SERVICE::REPLICATION].size_pct,
                    .alloc_type = svc_params[HS_SERVICE::REPLICATION].blkalloc_type,
                    .chunk_sel_type = svc_params[HS_SERVICE::REPLICATION].custom_chunk_selector
                        ? chunk_selector_type_t::CUSTOM

--- a/src/tests/test_common/hs_repl_test_common.hpp
+++ b/src/tests/test_common/hs_repl_test_common.hpp
@@ -168,7 +168,8 @@ public:
                 }
             }
             for (auto const& dev : rdev_list[replica_num_]) {
-                dev_list_.emplace_back(dev, homestore::HSDevType::Data);
+                dev_list_.emplace_back(dev,
+                                       dev_list_.empty() ? homestore::HSDevType::Fast : homestore::HSDevType::Data);
             }
         }
 


### PR DESCRIPTION
Log entry added into StreamTracker in write_async , through m_records.create().  Once create the status is active.

Later on in HomeLogStore::on_write_completion it update the tracker and in the `m_records.update`, is_completed set to true.

We should wait for is_completed == true to indicate a log entry has been persisted.