### PR TITLE
Implement GC_REPL_REQ Based on DSN to Prevent Resource Leaks

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.6"
+    version = "6.5.7"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.4"
+    version = "6.5.6"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -126,7 +126,7 @@ struct repl_req_ctx : public boost::intrusive_ref_counter< repl_req_ctx, boost::
     friend class SoloReplDev;
 
 public:
-    repl_req_ctx() {}
+    repl_req_ctx() { m_start_time = Clock::now(); }
     virtual ~repl_req_ctx();
     void init(repl_key rkey, journal_type_t op_code, bool is_proposer, sisl::blob const& user_header,
               sisl::blob const& key, uint32_t data_size);

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -1192,7 +1192,7 @@ std::pair< bool, nuraft::cb_func::ReturnCode > RaftReplDev::handle_raft_event(nu
 
             auto reqs = sisl::VectorPool< repl_req_ptr_t >::alloc();
             auto last_commit_lsn = uint64_cast(get_last_commit_lsn());
-            for (unsigned long i=0; i < entries.size(); i++) {
+            for (unsigned long i = 0; i < entries.size(); i++) {
                 auto& entry = entries[i];
                 auto lsn = start_lsn + i;
                 auto term = entry->get_term();
@@ -1201,8 +1201,8 @@ std::pair< bool, nuraft::cb_func::ReturnCode > RaftReplDev::handle_raft_event(nu
                 // skipping localize for already committed log(dup), they anyway will be discard
                 // by nuraft before append_log.
                 if (lsn <= last_commit_lsn) {
-                    RD_LOGT("Raft channel: term {}, lsn {}, skipping dup, last_commit_lsn {}",
-                            term, lsn, last_commit_lsn);
+                    RD_LOGT("Raft channel: term {}, lsn {}, skipping dup, last_commit_lsn {}", term, lsn,
+                            last_commit_lsn);
                     continue;
                 }
                 // Those LSNs already in logstore but not yet committed, will be dedup here,
@@ -1290,18 +1290,20 @@ void RaftReplDev::gc_repl_reqs() {
         // FIXME: Skipping proposer for now, the DSN in proposer increased in proposing stage, not when commit().
         // Need other mechanism.
         if (rreq->is_proposer()) {
-            RD_LOGD("Skipping rreq=[{}] due to is_proposer, elapsed_time_sec{};", rreq->to_string(), get_elapsed_time_sec(rreq->created_time()));
+            RD_LOGD("Skipping rreq=[{}] due to is_proposer, elapsed_time_sec{};", rreq->to_string(),
+                    get_elapsed_time_sec(rreq->created_time()));
             // don't clean up proposer's request
             continue;
         }
 
-        if (rreq->dsn() < cur_dsn ) {
-            RD_LOGD("legacy req with commited DSN, rreq=[{}] , dsn = {}, next_dsn = {}, gap= {}", rreq->to_string(), rreq->dsn(),
-                    cur_dsn, cur_dsn - rreq->dsn());
+        if (rreq->dsn() < cur_dsn) {
+            RD_LOGD("legacy req with commited DSN, rreq=[{}] , dsn = {}, next_dsn = {}, gap= {}", rreq->to_string(),
+                    rreq->dsn(), cur_dsn, cur_dsn - rreq->dsn());
             // FIXME: Wait till the rreq expired is obviously safer, though as commited request will
             //  be removed from map in on_commit(), we probably don't need wait till expired.
-	    if (rreq->is_expired()) {
-                RD_LOGD("Expired rreq =[{}], elapsed_time_sec {} ", rreq->to_string(), get_elapsed_time_sec(rreq->created_time()));
+            if (rreq->is_expired()) {
+                RD_LOGD("Expired rreq =[{}], elapsed_time_sec {} ", rreq->to_string(),
+                        get_elapsed_time_sec(rreq->created_time()));
                 expired_rreqs.push_back(rreq);
             }
         }
@@ -1320,8 +1322,8 @@ void RaftReplDev::gc_repl_reqs() {
             return;
         }
         if (rreq->dsn() < cur_dsn) {
-            RD_LOGD("legacy req, rreq=[{}] , dsn = {}, next_dsn = {}, gap= {}", rreq->to_string(), rreq->dsn(),
-                    cur_dsn, cur_dsn - rreq->dsn());
+            RD_LOGD("legacy req, rreq=[{}] , dsn = {}, next_dsn = {}, gap= {}", rreq->to_string(), rreq->dsn(), cur_dsn,
+                    cur_dsn - rreq->dsn());
         }
         if (rreq->is_expired()) {
             RD_LOGD("rreq=[{}] is expired, cleaning up; elapsed_time_sec{};", rreq->to_string(),

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -1316,17 +1316,17 @@ void RaftReplDev::gc_repl_reqs() {
     m_state_machine->iterate_repl_reqs([this, cur_dsn, &sm_req_cnt](auto key, auto rreq) {
         sm_req_cnt++;
         if (rreq->is_proposer()) {
-            RD_LOGD("Skipping rreq=[{}] due to is_proposer, elapsed_time_sec{};", rreq->to_string(),
+            RD_LOGD("StateMachine: Skipping rreq=[{}] due to is_proposer, elapsed_time_sec{};", rreq->to_string(),
                     get_elapsed_time_sec(rreq->created_time()));
             // don't clean up proposer's request
             return;
         }
         if (rreq->dsn() < cur_dsn) {
-            RD_LOGD("legacy req, rreq=[{}] , dsn = {}, next_dsn = {}, gap= {}", rreq->to_string(), rreq->dsn(), cur_dsn,
+            RD_LOGD("StateMachine: legacy req, rreq=[{}] , dsn = {}, next_dsn = {}, gap= {}", rreq->to_string(), rreq->dsn(), cur_dsn,
                     cur_dsn - rreq->dsn());
         }
         if (rreq->is_expired()) {
-            RD_LOGD("rreq=[{}] is expired, cleaning up; elapsed_time_sec{};", rreq->to_string(),
+            RD_LOGD("StateMachine: rreq=[{}] is expired, elapsed_time_sec{};", rreq->to_string(),
                     get_elapsed_time_sec(rreq->created_time()));
         }
     });

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -895,7 +895,7 @@ void RaftReplDev::handle_commit(repl_req_ptr_t rreq, bool recovery) {
     // Remove the request from repl_key map.
     m_repl_key_req_map.erase(rreq->rkey());
     // Remove the request from lsn map.
-    m_state_machine->unlink_lsn_to_req(rreq->lsn());
+    m_state_machine->unlink_lsn_to_req(rreq->lsn(), rreq);
 
     auto cur_dsn = m_next_dsn.load(std::memory_order_relaxed);
     while (cur_dsn <= rreq->dsn()) {
@@ -1351,7 +1351,7 @@ void RaftReplDev::gc_repl_reqs() {
         // 3. remove from state-machine
         if (removing_rreq->has_state(repl_req_state_t::LOG_FLUSHED)) {
             RD_LOGW("Removing rreq [{}] from state machine, it is risky")
-            m_state_machine->unlink_lsn_to_req(removing_rreq->lsn());
+            m_state_machine->unlink_lsn_to_req(removing_rreq->lsn(), removing_rreq);
         }
     }
 }

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -219,11 +219,18 @@ uint64_t RaftStateMachine::last_commit_index() {
 
 void RaftStateMachine::become_ready() { m_rd.become_ready(); }
 
-void RaftStateMachine::unlink_lsn_to_req(int64_t lsn) {
+void RaftStateMachine::unlink_lsn_to_req(int64_t lsn, repl_req_ptr_t rreq) {
     auto const it = m_lsn_req_map.find(lsn);
+    // it is possible a LSN mapped to different rreq in history
+    // due to log overwritten. Verify the rreq before removing
     if (it != m_lsn_req_map.cend()) {
-        RD_LOG(DEBUG, "Raft channel: erase lsn {},  rreq {}", lsn, it->second->to_string());
-        m_lsn_req_map.erase(lsn);
+        if (it->second == rreq) {
+            RD_LOG(DEBUG, "Raft channel: erase lsn {},  rreq {}", lsn, it->second->to_string());
+            m_lsn_req_map.erase(lsn);
+        } else {
+            RD_LOGC("Erasing lsn {} pointing to rreq{} differnt with providing rreq {}", lsn, it->second->to_string(),
+                    rreq->to_string());
+        }
     }
 }
 

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -222,17 +222,11 @@ uint64_t RaftStateMachine::last_commit_index() {
 void RaftStateMachine::become_ready() { m_rd.become_ready(); }
 
 void RaftStateMachine::unlink_lsn_to_req(int64_t lsn, repl_req_ptr_t rreq) {
-    auto const it = m_lsn_req_map.find(lsn);
     // it is possible a LSN mapped to different rreq in history
     // due to log overwritten. Verify the rreq before removing
-    if (it != m_lsn_req_map.cend()) {
-        if (it->second == rreq) {
-            RD_LOG(DEBUG, "Raft channel: erase lsn {},  rreq {}", lsn, it->second->to_string());
-            m_lsn_req_map.erase(lsn);
-        } else {
-            RD_LOGC("Erasing lsn {} pointing to rreq{} differnt with providing rreq {}", lsn, it->second->to_string(),
-                    rreq->to_string());
-        }
+    auto deleted = m_lsn_req_map.erase_if_equal(lsn, rreq);
+    if (deleted) {
+        RD_LOG(DEBUG, "Raft channel: erase lsn {},  rreq {}", lsn, rreq->to_string());
     }
 }
 

--- a/src/lib/replication/repl_dev/raft_state_machine.h
+++ b/src/lib/replication/repl_dev/raft_state_machine.h
@@ -126,7 +126,7 @@ public:
     repl_req_ptr_t localize_journal_entry_prepare(nuraft::log_entry& lentry);
     repl_req_ptr_t localize_journal_entry_finish(nuraft::log_entry& lentry);
     void link_lsn_to_req(repl_req_ptr_t rreq, int64_t lsn);
-    void unlink_lsn_to_req(int64_t lsn);
+    void unlink_lsn_to_req(int64_t lsn, repl_req_ptr_t rreq);
     repl_req_ptr_t lsn_to_req(int64_t lsn);
     nuraft_mesg::repl_service_ctx* group_msg_service();
 


### PR DESCRIPTION
This commit introduces a mechanism to garbage collect (GC) replication requests (rreqs) that may hang indefinitely, thereby consuming memory and disk resources unnecessarily. These rreqs can enter a hanging state under several circumstances, as outlined below:

1. Scenario with Delayed Commit:
   - Follower F1 receives LSN 100 and DSN 104 from Leader L1 and takes longer than the raft timeout to precommit/commit it.
   - L1 resends LSN 100, causing F1 to fetch the data again. Since LSN 100 was committed in a previous attempt, this log entry is skipped, leaving the rreq hanging indefinitely.

2. Scenario with Leader Failure Before Data Completion:
   - Follower F1 receives LSN 100 from L1, but before all data is fetched/pushed, L1 fails and L2 becomes the new leader.
   - L2 resends LSN 100 with L2 as the new originator. F1 proceeds with the new rreq and commits it, but the initial rreq from L1 hangs indefinitely as it cannot fetch data from the new leader L2.

3. Scenario with Leader Failure After Data Write:
   - Follower F1 receives data (DSN 104) from L1 and writes it. Before the log of LSN 100 reaches F1, L1 fails and L2 becomes the new leader.
   - L2 resends LSN 100 to F1, and F1 fetches DSN 104 from L2, leaving the original rreq hanging.

This garbage collection process cleans up based on DSN. Any rreqs in `m_repl_key_req_map`, whose DSN is already committed (`rreq->dsn < repl_dev->m_next_dsn`), will be GC'd. This is safe on the follower side, as the follower updates `m_next_dsn` during commit. Any DSN below `cur_dsn` should already be committed, implying that the rreq should already be removed from `m_repl_key_req_map`.

On the leader side, since `m_next_dsn` is updated when sending out the proposal, it is not safe to clean up based on `m_next_dsn`. Therefore, we explicitly skip the leader in this GC process.