### PR TITLE
Issue: 498 meta service long run fix

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.49"
+    version = "6.4.50"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/device/chunk.h
+++ b/src/lib/device/chunk.h
@@ -29,6 +29,9 @@ private:
     shared< BlkAllocator > m_blk_allocator;
 
 public:
+    static constexpr auto MAX_CHUNK_SIZE = std::numeric_limits< uint32_t >::max();
+
+public:
     friend class DeviceManager;
 
     Chunk(PhysicalDev* pdev, const chunk_info& cinfo, uint32_t chunk_slot);

--- a/src/lib/device/device_manager.cpp
+++ b/src/lib/device/device_manager.cpp
@@ -243,7 +243,7 @@ shared< VirtualDev > DeviceManager::create_vdev(vdev_parameters&& vparam) {
         if (vparam.num_chunks != 0) {
             auto input_num_chunks = vparam.num_chunks;
             // max chunk size is 4GB (uint32_max), capping it by tune up num_chunks
-            uint32_t min_num_chunks = (vparam.vdev_size - 1) / std::numeric_limits< uint32_t >::max() + 1;
+            uint32_t min_num_chunks = (vparam.vdev_size - 1) / Chunk::MAX_CHUNK_SIZE + 1;
             vparam.num_chunks = std::max(vparam.num_chunks, min_num_chunks);
             vparam.num_chunks = std::min(vparam.num_chunks, max_num_chunks);
 

--- a/src/lib/device/virtual_dev.cpp
+++ b/src/lib/device/virtual_dev.cpp
@@ -167,7 +167,8 @@ BlkAllocStatus VirtualDev::commit_blk(BlkId const& blkid) {
     HS_LOG(DEBUG, device, "commit_blk: bid {}", blkid.to_string());
     auto const recovering = homestore::hs()->is_initializing();
     if (!recovering) {
-        HS_DBG_ASSERT(is_blk_alloced(blkid), "commiting blkid {} is not allocated in non-recovery mode",
+        // in non-recovery mode, if a blk is committed without allocating, it will cause data corruption
+        HS_REL_ASSERT(is_blk_alloced(blkid), "commiting blkid {} is not allocated in non-recovery mode",
                       blkid.to_string());
     } else {
         chunk->blk_allocator_mutable()->reserve_on_cache(blkid);

--- a/src/tests/test_scripts/log_meta_test.py
+++ b/src/tests/test_scripts/log_meta_test.py
@@ -81,7 +81,7 @@ def meta_nightly(options, addln_opts):
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 
-    cmd_opts = "--min_write_size=10485760 --max_write_size=104857600 --bitmap=1"
+    cmd_opts = "--min_write_size=10485760 --max_write_size=80857600 --bitmap=1"
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 


### PR DESCRIPTION
Problem Desc:
===========
We have a limitation on max chunk size (uint32_t) which is 4GB, which will be carved into portions in blk allocator with each portion maps to tens of thousands of nblks available for each portion. This specific test case specifiy max io size to to limitation that is larger than the portion total nblks and during the test, the io size is randomized and when it comes to larger than the limit, it can't find available allocation in any chunk so return failed.

Fix:
===
1. adjust the test case to not exceed limitation 
2. refactor the code a little to get max chunk size from Chunk class.


Test:
====
Specific failed test (previously failing consistently) can pass with this.
