### PR TITLE
Ensure Consistent LSN Before Opening for Traffic in Raft Group

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.27"
+    version = "6.5.28"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
@@ -54,7 +54,7 @@ class HomestoreConan(ConanFile):
     def requirements(self):
         self.requires("iomgr/[^11.3]@oss/master", transitive_headers=True)
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
-        self.requires("nuraft_mesg/[^3.7]@oss/main", transitive_headers=True)
+        self.requires("nuraft_mesg/[^3.7.1]@oss/main", transitive_headers=True)
 
         self.requires("farmhash/cci.20190513@", transitive_headers=True)
         if self.settings.arch in ['x86', 'x86_64']:

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -124,8 +124,9 @@ struct snapshot_obj {
     bool is_last_obj{false};
 };
 
-//HomeStore has some meta information to be transmitted during the baseline resync,
-//Although now only dsn needs to be synced, this structure is defined as a general message, and we can easily add data if needed in the future.
+// HomeStore has some meta information to be transmitted during the baseline resync,
+// Although now only dsn needs to be synced, this structure is defined as a general message, and we can easily add data
+// if needed in the future.
 struct snp_repl_dev_data {
     uint64_t magic_num{HOMESTORE_RESYNC_DATA_MAGIC};
     uint32_t protocol_version{HOMESTORE_RESYNC_DATA_PROTOCOL_VERSION_V1};
@@ -467,6 +468,10 @@ public:
     /// @brief Gets the last commit lsn of this repldev
     /// @return last_commit_lsn
     virtual repl_lsn_t get_last_commit_lsn() const = 0;
+
+    /// @brief if this replica is ready for accepting client IO.
+    /// @return true if ready, false otherwise
+    virtual bool is_ready_for_traffic() const = 0;
 
     virtual void attach_listener(shared< ReplDevListener > listener) { m_listener = std::move(listener); }
 

--- a/src/lib/replication/repl_dev/common.cpp
+++ b/src/lib/replication/repl_dev/common.cpp
@@ -174,8 +174,7 @@ void repl_req_ctx::release_data() {
     m_buf_for_unaligned_data = sisl::io_blob_safe{};
     if (m_pushed_data) {
         LOGTRACEMOD(replication, "m_pushed_data addr={}, m_rkey={}, m_lsn={}",
-                    static_cast<void *>(m_pushed_data.get()),
-                    m_rkey.to_string(), m_lsn);
+                    static_cast< void* >(m_pushed_data.get()), m_rkey.to_string(), m_lsn);
         m_pushed_data->send_response();
         m_pushed_data = nullptr;
     }

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -385,7 +385,7 @@ bool RaftStateMachine::apply_snapshot(nuraft::snapshot& s) {
     m_rd.m_data_journal->set_last_durable_lsn(s.get_last_log_idx());
     auto snp_ctx = std::make_shared< nuraft_snapshot_context >(s);
     auto res = m_rd.m_listener->apply_snapshot(snp_ctx);
-    //make sure the changes are flushed.
+    // make sure the changes are flushed.
     hs()->cp_mgr().trigger_cp_flush(true /* force */).get();
     return res;
 }

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -53,6 +53,7 @@ public:
     std::vector< peer_info > get_replication_status() const override {
         return std::vector< peer_info >{peer_info{.id_ = m_group_id, .replication_idx_ = 0, .last_succ_resp_us_ = 0}};
     }
+    bool is_ready_for_traffic() const override { return true; }
 
     uuid_t group_id() const override { return m_group_id; }
 


### PR DESCRIPTION
We identified a gap when majority members in a Raft group are down. To save IO operations, we do not persist the last_commit_idx for every commit but instead at regular intervals. Consequently, upon reboot, we may not reflect the latest commit, leaving some logs in the state machine waiting for re-commitment.

For instance, if we committed up to LSN 103 but only persisted up to LSN 100, then LSNs 100-103 will remain in the log-store, awaiting re-commitment from the leader. If all members restart after a disaster, they face the following state:

- [S1]: commit_idx 100, last_log {idx = 105, term = 1}
- S2: commit_idx 100, last_log {idx = 103, term = 1}
- S3: commit_idx 100, last_log {idx = 103, term = 1}

If S1 opens for traffic at this point, previously committed LSN 102 might return NOT_FOUND to clients due to the uncommitted state.

Proposed Solution:
- Mark last_log_idx as `traffic_ready_lsn` in the BECOME_LEADER callback. In the example above, it is 105 if S1 becomes the leader.
- The leader will not accept IO until it commits up to this `consistent_lsn` (105), ensuring correctness by over-committing.
- The HO will call `repl_dev->is_ready_for_traffic()` for each IO.
- On followers, the traffic_ready_lsn is zero so it allows all.
- On the leader, all requests are rejected until it commits to the `traffic_ready_lsn` (105 in this example).