### PR TITLE
Calling pre_commit for lsn > dc_lsn.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.22"
+    version = "6.5.23"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"


### PR DESCRIPTION
driven by nuraft implementation

https://github.com/eBay/NuRaft/blob/1adcc6282109c2ddf1121bbc374d48d303145e39/src/handle_append_entries.cxx#L847-L852

the pre_commit is called once log appened to log store, even before persist.

For logs recovered from log store, it should call pre-commit with no condition.