### PR TITLE
Fix logstore sync flush

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.25"
+    version = "6.4.26"
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")

--- a/src/include/homestore/logstore/log_store.hpp
+++ b/src/include/homestore/logstore/log_store.hpp
@@ -368,6 +368,7 @@ private:
     // Sync flush sections
     std::atomic< logstore_seq_num_t > m_sync_flush_waiter_lsn{invalid_lsn()};
     std::mutex m_sync_flush_mtx;
+    std::mutex m_single_sync_flush_mtx;
     std::condition_variable m_sync_flush_cv;
 
     std::vector< seq_ld_key_pair > m_truncation_barriers; // List of truncation barriers

--- a/src/lib/device/journal_vdev.cpp
+++ b/src/lib/device/journal_vdev.cpp
@@ -284,7 +284,8 @@ off_t JournalVirtualDev::Descriptor::alloc_next_append_blk(size_t sz) {
     // update reserved size;
     m_reserved_sz += sz;
 
-    high_watermark_check();
+    // TODO enable after resource manager changes.
+    // high_watermark_check();
 
     // assert that returnning logical offset is in good range
     HS_DBG_ASSERT_LE(tail_off, m_end_offset);

--- a/src/lib/logstore/log_dev.cpp
+++ b/src/lib/logstore/log_dev.cpp
@@ -262,6 +262,11 @@ int64_t LogDev::append_async(const logstore_id_t store_id, const logstore_seq_nu
     auto threshold_size = LogDev::flush_data_threshold_size();
     m_log_records->create(idx, store_id, seq_num, data, cb_context);
 
+    if (HS_DYNAMIC_CONFIG(logstore.flush_threshold_size) == 0) {
+        // This is set in tests to disable implicit flush. This will be removed in future.
+        return idx;
+    }
+
     if (flush_wait ||
         ((prev_size < threshold_size && ((prev_size + data.size()) >= threshold_size) &&
           !m_is_flushing.load(std::memory_order_relaxed)))) {

--- a/src/lib/logstore/log_store.cpp
+++ b/src/lib/logstore/log_store.cpp
@@ -173,10 +173,11 @@ void HomeLogStore::read_async(logstore_seq_num_t seq_num, void* cookie, const lo
 #endif
 
 void HomeLogStore::on_write_completion(logstore_req* req, const logdev_key& ld_key) {
+    std::unique_lock lk(m_sync_flush_mtx);
     // Upon completion, create the mapping between seq_num and log dev key
     m_records.update(req->seq_num, [&](logstore_record& rec) -> bool {
         rec.m_dev_key = ld_key;
-        // THIS_LOGSTORE_LOG(DEBUG, "Completed write of lsn {} logdev_key={}", req->seq_num, ld_key);
+        THIS_LOGSTORE_LOG(DEBUG, "Completed write of store lsn {} logdev_key={}", req->seq_num, ld_key);
         return true;
     });
     // assert(flush_ld_key.idx >= m_last_flush_ldkey.idx);
@@ -402,6 +403,7 @@ void HomeLogStore::flush_sync(logstore_seq_num_t upto_seq_num) {
     HS_DBG_ASSERT_EQ(LogDev::can_flush_in_this_thread(), false,
                      "Logstore flush sync cannot be called on same thread which could do logdev flush");
 
+    std::unique_lock lk(m_single_sync_flush_mtx);
     if (upto_seq_num == invalid_lsn()) { upto_seq_num = m_records.active_upto(); }
 
     // if we have flushed already, we are done
@@ -426,6 +428,7 @@ void HomeLogStore::flush_sync(logstore_seq_num_t upto_seq_num) {
 
         // NOTE: We are not resetting the lsn because same seq number should never have 2 completions and thus not
         // doing it saves an atomic instruction
+        THIS_LOGSTORE_LOG(TRACE, "flush_sync over upto_seq_num {}", upto_seq_num);
     }
 }
 

--- a/src/lib/replication/log_store/home_raft_log_store.cpp
+++ b/src/lib/replication/log_store/home_raft_log_store.cpp
@@ -130,7 +130,7 @@ ulong HomeRaftLogStore::next_slot() const {
 }
 
 ulong HomeRaftLogStore::last_index() const {
-    uint64_t last_index = m_log_store->get_contiguous_completed_seq_num(m_last_durable_lsn);
+    uint64_t last_index = to_repl_lsn(m_log_store->get_contiguous_completed_seq_num(m_last_durable_lsn));
     return last_index;
 }
 

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -148,13 +148,15 @@ void RaftReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& 
                                     repl_req_ptr_t rreq) {
     if (!rreq) { auto rreq = repl_req_ptr_t(new repl_req_ctx{}); }
 
-    auto const guard = m_stage.access();
-    if (auto const stage = *guard.get(); stage != repl_dev_stage_t::ACTIVE) {
-        RD_LOGW("Raft channel: Not ready to accept writes, stage={}", enum_name(stage));
-        handle_error(rreq,
-                     (stage == repl_dev_stage_t::INIT) ? ReplServiceError::SERVER_IS_JOINING
-                                                       : ReplServiceError::SERVER_IS_LEAVING);
-        return;
+    {
+        auto const guard = m_stage.access();
+        if (auto const stage = *guard.get(); stage != repl_dev_stage_t::ACTIVE) {
+            RD_LOGW("Raft channel: Not ready to accept writes, stage={}", enum_name(stage));
+            handle_error(rreq,
+                         (stage == repl_dev_stage_t::INIT) ? ReplServiceError::SERVER_IS_JOINING
+                                                           : ReplServiceError::SERVER_IS_LEAVING);
+            return;
+        }
     }
 
     rreq->init(repl_key{.server_id = server_id(), .term = raft_server()->get_term(), .dsn = m_next_dsn.fetch_add(1)},
@@ -522,7 +524,7 @@ void RaftReplDev::check_and_fetch_remote_data(std::vector< repl_req_ptr_t > rreq
 void RaftReplDev::fetch_data_from_remote(std::vector< repl_req_ptr_t > rreqs) {
     if (rreqs.size() == 0) { return; }
 
-    std::vector<::flatbuffers::Offset< RequestEntry > > entries;
+    std::vector< ::flatbuffers::Offset< RequestEntry > > entries;
     entries.reserve(rreqs.size());
 
     shared< flatbuffers::FlatBufferBuilder > builder = std::make_shared< flatbuffers::FlatBufferBuilder >();

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -181,10 +181,8 @@ public:
         do_start_homestore(false /* fake_restart */, init_device);
     }
 
-
     virtual void restart_homestore(uint32_t shutdown_delay_sec = 5) {
         do_start_homestore(true /* fake_restart*/, false /* init_device */, shutdown_delay_sec);
-
     }
 
     virtual void shutdown_homestore(bool cleanup = true) {

--- a/src/tests/test_raft_repl_dev.cpp
+++ b/src/tests/test_raft_repl_dev.cpp
@@ -728,6 +728,10 @@ int main(int argc, char* argv[]) {
         s.consensus.leadership_expiry_ms = -1; // -1 means never expires;
         s.generic.repl_dev_cleanup_interval_sec = 0;
 
+        // Disable implicit flush and timer.
+        s.logstore.flush_threshold_size = 0;
+        s.logstore.flush_timer_frequency_us = 0;
+
         // only reset when user specified the value for test;
         if (SISL_OPTIONS.count("snapshot_distance")) {
             s.consensus.snapshot_freq_distance = SISL_OPTIONS["snapshot_distance"].as< uint32_t >();


### PR DESCRIPTION
Due to raft multiple threads calling sync flush, race condition for m_sync_flush_cv. Allow only one sync flush at a time.