### PR TITLE
Add index CR UT for basic merge

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.3"
+    version = "6.5.4"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/btree/detail/btree_internal.hpp
+++ b/src/include/homestore/btree/detail/btree_internal.hpp
@@ -245,7 +245,9 @@ struct BtreeConfig {
     uint8_t m_split_pct{50};
     uint32_t m_max_merge_nodes{3};
 #ifdef _PRERELEASE
-        uint64_t m_max_keys_in_node{0};
+    // These are for testing purpose only
+    uint64_t m_max_keys_in_node{0};
+    uint64_t m_min_keys_in_node{0};
 #endif
     bool m_rebalance_turned_on{false};
     bool m_merge_turned_on{true};

--- a/src/lib/device/virtual_dev.cpp
+++ b/src/lib/device/virtual_dev.cpp
@@ -424,6 +424,8 @@ std::error_code VirtualDev::sync_write(const char* buf, uint32_t size, BlkId con
 
     Chunk* chunk;
     uint64_t const dev_offset = to_dev_offset(bid, &chunk);
+    HS_LOG(TRACE, device, "Writing sync in device: {}, offset = {}", chunk->physical_dev_mutable()->pdev_id(),
+           dev_offset);
     if (sisl_unlikely(dev_offset == INVALID_DEV_OFFSET)) {
         return std::make_error_code(std::errc::resource_unavailable_try_again);
     }
@@ -435,6 +437,9 @@ std::error_code VirtualDev::sync_write(const char* buf, uint32_t size, cshared< 
 #ifdef _PRERELEASE
     if (hs()->crash_simulator().is_crashed()) { return std::error_code{}; }
 #endif
+
+    HS_LOG(TRACE, device, "Writing sync in device: {}, offset = {}", chunk->physical_dev_mutable()->pdev_id(),
+           chunk->start_offset() + offset_in_chunk);
 
     if (sisl_unlikely(!is_chunk_available(chunk))) {
         return std::make_error_code(std::errc::resource_unavailable_try_again);
@@ -457,6 +462,8 @@ std::error_code VirtualDev::sync_writev(const iovec* iov, int iovcnt, BlkId cons
     auto const size = get_len(iov, iovcnt);
     auto* pdev = chunk->physical_dev_mutable();
 
+    HS_LOG(TRACE, device, "Writing sync in device: {}, offset = {}", pdev->pdev_id(), dev_offset);
+
     COUNTER_INCREMENT(m_metrics, vdev_write_count, 1);
     if (sisl_unlikely(!hs_utils::mod_aligned_sz(dev_offset, pdev->align_size()))) {
         COUNTER_INCREMENT(m_metrics, unalign_writes, 1);
@@ -478,6 +485,8 @@ std::error_code VirtualDev::sync_writev(const iovec* iov, int iovcnt, cshared< C
     uint64_t const dev_offset = chunk->start_offset() + offset_in_chunk;
     auto const size = get_len(iov, iovcnt);
     auto* pdev = chunk->physical_dev_mutable();
+
+    HS_LOG(TRACE, device, "Writing sync in device: {}, offset = {}", pdev->pdev_id(), dev_offset);
 
     COUNTER_INCREMENT(m_metrics, vdev_write_count, 1);
     if (sisl_unlikely(!hs_utils::mod_aligned_sz(dev_offset, pdev->align_size()))) {

--- a/src/lib/homestore.cpp
+++ b/src/lib/homestore.cpp
@@ -329,8 +329,6 @@ void HomeStore::shutdown() {
 #ifdef _PRERELEASE
     flip::Flip::instance().stop_rpc_server();
 #endif
-
-    HomeStore::reset_instance();
     LOGINFO("Homestore is completed its shutdown");
 }
 

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -198,8 +198,8 @@ public:
         }
 
         homestore::HomeStore::instance()->shutdown();
+        iomanager.stop(); // Stop iomanager first in case any fiber is still referencing homestore resources
         homestore::HomeStore::reset_instance();
-        iomanager.stop();
 
         if (cleanup) {
             remove_files(m_generated_devs);
@@ -250,6 +250,11 @@ public:
         freq.set_percent(percent);
         m_fc.inject_delay_flip(flip_name, {null_cond}, freq, delay_usec);
         LOGDEBUG("Flip {} set", flip_name);
+    }
+
+    void remove_flip(const std::string flip_name) {
+        m_fc.remove_flip(flip_name);
+        LOGDEBUG("Flip {} removed", flip_name);
     }
 #endif
 

--- a/src/tests/test_scripts/index_test.py
+++ b/src/tests/test_scripts/index_test.py
@@ -52,6 +52,7 @@ def parse_arguments():
     parser.add_argument('--cleanup_after_shutdown', help='Cleanup after shutdown', type=bool, default=False)
     parser.add_argument('--init_device', help='Initialize device', type=bool, default=True)
     parser.add_argument('--max_keys_in_node', help='Maximum num of keys in btree nodes', type=int, default=5)
+    parser.add_argument('--min_keys_in_node', help='Minimum num of keys in btree nodes', type=int, default=2)
     parser.add_argument('--num_rounds', help='number of rounds for crash test', type=int, default=10000)
     parser.add_argument('--num_entries_per_rounds', help='number of rounds for crash test', type=int, default=60)
 


### PR DESCRIPTION
https://docs.google.com/presentation/d/1NUvu1ZlDKqJWfBayg2lSWHSB6TEaZ4Y3VbnGc996drM/edit#slide=id.g2f8c68a8252_1_10

------

Add basic index CR logic & UT.

Major changes including:
* Reconstruct our handling strategy in `wb_cache::recover()` for recovered new/freed buffers
* Add protection for several corner cases in `index_table::repair_link()`

As well as some bug fixes:
* Fix several down_buffer counter leaks
* Fix a bug in wb_cache async_flush that may cause one buffer get processed multiple times
* Fix some bugs in racing conditions during homestore restart

------

There are still some known issues in some corner cases, such as incorrect next_node pointer. However, since solving these may introduce complicated modification to the current logic, let's leave them to future PRs and discuss later.