### PR TITLE
fix long duration of write_to_full test case and max_io test case

### DIFF
--- a/.github/workflows/build_dependencies.yml
+++ b/.github/workflows/build_dependencies.yml
@@ -155,6 +155,7 @@ jobs:
     - name: Export Recipes
       run: |
         sudo apt-get install -y python3-pyelftools libaio-dev
+        sudo rm -rf $ANDROID_HOME
         python -m pip install pyelftools
         conan export import/iomgr oss/master
         conan export import/nuraft_mesg oss/main
@@ -165,7 +166,6 @@ jobs:
     - name: Build Cache
       run: |
         pre=$([[ "${{ inputs.build-type }}" != "Debug" ]] && echo "-o sisl:prerelease=${{ inputs.prerelease }}" || echo "")
-        sudo rm -rf $ANDROID_HOME
         conan install \
             -c tools.build:skip_test=True \
             ${pre} \

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.57"
+    version = "6.4.58"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.56"
+    version = "6.4.57"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.58"
+    version = "6.4.59"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -1092,7 +1092,7 @@ void RaftReplDev::flush_durable_commit_lsn() {
 }
 
 ///////////////////////////////////  Private metohds ////////////////////////////////////
-void RaftReplDev::cp_flush(CP*) {
+void RaftReplDev::cp_flush(CP* cp) {
     auto const lsn = m_commit_upto_lsn.load();
     auto const clsn = m_compact_lsn.load();
 
@@ -1108,6 +1108,8 @@ void RaftReplDev::cp_flush(CP*) {
     m_rd_sb->last_applied_dsn = m_next_dsn.load();
     m_rd_sb.write();
     m_last_flushed_commit_lsn = lsn;
+    RD_LOGD("cp flush in raft repl dev, lsn={}, clsn={}, next_dsn={}, cp string:{}", lsn, clsn, m_next_dsn.load(),
+            cp->to_string());
 }
 
 void RaftReplDev::cp_cleanup(CP*) {}

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -185,6 +185,7 @@ RaftReplDev* RaftReplService::raft_group_config_found(sisl::byte_view const& buf
 
 std::string RaftReplService::lookup_peer(nuraft_mesg::peer_id_t const& peer) {
     auto const p = m_repl_app->lookup_peer(peer);
+    if (p.first.empty()) { return {}; }
     return p.first + ":" + std::to_string(p.second);
 }
 

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -56,6 +56,8 @@ SISL_OPTION_GROUP(
     (qdepth, "", "qdepth", "Max outstanding operations", ::cxxopts::value< uint32_t >()->default_value("8"), "number"),
     (spdk, "", "spdk", "spdk", ::cxxopts::value< bool >()->default_value("false"), "true or false"),
     (flip_list, "", "flip_list", "btree flip list", ::cxxopts::value< std::vector< std::string > >(), "flips [...]"),
+    (use_file, "", "use_file", "use file instead of real drive", ::cxxopts::value< bool >()->default_value("false"),
+     "true or false"),
     (enable_crash, "", "enable_crash", "enable crash", ::cxxopts::value< bool >()->default_value("0"), ""));
 
 SETTINGS_INIT(iomgrcfg::IomgrSettings, iomgr_config);
@@ -354,12 +356,17 @@ private:
         auto num_threads = SISL_OPTIONS["num_threads"].as< uint32_t >();
         auto num_fibers = SISL_OPTIONS["num_fibers"].as< uint32_t >();
         auto is_spdk = SISL_OPTIONS["spdk"].as< bool >();
+        auto use_file = SISL_OPTIONS["use_file"].as< bool >();
+
+        if (use_file && SISL_OPTIONS.count("device_list")) {
+            LOGWARN("Ignoring device_list as use_file is set to true");
+        }
 
         if (fake_restart) {
             // Fake restart, device list is unchanged.
             shutdown_homestore(false);
             std::this_thread::sleep_for(std::chrono::seconds{shutdown_delay_sec});
-        } else if (SISL_OPTIONS.count("device_list")) {
+        } else if (SISL_OPTIONS.count("device_list") && !use_file) {
             // User has provided explicit device list, use that and initialize them
             auto const devs = SISL_OPTIONS["device_list"].as< std::vector< std::string > >();
             for (const auto& name : devs) {

--- a/src/tests/test_log_store.cpp
+++ b/src/tests/test_log_store.cpp
@@ -1266,7 +1266,7 @@ SISL_OPTION_GROUP(test_log_store,
                    "number of log stores in all, they will spread to each logdev evenly",
                    ::cxxopts::value< uint32_t >()->default_value("16"), "number"),
                   (num_records, "", "num_records", "number of record to test",
-                   ::cxxopts::value< uint32_t >()->default_value("10000"), "number"),
+                   ::cxxopts::value< uint32_t >()->default_value("1000"), "number"),
                   (iterations, "", "iterations", "Iterations", ::cxxopts::value< uint32_t >()->default_value("1"),
                    "the number of iterations to run each test"));
 
@@ -1276,7 +1276,5 @@ int main(int argc, char* argv[]) {
     SISL_OPTIONS_LOAD(parsed_argc, argv, logging, test_log_store, iomgr, test_common_setup);
     sisl::logging::SetLogger("test_log_store");
     spdlog::set_pattern("[%D %T%z] [%^%l%$] [%t] %v");
-    sisl::logging::SetModuleLogLevel("logstore", spdlog::level::level_enum::trace);
-    sisl::logging::SetModuleLogLevel("journalvdev", spdlog::level::level_enum::debug);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/test_meta_blk_mgr.cpp
+++ b/src/tests/test_meta_blk_mgr.cpp
@@ -125,7 +125,7 @@ public:
 protected:
     void SetUp() override { m_helper.start_homestore("test_meta_blk_mgr", {{HS_SERVICE::META, {.size_pct = 85.0}}}); }
 
-    void TearDown() override {};
+    void TearDown() override{};
 
 public:
     [[nodiscard]] uint64_t get_elapsed_time(const Clock::time_point& start) {
@@ -399,7 +399,7 @@ public:
             iomanager.iobuf_free(buf);
         } else {
             if (unaligned_addr) {
-                delete[] (buf - unaligned_shift);
+                delete[](buf - unaligned_shift);
             } else {
                 delete[] buf;
             }
@@ -585,6 +585,7 @@ public:
     }
 
     void register_client() {
+        LOGINFO("Registering client with type: {}", mtype);
         m_mbm = &(meta_service());
         m_total_wrt_sz = m_mbm->used_size();
         HS_REL_ASSERT_EQ(m_mbm->total_size() - m_total_wrt_sz, m_mbm->available_blks() * m_mbm->block_size());

--- a/src/tests/test_scripts/log_meta_test.py
+++ b/src/tests/test_scripts/log_meta_test.py
@@ -73,21 +73,26 @@ def meta_nightly(options, addln_opts):
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 
-    cmd_opts = "--run_time=7200 --num_io=1000000"
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --run_time=7200 --num_io=1000000"
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 
-    cmd_opts = "--min_write_size=65536 --max_write_size=2097152 --run_time=14400 --num_io=1000000"
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --min_write_size=65536 --max_write_size=2097152 --run_time=14400 --num_io=1000000"
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 
-    cmd_opts = "--min_write_size=10485760 --max_write_size=80857600 --bitmap=1"
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --min_write_size=10485760 --max_write_size=60857600 --bitmap=1"
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 
-    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.write_to_full_test"  # write to file instead of real disk to save time;
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --min_write_size=10485760 --max_write_size=60857600 --bitmap=1"
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
+
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --gtest_filter=VMetaBlkMgrTest.write_to_full_test --use_file=true"  # write to file instead of real disk to save time;
+    subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
+                          shell=True)
+
     print("meta blk store test completed")
 
 

--- a/src/tests/test_scripts/log_meta_test.py
+++ b/src/tests/test_scripts/log_meta_test.py
@@ -85,10 +85,6 @@ def meta_nightly(options, addln_opts):
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 
-    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --min_write_size=10485760 --max_write_size=60857600 --bitmap=1"
-    subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
-                          shell=True)
-
     cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --gtest_filter=VMetaBlkMgrTest.write_to_full_test --use_file=true"  # write to file instead of real disk to save time;
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)


### PR DESCRIPTION
1. change max_io size to 60MB which will fit in with existing portion nblks with 4GB min chunk size;
2. change write_to_full case to allow use file for testing to complete sooner. The original purpose of this test case is to see what meta svc will behave after writing laste byte of its vdev. If with real drives, it will take around 3 days to complete this single test case. We can choose to remove --use_file if we do really want to test that long with meta svc some day...

Testing:
======
1. both max io test case and write to full test case passed by manual run on real drives. 
2. a new round of meta svc long run is kicked off and waiting to complete (will merge after a full round passed).