### PR TITLE
add new dsn for destroy group 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.54"
+    version = "6.4.55"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -1053,14 +1053,6 @@ std::pair< bool, nuraft::cb_func::ReturnCode > RaftReplDev::handle_raft_event(nu
                 entries.size(), raft_req->get_last_log_term(), start_lsn, start_lsn + entries.size() - 1,
                 m_commit_upto_lsn.load(), raft_req->get_commit_idx());
 
-        if (start_lsn != m_data_journal->next_slot()) {
-            // if the start_lsn of this batch does not match the next_slot, drop this log batch
-            // this will happen when the leader is sending the logs which are already received and appended
-            RD_LOGD("start_lsn={} does not match the next_slot={}, dropping the log batch", start_lsn,
-                    m_data_journal->next_slot());
-            return {true, nuraft::cb_func::ReturnCode::ReturnNull};
-        }
-
         if (!entries.empty()) {
             RD_LOGT("Raft channel: Received {} append entries on follower from leader, localizing them",
                     entries.size());

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -221,7 +221,10 @@ void RaftStateMachine::become_ready() { m_rd.become_ready(); }
 
 void RaftStateMachine::unlink_lsn_to_req(int64_t lsn) {
     auto const it = m_lsn_req_map.find(lsn);
-    if (it != m_lsn_req_map.cend()) { m_lsn_req_map.erase(lsn); }
+    if (it != m_lsn_req_map.cend()) {
+        RD_LOG(DEBUG, "Raft channel: erase lsn {},  rreq {}", lsn, it->second->to_string());
+        m_lsn_req_map.erase(lsn);
+    }
 }
 
 void RaftStateMachine::link_lsn_to_req(repl_req_ptr_t rreq, int64_t lsn) {

--- a/src/tests/test_raft_repl_dev.cpp
+++ b/src/tests/test_raft_repl_dev.cpp
@@ -432,7 +432,7 @@ public:
                 // destroyed for ever. we need handle this in raft_repl_dev. revisit here after making changes at
                 // raft_repl_dev side to hanle this case. this is a workaround to avoid the infinite loop for now.
                 if (i++ > 10 && !force_leave) {
-                    LOGWARN("Waiting for repl dev to get destroyed and it is leader, so do a force leave");
+                    LOGWARN("has already waited for repl dev to get destroyed for 10 times, so do a force leave");
                     repl_dev->force_leave();
                     force_leave = true;
                 }


### PR DESCRIPTION
if we have a rreq {originator=1, term=1, dsn=0, lsn=7} in follower and a baseline resync is triggerd before the rreq is committed in the follower, then the on_commit of the rreq will not be called and as a result this rreq will become a garbage rreq in this follower. now if we trigger a destroy_group, a new rreq {originator=1, term=1, dsn=0} will created in the follower since the default dsn of a repl_key is 0.after the log of this rreq is appended to log store and get a new lsn, if we link the new lsn to the old rreq which has alread have a lsn, then a assert will be throw out. pls refer to repl_req_ctx::set_lsn

in this pr, we set the dsn to a new one , which is definitely unique in the follower, so that the new rreq will not have a conflict with the old rreq.