### PR TITLE
Fix grpc crash

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.16"
+    version = "6.5.17"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/common.cpp
+++ b/src/lib/replication/repl_dev/common.cpp
@@ -164,7 +164,6 @@ bool repl_req_ctx::add_state_if_not_already(repl_req_state_t s) {
 void repl_req_ctx::clear() {
     m_header = sisl::blob{};
     m_key = sisl::blob{};
-    release_data();
     m_pkts.clear();
 }
 
@@ -174,7 +173,9 @@ void repl_req_ctx::release_data() {
     // explicitly clear m_buf_for_unaligned_data as unaligned pushdata/fetchdata will be saved here
     m_buf_for_unaligned_data = sisl::io_blob_safe{};
     if (m_pushed_data) {
-        LOGTRACEMOD(replication, "m_pushed_data addr: {}", static_cast<void *>(m_pushed_data.get()));
+        LOGTRACEMOD(replication, "m_pushed_data addr={}, m_rkey={}, m_lsn={}",
+                    static_cast<void *>(m_pushed_data.get()),
+                    m_rkey.to_string(), m_lsn);
         m_pushed_data->send_response();
         m_pushed_data = nullptr;
     }

--- a/src/lib/replication/repl_dev/common.cpp
+++ b/src/lib/replication/repl_dev/common.cpp
@@ -168,6 +168,7 @@ void repl_req_ctx::clear() {
     m_pkts.clear();
 }
 
+// FIXME: Use lock to avoid concurrent release of data.
 void repl_req_ctx::release_data() {
     m_data = nullptr;
     // explicitly clear m_buf_for_unaligned_data as unaligned pushdata/fetchdata will be saved here

--- a/src/lib/replication/repl_dev/common.cpp
+++ b/src/lib/replication/repl_dev/common.cpp
@@ -174,6 +174,7 @@ void repl_req_ctx::release_data() {
     // explicitly clear m_buf_for_unaligned_data as unaligned pushdata/fetchdata will be saved here
     m_buf_for_unaligned_data = sisl::io_blob_safe{};
     if (m_pushed_data) {
+        LOGTRACEMOD(replication, "m_pushed_data addr: {}", static_cast<void *>(m_pushed_data.get()));
         m_pushed_data->send_response();
         m_pushed_data = nullptr;
     }

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -454,8 +454,8 @@ void RaftReplDev::on_push_data_received(intrusive< sisl::GenericRpcData >& rpc_d
                 handle_error(rreq, ReplServiceError::DRIVE_WRITE_ERROR);
             } else {
                 rreq->add_state(repl_req_state_t::DATA_WRITTEN);
-                rreq->m_data_written_promise.setValue();
                 rreq->release_data();
+                rreq->m_data_written_promise.setValue();
                 const auto data_log_diff_us =
                     push_data_rcv_time.time_since_epoch().count() > rreq->created_time().time_since_epoch().count()
                     ? get_elapsed_time_us(rreq->created_time(), push_data_rcv_time)
@@ -873,8 +873,8 @@ void RaftReplDev::handle_fetch_data_response(sisl::GenericClientResponse respons
                     RD_REL_ASSERT(!err,
                                   "Error in writing data"); // TODO: Find a way to return error to the Listener
                     rreq->add_state(repl_req_state_t::DATA_WRITTEN);
-                    rreq->m_data_written_promise.setValue();
                     rreq->release_data();
+                    rreq->m_data_written_promise.setValue();
 
                     RD_LOGD("Data Channel: Data Write completed rreq=[{}], data_write_latency_us={}, "
                             "total_write_latency_us={}, write_num_pieces={}",

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -453,8 +453,8 @@ void RaftReplDev::on_push_data_received(intrusive< sisl::GenericRpcData >& rpc_d
                 RD_DBG_ASSERT(false, "Error in writing data, error_code={}", err.value());
                 handle_error(rreq, ReplServiceError::DRIVE_WRITE_ERROR);
             } else {
-                rreq->add_state(repl_req_state_t::DATA_WRITTEN);
                 rreq->release_data();
+                rreq->add_state(repl_req_state_t::DATA_WRITTEN);
                 rreq->m_data_written_promise.setValue();
                 const auto data_log_diff_us =
                     push_data_rcv_time.time_since_epoch().count() > rreq->created_time().time_since_epoch().count()
@@ -872,8 +872,8 @@ void RaftReplDev::handle_fetch_data_response(sisl::GenericClientResponse respons
 
                     RD_REL_ASSERT(!err,
                                   "Error in writing data"); // TODO: Find a way to return error to the Listener
-                    rreq->add_state(repl_req_state_t::DATA_WRITTEN);
                     rreq->release_data();
+                    rreq->add_state(repl_req_state_t::DATA_WRITTEN);
                     rreq->m_data_written_promise.setValue();
 
                     RD_LOGD("Data Channel: Data Write completed rreq=[{}], data_write_latency_us={}, "


### PR DESCRIPTION
If data channel and raft channel release the same data at the same time, there is a chance that send_response may be called twice, then grpc will crash with error TOO_MANY_OPERATIONS. This pr make sure data channel release data at first.

Signed-off-by: Yawen Zhang <yawzhang@ebay.com>