### PR TITLE
Add on_repl_devs_init_completed cb.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.21"
+    version = "6.5.22"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -75,6 +75,10 @@ public:
     // Listener corresponding to the ReplDev which will be used to perform the precommit/commit/rollback.
     virtual shared< ReplDevListener > create_repl_dev_listener(group_id_t group_id) = 0;
 
+    // Called after all the repl devs are found upon restart of the homestore instance.
+    // it is a nice place for upper layer to recovery anything depends on repl_devs
+    virtual void on_repl_devs_init_completed() = 0;
+
     // Given the uuid of the peer, get their address and port
     virtual std::pair< std::string, uint16_t > lookup_peer(replica_id_t uuid) const = 0;
 

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -131,6 +131,8 @@ void RaftReplService::start() {
         rdev->on_restart();
     }
     m_config_sb_bufs.clear();
+    LOGINFO("Repl devs load completed, calling upper layer on_repl_devs_init_completed");
+    m_repl_app->on_repl_devs_init_completed();
 
     // Step 5: Start the data and logstore service now. This step is essential before we can ask Raft to join groups etc
 

--- a/src/tests/test_common/hs_repl_test_common.hpp
+++ b/src/tests/test_common/hs_repl_test_common.hpp
@@ -115,6 +115,7 @@ public:
         create_repl_dev_listener(homestore::group_id_t group_id) override {
             return helper_.get_listener(group_id);
         }
+        void on_repl_devs_init_completed() { LOGINFO("Repl dev init completed CB called"); }
 
         std::pair< std::string, uint16_t > lookup_peer(homestore::replica_id_t replica_id) const override {
             uint16_t port;

--- a/src/tests/test_solo_repl_dev.cpp
+++ b/src/tests/test_solo_repl_dev.cpp
@@ -153,6 +153,7 @@ public:
         shared< ReplDevListener > create_repl_dev_listener(uuid_t) override {
             return std::make_shared< Listener >(m_test);
         }
+        void on_repl_devs_init_completed() { LOGINFO("Repl dev init completed CB called"); }
         std::pair< std::string, uint16_t > lookup_peer(uuid_t uuid) const override { return std::make_pair("", 0u); }
         replica_id_t get_my_repl_id() const override { return hs_utils::gen_random_uuid(); }
     };


### PR DESCRIPTION
A stable callback is needed regardless whether we have repl_dev created.

This CB is a nice place for upper layer to recover those depends on repl_dev.