### PR TITLE
Support flexible virtual device creation in HomeStore with num_chunks or chunk_size

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.17"
+    version = "6.5.18"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/blkdata_service.hpp
+++ b/src/include/homestore/blkdata_service.hpp
@@ -56,17 +56,19 @@ public:
 
     /**
      * @brief Creates a new virtual device with the specified size and block size, using the specified
-     * block allocator and chunk selector types. The virtual device will be composed of the specified
-     * number of chunks.
+     * block allocator and chunk selector types. The virtual device will be composed of a number of chunks.
+     * Either `num_chunks` or `chunk_size` must be specified.
+     * Prioritize `num_chunks` over `chunk_size` if both are provided.
      *
      * @param size The size of the virtual device, in bytes.
      * @param blk_size The size of each block in the virtual device, in bytes.
      * @param alloc_type The type of block allocator to use for the virtual device.
      * @param chunk_sel_type The type of chunk selector to use for the virtual device.
      * @param num_chunks The number of chunks to use for the virtual device.
+     * @param chunk_size The size of chunks to use for the virtual device, in bytes.
      */
     void create_vdev(uint64_t size, HSDevType devType, uint32_t blk_size, blk_allocator_type_t alloc_type,
-                     chunk_selector_type_t chunk_sel_type, uint32_t num_chunks);
+                     chunk_selector_type_t chunk_sel_type, uint32_t num_chunks, uint32_t chunk_size);
 
     /**
      * @brief Opens a virtual device with the specified virtual device information.

--- a/src/lib/blkdata_svc/blkdata_service.cpp
+++ b/src/lib/blkdata_svc/blkdata_service.cpp
@@ -38,7 +38,7 @@ BlkDataService::~BlkDataService() = default;
 
 // first-time boot path
 void BlkDataService::create_vdev(uint64_t size, HSDevType devType, uint32_t blk_size, blk_allocator_type_t alloc_type,
-                                 chunk_selector_type_t chunk_sel_type, uint32_t num_chunks) {
+                                 chunk_selector_type_t chunk_sel_type, uint32_t num_chunks, uint32_t chunk_size) {
     hs_vdev_context vdev_ctx;
     vdev_ctx.type = hs_vdev_type_t::DATA_VDEV;
 
@@ -48,6 +48,7 @@ void BlkDataService::create_vdev(uint64_t size, HSDevType devType, uint32_t blk_
                                                         .vdev_size = size,
                                                         .num_chunks = num_chunks,
                                                         .blk_size = blk_size,
+                                                        .chunk_size = chunk_size,
                                                         .dev_type = devType,
                                                         .alloc_type = alloc_type,
                                                         .chunk_sel_type = chunk_sel_type,

--- a/src/lib/homestore.cpp
+++ b/src/lib/homestore.cpp
@@ -226,11 +226,11 @@ void HomeStore::format_and_start(std::map< uint32_t, hs_format_params >&& format
         } else if ((svc_type & HS_SERVICE::DATA) && has_data_service()) {
             m_data_service->create_vdev(pct_to_size(fparams.size_pct, fparams.dev_type), fparams.dev_type,
                                         fparams.block_size, fparams.alloc_type, fparams.chunk_sel_type,
-                                        fparams.num_chunks);
+                                        fparams.num_chunks, fparams.chunk_size);
         } else if ((svc_type & HS_SERVICE::REPLICATION) && has_repl_data_service()) {
             m_data_service->create_vdev(pct_to_size(fparams.size_pct, fparams.dev_type), fparams.dev_type,
                                         fparams.block_size, fparams.alloc_type, fparams.chunk_sel_type,
-                                        fparams.num_chunks);
+                                        fparams.num_chunks, fparams.chunk_size);
         }
     }
 


### PR DESCRIPTION
Support flexible virtual device creation in `homestore::BlkDataService` with num_chunks or chunk_size. Prioritize `num_chunks` over `chunk_size` if both are provided.
