### PR TITLE
Fix crash simulation

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.59"
+    version = "6.4.60"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/homestore.hpp
+++ b/src/include/homestore/homestore.hpp
@@ -167,7 +167,10 @@ public:
     BlkDataService& data_service() { return *m_data_service; }
     MetaBlkService& meta_service() { return *m_meta_service; }
     LogStoreService& logstore_service() { return *m_log_service; }
-    IndexService& index_service() { return *m_index_service; }
+    IndexService& index_service() {
+        if (!m_index_service) { throw std::runtime_error("index_service is nullptr"); }
+        return *m_index_service;
+    }
     ReplicationService& repl_service() { return *m_repl_service; }
     DeviceManager* device_mgr() { return m_dev_mgr.get(); }
     ResourceMgr& resource_mgr() { return *m_resource_mgr.get(); }

--- a/src/include/homestore/index_service.hpp
+++ b/src/include/homestore/index_service.hpp
@@ -82,7 +82,10 @@ public:
     uint32_t node_size() const;
     void repair_index_node(uint32_t ordinal, IndexBufferPtr const& node_buf);
 
-    IndexWBCacheBase& wb_cache() { return *m_wb_cache; }
+    IndexWBCacheBase& wb_cache() {
+        if (!m_wb_cache) { throw std::runtime_error("Attempted to access a null pointer wb_cache"); }
+        return *m_wb_cache;
+    }
 };
 
 extern IndexService& index_service();

--- a/src/tests/test_index_crash_recovery.cpp
+++ b/src/tests/test_index_crash_recovery.cpp
@@ -555,19 +555,18 @@ TYPED_TEST(IndexCrashTest, long_running_put_crash) {
         bool print_time = false;
         elapsed_time = get_elapsed_time_sec(m_start_time);
 
-//        this->reset_btree();
+        this->reset_btree();
         auto flip = flips[i % flips.size()];
         LOGINFO("Step 1-{}: Set flag {}", i + 1, flip);
 
         this->set_basic_flip(flip, 1, 10);
-//        operations = generator.generateOperations(num_entries -1, true /* reset */);
-          operations = generator.generateOperations(num_entries/10, false /* reset */);
+        operations = generator.generateOperations(num_entries -1, true /* reset */);
+        //        operations = generator.generateOperations(num_entries/10, false /* reset */);
         //        LOGINFO("Batch {} Operations:\n {} \n ", i + 1, generator.printOperations(operations));
         //        LOGINFO("Detailed Key Occurrences for Batch {}:\n {} \n ", i + 1,
         //        generator.printKeyOccurrences(operations));
         for (auto [k, _] : operations) {
-//            LOGINFO("\t \t \t \t \t \t \t \t \t upserting entry {}", k);
-//            LOGINFO("{}",generator.printKeyOccurrences(operations, k));
+            //          LOGINFO("\t\t\t\t\t\t\t\t\t\t\t\t\tupserting entry {}", k);
             this->put(k, btree_put_type::INSERT, true /* expect_success */);
         }
         this->crash_and_recover(operations/*,  fmt::format("recover_tree_crash_{}.dot", i + 1)*/);

--- a/src/tests/test_scripts/index_test.py
+++ b/src/tests/test_scripts/index_test.py
@@ -90,6 +90,7 @@ def long_running_clean_shutdown(options, type=0):
 def long_running_crash_put(options):
     print("Long running crash put started")
     options['num_entries'] = 20480 # 20K
+    options['init_device'] = True
     print(f"options: {options}")
     run_crash_test(options)
     print("Long running crash put completed")

--- a/src/tests/test_scripts/index_test.py
+++ b/src/tests/test_scripts/index_test.py
@@ -49,7 +49,7 @@ def parse_arguments():
     parser.add_argument('--dev_list', help='Device list', default='')
     parser.add_argument('--cleanup_after_shutdown', help='Cleanup after shutdown', type=bool, default=False)
     parser.add_argument('--init_device', help='Initialize device', type=bool, default=True)
-    parser.add_argument('--max_keys_in_node', help='Maximum num of keys in btree nodes', type=int, default=5)
+    parser.add_argument('--max_keys_in_node', help='Maximum num of keys in btree nodes', type=int, default=20)
 
     # Parse the known arguments and ignore any unknown arguments
     args, unknown = parser.parse_known_args()

--- a/src/tests/test_scripts/index_test.py
+++ b/src/tests/test_scripts/index_test.py
@@ -20,7 +20,7 @@ def run_test(options, type):
         raise TestFailedError(f"Test failed for type {type}")
     print("Test completed")
 
-def run_test(options):
+def run_crash_test(options):
     cmd_opts = f"--gtest_filter=IndexCrashTest/0.long_running_put_crash --gtest_break_on_failure --max_keys_in_node={options['max_keys_in_node']} --init_device={options['init_device']} {options['log_mods']} --run_time={options['run_time']} --num_entries={options['num_entries']} {options['dev_list']}"
     # print(f"Running test with options: {cmd_opts}")
     try:
@@ -91,7 +91,7 @@ def long_running_crash_put(options):
     print("Long running crash put started")
     options['num_entries'] = 20480 # 20K
     print(f"options: {options}")
-    run_test(options)
+    run_crash_test(options)
     print("Long running crash put completed")
 
 def main():


### PR DESCRIPTION
The problem was in case of crash, either index service or wb cache can be nullptr during crash simulation while accessing in different code path. This will prevent accessing them while triggering crash simulator