### PR TITLE
shorten log store test

### DIFF
--- a/.github/workflows/build_dependencies.yml
+++ b/.github/workflows/build_dependencies.yml
@@ -155,6 +155,7 @@ jobs:
     - name: Export Recipes
       run: |
         sudo apt-get install -y python3-pyelftools libaio-dev
+        sudo rm -rf $ANDROID_HOME
         python -m pip install pyelftools
         conan export import/iomgr oss/master
         conan export import/nuraft_mesg oss/main
@@ -165,7 +166,6 @@ jobs:
     - name: Build Cache
       run: |
         pre=$([[ "${{ inputs.build-type }}" != "Debug" ]] && echo "-o sisl:prerelease=${{ inputs.prerelease }}" || echo "")
-        sudo rm -rf $ANDROID_HOME
         conan install \
             -c tools.build:skip_test=True \
             ${pre} \

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.57"
+    version = "6.4.58"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/tests/test_log_store.cpp
+++ b/src/tests/test_log_store.cpp
@@ -1266,7 +1266,7 @@ SISL_OPTION_GROUP(test_log_store,
                    "number of log stores in all, they will spread to each logdev evenly",
                    ::cxxopts::value< uint32_t >()->default_value("16"), "number"),
                   (num_records, "", "num_records", "number of record to test",
-                   ::cxxopts::value< uint32_t >()->default_value("10000"), "number"),
+                   ::cxxopts::value< uint32_t >()->default_value("1000"), "number"),
                   (iterations, "", "iterations", "Iterations", ::cxxopts::value< uint32_t >()->default_value("1"),
                    "the number of iterations to run each test"));
 
@@ -1276,7 +1276,5 @@ int main(int argc, char* argv[]) {
     SISL_OPTIONS_LOAD(parsed_argc, argv, logging, test_log_store, iomgr, test_common_setup);
     sisl::logging::SetLogger("test_log_store");
     spdlog::set_pattern("[%D %T%z] [%^%l%$] [%t] %v");
-    sisl::logging::SetModuleLogLevel("logstore", spdlog::level::level_enum::trace);
-    sisl::logging::SetModuleLogLevel("journalvdev", spdlog::level::level_enum::debug);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
1 only output info log in this UT, disable debug and trace
2 reduce the number of num_records so that this UT will not take too much time


before:
15/19 Test # 15: LogStore-Epoll ...................   Passed  253.07 sec

only remove log of debug and trace 

15/19 Test # 15: LogStore-Epoll ...................   Passed  252.39 sec


remove log of debug and trace , and set num_record from 10000 to 1000
15/19 Test # 15: LogStore-Epoll ...................   Passed   45.89 sec


also , this PR mv `sudo rm -rf $ANDROID_HOME` from build cache phrase to Export Recipes phrase, which will solve the no-space left issue , since some github CI does not have build cache phrase
