### PR TITLE
Count in ovf headers.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.65"
+    version = "6.4.66"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/tests/test_meta_blk_mgr.cpp
+++ b/src/tests/test_meta_blk_mgr.cpp
@@ -195,7 +195,8 @@ public:
 
         uint64_t size_written{0};
         while (free_size > 0) {
-            if (free_size >= gp.max_wrt_sz) {
+            // if it is overflow, 2 extra blocks are needed for ovf blk header and meta blk;
+            if (free_size -  2 * m_mbm->block_size()  >= gp.max_wrt_sz) {
                 size_written = do_sb_write(do_overflow(), 0);
             } else {
                 size_written = do_sb_write(false, m_mbm->meta_blk_context_sz());


### PR DESCRIPTION
We see no space error in write_to_full ut, might
due to when left space == max_wrt_sz and we take max_wrt_sz, however two extra blks are needed.