### PR TITLE
Add protection for concurrent access to m_down_buffers

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.5"
+    version = "6.5.6"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/index/index_internal.hpp
+++ b/src/include/homestore/index/index_internal.hpp
@@ -97,7 +97,8 @@ struct IndexBuffer : public sisl::ObjLifeCounter< IndexBuffer > {
     sisl::atomic_counter< int > m_wait_for_down_buffers{0}; // Number of children need to wait for before persisting
 #ifndef NDEBUG
     // Down buffers are not mandatory members, but only to keep track of any bugs and asserts
-    std::vector< std::weak_ptr< IndexBuffer > > m_down_buffers;
+    std::vector<std::weak_ptr<IndexBuffer> > m_down_buffers;
+    std::mutex m_down_buffers_mtx;
     std::shared_ptr< IndexBuffer > m_prev_up_buffer; // Keep a copy for debugging
 #endif
 
@@ -123,6 +124,13 @@ struct IndexBuffer : public sisl::ObjLifeCounter< IndexBuffer > {
 
     std::string to_string() const;
     std::string to_string_dot() const;
+
+    void add_down_buffer(const IndexBufferPtr &buf);
+
+    void remove_down_buffer(const IndexBufferPtr &buf);
+#ifndef NDEBUG
+    bool is_in_down_buffers(const IndexBufferPtr &buf);
+#endif
 };
 
 // This is a special buffer which is used to write to the meta block


### PR DESCRIPTION
Issue: <https://github.com/eBay/HomeStore/issues/578>

The `down_buf` has the `real_up_buf` (the meta buf) as its up_buffer, but cannot be found in the `read_up_buf->m_down_buffers`. The inconsistency is caused by unprotected concurrent writes to the vector `m_down_buffers`.

Add a mutex lock to `IndexBuffer` as well as extracting add/remove operations into member functions to make the vector thread-safe. 