### PR TITLE
push data asynchronously at leader

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.11"
+    version = "6.5.12"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"


### PR DESCRIPTION
now we always start appending log to log store at leader until all the futures of pushing data to followers are completed , which will involve unnecessary latency

this PR aims to make pushing data asynchronously,  so that logs can be set to follower ASAP. it does not matter whether push_data is successful, since follower will try to fetch data from the leader if push_data fails