### PR TITLE
Add batching in UT to support million ios for baseline test.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.51"
+    version = "6.4.52"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/log_store/home_raft_log_store.cpp
+++ b/src/lib/replication/log_store/home_raft_log_store.cpp
@@ -315,7 +315,8 @@ bool HomeRaftLogStore::compact(ulong compact_lsn) {
         // release this assert if for some use case, we should tolorant this case;
         // for now, don't expect this case to happen.
         // RELEASE_ASSERT(false, "compact_lsn={} is beyond the current max_lsn={}", compact_lsn, cur_max_lsn);
-
+        REPL_STORE_LOG(DEBUG, "Adding dummy entries during compact from={} upto={}", cur_max_lsn + 1,
+                       to_store_lsn(compact_lsn));
         // We need to fill the remaining entries with dummy data.
         for (auto lsn{cur_max_lsn + 1}; lsn <= to_store_lsn(compact_lsn); ++lsn) {
             append(m_dummy_log_entry);

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -185,7 +185,16 @@ public:
         do_start_homestore(true /* fake_restart*/, false /* init_device */, shutdown_delay_sec);
     }
 
+    virtual void start_homestore() {
+        do_start_homestore(true /* fake_restart*/, false /* init_device */, 1 /* shutdown_delay_sec */);
+    }
+
     virtual void shutdown_homestore(bool cleanup = true) {
+        if (homestore::HomeStore::safe_instance() == nullptr) {
+            /* Already shutdown */
+            return;
+        }
+
         homestore::HomeStore::instance()->shutdown();
         homestore::HomeStore::reset_instance();
         iomanager.stop();

--- a/src/tests/test_common/hs_repl_test_common.hpp
+++ b/src/tests/test_common/hs_repl_test_common.hpp
@@ -242,6 +242,13 @@ public:
         });
     }
 
+    void shutdown() { shutdown_homestore(false /* cleanup */); }
+
+    void start() {
+        m_token.params(HS_SERVICE::REPLICATION).repl_app = std::make_unique< TestReplApplication >(*this);
+        start_homestore();
+    }
+
     uint16_t replica_num() const { return replica_num_; }
     homestore::replica_id_t my_replica_id() const { return my_replica_id_; }
     homestore::replica_id_t replica_id(uint16_t member_id) const {


### PR DESCRIPTION
Add batching of read and write values in UT.
Keep mapping a index to key value pairs for quick lookup during snapshot read.
Add shutdown and start to simulate follower down, writes complete, follower start. Earlier we used to restart with sleep, but for 1 million io's or different values of num_io's we dont know how much to sleep. 

To test
./test_raft_repl_dev --gtest_filter=RaftReplDevTest.BaselineTest --num_io=1000000 --log_mods=replication:debug --config_path ./config --dev_size_mb=2048600 --snapsho
t_distance=0