### PR TITLE
Add application_hint into blk_alloc_hints

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.12"
+    version = "6.5.13"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/blk.h
+++ b/src/include/homestore/blk.h
@@ -252,6 +252,7 @@ struct blk_alloc_hints {
     std::optional< uint32_t > pdev_id_hint;      // which physical device to pick (hint if any) -1 for don't care
     std::optional< chunk_num_t > chunk_id_hint;  // any specific chunk id to pick for this allocation
     std::optional< stream_id_t > stream_id_hint; // any specific stream to pick
+    std::optional< uint64_t > application_hint;  // hints in uint64 what will be passed opaque to select_chunk
     bool can_look_for_other_chunk{true};         // If alloc on device not available can I pick other device
     bool is_contiguous{true};                    // Should the entire allocation be one contiguous block
     bool partial_alloc_ok{false};   // ok to allocate only portion of nblks? Mutually exclusive with is_contiguous


### PR DESCRIPTION
Add `application_hint` to the `blk_alloc_hints` structure. This change addresses the need for certain users of `homestore`, such as `homeobject`, to pass additional hints. The `application_hint` can be used to specify behavior in the `select_chunk` interface.