### PR TITLE
Improve test_raft_repl_dev UT

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,8 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.54"
-
+    version = "6.4.55"
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")

--- a/src/lib/replication/repl_dev/raft_state_machine.h
+++ b/src/lib/replication/repl_dev/raft_state_machine.h
@@ -110,6 +110,7 @@ public:
     raft_buf_ptr_t commit_ext(const nuraft::state_machine::ext_op_params& params) override;
     void commit_config(const ulong log_idx, raft_cluster_config_ptr_t& new_conf) override;
     void rollback(uint64_t lsn, nuraft::buffer&) override { LOGCRITICAL("Unimplemented rollback on: [{}]", lsn); }
+    void rollback_ext(const nuraft::state_machine::ext_op_params& params) override;
     void become_ready();
 
     void create_snapshot(nuraft::snapshot& s, nuraft::async_result< bool >::handler_type& when_done) override;

--- a/src/tests/test_common/hs_repl_test_common.hpp
+++ b/src/tests/test_common/hs_repl_test_common.hpp
@@ -137,7 +137,7 @@ public:
     void setup() {
         replica_num_ = SISL_OPTIONS["replica_num"].as< uint16_t >();
         sisl::logging::SetLogger(name_ + std::string("_replica_") + std::to_string(replica_num_));
-        sisl::logging::SetLogPattern("[%D %T%z] [%^%L%$] [%n] [%t] %v");
+        sisl::logging::SetLogPattern("[%D %T.%f] [%^%L%$] [%n] [%t] %v");
         auto const num_replicas = SISL_OPTIONS["replicas"].as< uint32_t >();
 
         boost::uuids::string_generator gen;

--- a/src/tests/test_common/hs_repl_test_common.hpp
+++ b/src/tests/test_common/hs_repl_test_common.hpp
@@ -168,7 +168,8 @@ public:
                 }
             }
             for (auto const& dev : rdev_list[replica_num_]) {
-                dev_list_.emplace_back(dev, homestore::HSDevType::Data);
+                dev_list_.emplace_back(dev,
+                                       dev_list_.empty() ? homestore::HSDevType::Fast : homestore::HSDevType::Data);
             }
         }
 


### PR DESCRIPTION
majar changes:

1. fix device list
2. when leader switches , new leader will continue to write in `write_on_leader`.
3. logging improvement, print out ms/us for timestamp.


Other than UT

implement rollback for statemachine.