### PR TITLE
fix long duration of write_to_full test case and max_io test case

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.58"
+    version = "6.4.59"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/tests/test_meta_blk_mgr.cpp
+++ b/src/tests/test_meta_blk_mgr.cpp
@@ -125,7 +125,7 @@ public:
 protected:
     void SetUp() override { m_helper.start_homestore("test_meta_blk_mgr", {{HS_SERVICE::META, {.size_pct = 85.0}}}); }
 
-    void TearDown() override {};
+    void TearDown() override{};
 
 public:
     [[nodiscard]] uint64_t get_elapsed_time(const Clock::time_point& start) {
@@ -399,7 +399,7 @@ public:
             iomanager.iobuf_free(buf);
         } else {
             if (unaligned_addr) {
-                delete[] (buf - unaligned_shift);
+                delete[](buf - unaligned_shift);
             } else {
                 delete[] buf;
             }
@@ -585,6 +585,7 @@ public:
     }
 
     void register_client() {
+        LOGINFO("Registering client with type: {}", mtype);
         m_mbm = &(meta_service());
         m_total_wrt_sz = m_mbm->used_size();
         HS_REL_ASSERT_EQ(m_mbm->total_size() - m_total_wrt_sz, m_mbm->available_blks() * m_mbm->block_size());

--- a/src/tests/test_scripts/log_meta_test.py
+++ b/src/tests/test_scripts/log_meta_test.py
@@ -73,21 +73,22 @@ def meta_nightly(options, addln_opts):
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 
-    cmd_opts = "--run_time=7200 --num_io=1000000"
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --run_time=7200 --num_io=1000000"
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 
-    cmd_opts = "--min_write_size=65536 --max_write_size=2097152 --run_time=14400 --num_io=1000000"
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --min_write_size=65536 --max_write_size=2097152 --run_time=14400 --num_io=1000000"
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 
-    cmd_opts = "--min_write_size=10485760 --max_write_size=80857600 --bitmap=1"
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --min_write_size=10485760 --max_write_size=60857600 --bitmap=1"
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 
-    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.write_to_full_test"  # write to file instead of real disk to save time;
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --gtest_filter=VMetaBlkMgrTest.write_to_full_test --use_file=true"  # write to file instead of real disk to save time;
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
+
     print("meta blk store test completed")
 
 


### PR DESCRIPTION
1. change max_io size to 60MB which will fit in with existing portion nblks with 4GB min chunk size;
2. change write_to_full case to allow use file for testing to complete sooner. The original purpose of this test case is to see what meta svc will behave after writing laste byte of its vdev. If with real drives, it will take around 3 days to complete this single test case. We can choose to remove --use_file if we do really want to test that long with meta svc some day...

Testing:
======
1. both max io test case and write to full test case passed by manual run on real drives. 
2. a new round of meta svc long run is kicked off and waiting to complete (will merge after a full round passed).