### PR TITLE
Inlined_data

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.50"
+    version = "6.4.51"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/common/homestore_config.fbs
+++ b/src/lib/common/homestore_config.fbs
@@ -261,6 +261,9 @@ table Consensus {
 
     // Frequency to flush durable commit LSN in millis
     flush_durable_commit_interval_ms: uint64 = 500;
+
+    // Log difference to determine if the follower is in resync mode
+    resync_log_idx_threshold: int64 = 100;
 }
 
 table HomeStoreSettings {

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -135,7 +135,6 @@ private:
 
     iomgr::timer_handle_t m_wait_data_timer_hdl{
         iomgr::null_timer_handle}; // non-recurring timer doesn't need to be cancelled on shutdown;
-    bool m_resync_mode{false};
     Clock::time_point m_destroyed_time;
     folly::Promise< ReplServiceError > m_destroy_promise;
     RaftReplDevMetrics m_metrics;
@@ -255,7 +254,7 @@ private:
     void on_fetch_data_received(intrusive< sisl::GenericRpcData >& rpc_data);
     void fetch_data_from_remote(std::vector< repl_req_ptr_t > rreqs);
     void handle_fetch_data_response(sisl::GenericClientResponse response, std::vector< repl_req_ptr_t > rreqs);
-    bool is_resync_mode() { return m_resync_mode; }
+    bool is_resync_mode();
     void handle_error(repl_req_ptr_t const& rreq, ReplServiceError err);
     bool wait_for_data_receive(std::vector< repl_req_ptr_t > const& rreqs, uint64_t timeout_ms);
     void on_log_found(logstore_seq_num_t lsn, log_buffer buf, void* ctx);


### PR DESCRIPTION
- Do not allocate blks if data is not inlined
- Implement a basic version of is_resync_mode where we declare the follower to be in resync mode if the diff between leader_commit_lsn and his own last_log_idx from logstore is greater than a threshold