### PR TITLE
Change replace member api signature.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.4.67"
+    version = "6.5.1"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_decls.h
+++ b/src/include/homestore/replication/repl_decls.h
@@ -78,6 +78,13 @@ struct peer_info {
     uint64_t last_succ_resp_us_;
 };
 
+struct replica_member_info {
+    static constexpr uint64_t max_name_len = 128;
+    replica_id_t id;
+    char name[max_name_len];
+    int32_t priority{0};
+};
+
 } // namespace homestore
 
 // hash function definitions

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -348,7 +348,7 @@ public:
     virtual void on_destroy() = 0;
 
     /// @brief Called when replace member is performed.
-    virtual void replace_member(replica_id_t member_out, replica_id_t member_in) = 0;
+    virtual void on_replace_member(const replica_member_info& member_out, const replica_member_info& member_in) = 0;
 
     /// @brief Called when the snapshot is being created by nuraft
     virtual AsyncReplResult<> create_snapshot(shared< snapshot_context > context) = 0;

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -41,7 +41,8 @@ public:
     /// @return A Future which gets called after schedule to release (before garbage collection is kicked in)
     virtual folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) = 0;
 
-    virtual AsyncReplResult<> replace_member(group_id_t group_id, replica_id_t member_out, replica_id_t member_in,
+    virtual AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                             const replica_member_info& member_in,
                                              uint32_t commit_quorum = 0) const = 0;
 
     /// @brief Get the repl dev for a given group id if it is already created or opened

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -36,8 +36,8 @@ using raft_cluster_config_ptr_t = nuraft::ptr< nuraft::cluster_config >;
 ENUM(repl_dev_stage_t, uint8_t, INIT, ACTIVE, DESTROYING, DESTROYED, PERMANENT_DESTROYED);
 
 struct replace_members_ctx {
-    std::array< uint8_t, 16 > out_replica_id;
-    std::array< uint8_t, 16 > in_replica_id;
+    replica_member_info replica_out;
+    replica_member_info replica_in;
 };
 
 class RaftReplDevMetrics : public sisl::MetricsGroup {
@@ -162,7 +162,8 @@ public:
 
     bool bind_data_service();
     bool join_group();
-    AsyncReplResult<> replace_member(replica_id_t member_out, replica_id_t member_in, uint32_t commit_quorum);
+    AsyncReplResult<> replace_member(const replica_member_info& member_out, const replica_member_info& member_in,
+                                     uint32_t commit_quorum);
     folly::SemiFuture< ReplServiceError > destroy_group();
 
     //////////////// All ReplDev overrides/implementation ///////////////////////
@@ -199,8 +200,8 @@ public:
                                       sisl::blob const& key, uint32_t data_size, bool is_data_channel);
     folly::Future< folly::Unit > notify_after_data_written(std::vector< repl_req_ptr_t >* rreqs);
     void check_and_fetch_remote_data(std::vector< repl_req_ptr_t > rreqs);
-    void cp_flush(CP* cp, cshared<ReplDevCPContext> ctx);
-    cshared<ReplDevCPContext> get_cp_ctx(CP* cp);
+    void cp_flush(CP* cp, cshared< ReplDevCPContext > ctx);
+    cshared< ReplDevCPContext > get_cp_ctx(CP* cp);
     void cp_cleanup(CP* cp);
     void become_ready();
 

--- a/src/lib/replication/service/generic_repl_svc.cpp
+++ b/src/lib/replication/service/generic_repl_svc.cpp
@@ -147,8 +147,8 @@ void SoloReplService::load_repl_dev(sisl::byte_view const& buf, void* meta_cooki
     }
 }
 
-AsyncReplResult<> SoloReplService::replace_member(group_id_t group_id, replica_id_t member_out, replica_id_t member_in,
-                                                  uint32_t commit_quorum) const {
+AsyncReplResult<> SoloReplService::replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                                  const replica_member_info& member_in, uint32_t commit_quorum) const {
     return make_async_error<>(ReplServiceError::NOT_IMPLEMENTED);
 }
 

--- a/src/lib/replication/service/generic_repl_svc.h
+++ b/src/lib/replication/service/generic_repl_svc.h
@@ -73,8 +73,8 @@ public:
                                                          std::set< replica_id_t > const& members) override;
     folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) override;
     void load_repl_dev(sisl::byte_view const& buf, void* meta_cookie) override;
-    AsyncReplResult<> replace_member(group_id_t group_id, replica_id_t member_out, replica_id_t member_in,
-                                     uint32_t commit_quorum = 0) const override;
+    AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                     const replica_member_info& member_in, uint32_t commit_quorum = 0) const override;
 };
 
 class SoloReplServiceCPHandler : public CPCallbacks {

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -85,12 +85,11 @@ void RaftReplService::start() {
     LOGINFO("Starting RaftReplService with server_uuid={} port={}", boost::uuids::to_string(params.server_uuid_),
             params.mesg_port_);
 
-    //check if ssl cert files are provided, if yes, monitor the changes
+    // check if ssl cert files are provided, if yes, monitor the changes
     if (!params.ssl_key_.empty() && !params.ssl_cert_.empty()) {
         ioenvironment.with_file_watcher();
         monitor_cert_changes();
     }
-    
 
     // Step 2: Register all RAFT parameters. At the end of this step, raft is ready to be created/join group
     auto r_params = nuraft::raft_params()
@@ -158,7 +157,7 @@ void RaftReplService::start() {
         auto rdev = std::dynamic_pointer_cast< RaftReplDev >(it->second);
         rdev->wait_for_logstore_ready();
         if (!rdev->join_group()) {
-	    HS_REL_ASSERT(false, "FAILED TO JOIN GROUP, PANIC HERE");
+            HS_REL_ASSERT(false, "FAILED TO JOIN GROUP, PANIC HERE");
             it = m_rd_map.erase(it);
         } else {
             ++it;
@@ -191,19 +190,19 @@ void RaftReplService::monitor_cert_changes() {
         restart_svc.detach();
     };
 
-    //monitor ssl cert file
+    // monitor ssl cert file
     if (!fw->register_listener(ioenvironment.get_ssl_cert(), "hs_ssl_cert_watcher", cert_change_cb)) {
-        LOGERROR("Failed to register listner, {} to watch file {}, Not monitoring cert files",
-                   "hs_ssl_cert_watcher", ioenvironment.get_ssl_cert());
+        LOGERROR("Failed to register listner, {} to watch file {}, Not monitoring cert files", "hs_ssl_cert_watcher",
+                 ioenvironment.get_ssl_cert());
     }
-    //monitor ssl key file
+    // monitor ssl key file
     if (!fw->register_listener(ioenvironment.get_ssl_key(), "hs_ssl_key_watcher", cert_change_cb)) {
-        LOGERROR("Failed to register listner, {} to watch file {}, Not monitoring cert files",
-                   "hs_ssl_key_watcher", ioenvironment.get_ssl_key());
+        LOGERROR("Failed to register listner, {} to watch file {}, Not monitoring cert files", "hs_ssl_key_watcher",
+                 ioenvironment.get_ssl_key());
     }
 }
 
-void RaftReplService::restart_raft_svc(const std::string filepath, const bool deleted){
+void RaftReplService::restart_raft_svc(const std::string filepath, const bool deleted) {
     if (deleted && !wait_for_cert(filepath)) {
         LOGINFO("file {} deleted, ", filepath)
         // wait for the deleted file to be added again
@@ -215,7 +214,7 @@ void RaftReplService::restart_raft_svc(const std::string filepath, const bool de
 }
 
 bool RaftReplService::wait_for_cert(const std::string& filepath) {
-    auto attempts = cert_change_timeout/cert_check_sleep;
+    auto attempts = cert_change_timeout / cert_check_sleep;
     for (auto i = attempts; i > 0; --i) {
         if (std::filesystem::exists(filepath)) { return true; }
         std::this_thread::sleep_for(cert_check_sleep);
@@ -394,8 +393,8 @@ void RaftReplService::load_repl_dev(sisl::byte_view const& buf, void* meta_cooki
     add_repl_dev(group_id, rdev);
 }
 
-AsyncReplResult<> RaftReplService::replace_member(group_id_t group_id, replica_id_t member_out, replica_id_t member_in,
-                                                  uint32_t commit_quorum) const {
+AsyncReplResult<> RaftReplService::replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                                  const replica_member_info& member_in, uint32_t commit_quorum) const {
     auto rdev_result = get_repl_dev(group_id);
     if (!rdev_result) { return make_async_error<>(ReplServiceError::SERVER_NOT_FOUND); }
 

--- a/src/lib/replication/service/raft_repl_service.h
+++ b/src/lib/replication/service/raft_repl_service.h
@@ -51,7 +51,7 @@ private:
     iomgr::timer_handle_t m_flush_durable_commit_timer_hdl;
     iomgr::io_fiber_t m_reaper_fiber;
     std::mutex raft_restart_mutex;
-    
+
 public:
     RaftReplService(cshared< ReplApplication >& repl_app);
 
@@ -73,8 +73,8 @@ protected:
                                                          std::set< replica_id_t > const& members) override;
     folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) override;
     void load_repl_dev(sisl::byte_view const& buf, void* meta_cookie) override;
-    AsyncReplResult<> replace_member(group_id_t group_id, replica_id_t member_out, replica_id_t member_in,
-                                     uint32_t commit_quorum = 0) const override;
+    AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                     const replica_member_info& member_in, uint32_t commit_quorum = 0) const override;
 
 private:
     RaftReplDev* raft_group_config_found(sisl::byte_view const& buf, void* meta_cookie);
@@ -98,12 +98,13 @@ struct ReplDevCPContext;
 
 class ReplSvcCPContext : public CPContext {
     std::shared_mutex m_cp_map_mtx;
-    std::map< ReplDev*, cshared<ReplDevCPContext> > m_cp_ctx_map;
+    std::map< ReplDev*, cshared< ReplDevCPContext > > m_cp_ctx_map;
+
 public:
-    ReplSvcCPContext(CP* cp) : CPContext(cp){};
+    ReplSvcCPContext(CP* cp) : CPContext(cp) {};
     virtual ~ReplSvcCPContext() = default;
-    int add_repl_dev_ctx(ReplDev* dev, cshared<ReplDevCPContext> dev_ctx);
-    cshared<ReplDevCPContext> get_repl_dev_ctx(ReplDev* dev);
+    int add_repl_dev_ctx(ReplDev* dev, cshared< ReplDevCPContext > dev_ctx);
+    cshared< ReplDevCPContext > get_repl_dev_ctx(ReplDev* dev);
 };
 
 class RaftReplServiceCPHandler : public CPCallbacks {

--- a/src/tests/test_solo_repl_dev.cpp
+++ b/src/tests/test_solo_repl_dev.cpp
@@ -136,7 +136,7 @@ public:
                       cintrusive< repl_req_ctx >& ctx) override {
             LOGINFO("Received error={} on repl_dev", enum_name(error));
         }
-        void replace_member(replica_id_t member_out, replica_id_t member_in) override {}
+        void on_replace_member(const replica_member_info& member_out, const replica_member_info& member_in) override {}
         void on_destroy() override {}
     };
 


### PR DESCRIPTION
Changed the api signature because homeobject gets Member info with name, priority etc. But homestore api's dont have that.
Add replica member info with name, priority and id. Use replica member info for replace member api and listener callbacks.