### PR TITLE
Duplication Handling

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.29"
+    version = "6.6.0"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/blk.h
+++ b/src/include/homestore/blk.h
@@ -251,6 +251,7 @@ struct blk_alloc_hints {
     blk_temp_t desired_temp{0};                  // Temperature hint for the device
     std::optional< uint32_t > pdev_id_hint;      // which physical device to pick (hint if any) -1 for don't care
     std::optional< chunk_num_t > chunk_id_hint;  // any specific chunk id to pick for this allocation
+    std::optional<MultiBlkId> committed_blk_id; //  blk id indicates the blk was already allocated and committed, don't allocate and commit again
     std::optional< stream_id_t > stream_id_hint; // any specific stream to pick
     std::optional< uint64_t > application_hint;  // hints in uint64 what will be passed opaque to select_chunk
     bool can_look_for_other_chunk{true};         // If alloc on device not available can I pick other device

--- a/src/include/homestore/replication/repl_decls.h
+++ b/src/include/homestore/replication/repl_decls.h
@@ -34,6 +34,7 @@ VENUM(ReplServiceError, int32_t,
       NOT_IMPLEMENTED = -10001,
       NO_SPACE_LEFT = -20000,
       DRIVE_WRITE_ERROR = -20001,
+      DATA_DUPLICATED = -20002,
       FAILED = -32768);
 // clang-format on
 

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -143,8 +143,8 @@ struct repl_req_ctx : public boost::intrusive_ref_counter< repl_req_ctx, boost::
 public:
     repl_req_ctx() { m_start_time = Clock::now(); }
     virtual ~repl_req_ctx();
-    void init(repl_key rkey, journal_type_t op_code, bool is_proposer, sisl::blob const& user_header,
-              sisl::blob const& key, uint32_t data_size);
+    ReplServiceError init(repl_key rkey, journal_type_t op_code, bool is_proposer, sisl::blob const& user_header,
+              sisl::blob const& key, uint32_t data_size, cshared< ReplDevListener >& listener);
 
     /////////////////////// All getters ///////////////////////
     repl_key const& rkey() const { return m_rkey; }

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -36,7 +36,8 @@ VENUM(repl_req_state_t, uint32_t,
       DATA_WRITTEN = 1 << 2,  // Data has been written to the storage
       LOG_RECEIVED = 1 << 3,  // Log is received and waiting for data
       LOG_FLUSHED = 1 << 4,   // Log has been flushed
-      ERRORED = 1 << 5        // Error has happened and cleaned up
+      ERRORED = 1 << 5,        // Error has happened and cleaned up
+      DATA_COMMITTED = 1 << 6  // Data has already been committed, used in duplication handling, will skip commit_blk
 )
 
 VENUM(journal_type_t, uint16_t,

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -501,9 +501,7 @@ repl_req_ptr_t RaftReplDev::applier_create_req(repl_key const& rkey, journal_typ
         }
     }
 
-    // We need to allocate the block, since entry doesn't exist or if it exist, two threads are trying to do the same
-    // thing. So take state mutex and allocate the blk
-    std::unique_lock< std::mutex > lg(rreq->m_state_mtx);
+    // rreq->init will allocate the block if it has linked data.
     auto status = rreq->init(rkey, code, false /* is_proposer */, user_header, key, data_size, m_listener);
     if (!rreq->has_linked_data()) { return rreq; }
 #ifdef _PRERELEASE

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -184,7 +184,7 @@ AsyncReplResult<> RaftReplDev::replace_member(const replica_member_info& member_
             sisl::blob header(r_cast< uint8_t* >(&members), sizeof(replace_members_ctx));
             rreq->init(
                 repl_key{.server_id = server_id(), .term = raft_server()->get_term(), .dsn = m_next_dsn.fetch_add(1)},
-                journal_type_t::HS_CTRL_REPLACE, true, header, sisl::blob{}, 0);
+                journal_type_t::HS_CTRL_REPLACE, true, header, sisl::blob{}, 0, m_listener);
 
             auto err = m_state_machine->propose_to_raft(std::move(rreq));
             if (err != ReplServiceError::OK) {
@@ -251,7 +251,7 @@ folly::SemiFuture< ReplServiceError > RaftReplDev::destroy_group() {
     // here, we set the dsn to a new one , which is definitely unique in the follower, so that the new rreq will not
     // have a conflict with the old rreq.
     rreq->init(repl_key{.server_id = server_id(), .term = raft_server()->get_term(), .dsn = m_next_dsn.fetch_add(1)},
-               journal_type_t::HS_CTRL_DESTROY, true, sisl::blob{}, sisl::blob{}, 0);
+               journal_type_t::HS_CTRL_DESTROY, true, sisl::blob{}, sisl::blob{}, 0, m_listener);
 
     auto err = m_state_machine->propose_to_raft(std::move(rreq));
     if (err != ReplServiceError::OK) {
@@ -292,24 +292,22 @@ void RaftReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& 
         }
     }
 
-    rreq->init(repl_key{.server_id = server_id(), .term = raft_server()->get_term(), .dsn = m_next_dsn.fetch_add(1)},
+    auto status = rreq->init(repl_key{.server_id = server_id(), .term = raft_server()->get_term(), .dsn = m_next_dsn.fetch_add(1)},
                data.size ? journal_type_t::HS_DATA_LINKED : journal_type_t::HS_DATA_INLINED, true /* is_proposer */,
-               header, key, data.size);
+               header, key, data.size, m_listener);
 
     // Add the request to the repl_dev_rreq map, it will be accessed throughout the life cycle of this request
     auto const [it, happened] = m_repl_key_req_map.emplace(rreq->rkey(), rreq);
     RD_DBG_ASSERT(happened, "Duplicate repl_key={} found in the map", rreq->rkey().to_string());
 
+    if (status != ReplServiceError::OK) {
+        RD_LOGD("Initializing rreq failed error={}, failing this req", status);
+        handle_error(rreq, status);
+        return;
+    }
+
     // If it is header only entry, directly propose to the raft
     if (rreq->has_linked_data()) {
-
-        // Step 1: Alloc Blkid
-        auto const status = rreq->alloc_local_blks(m_listener, data.size);
-        if (status != ReplServiceError::OK) {
-            RD_LOGD("Allocating blks failed error={}, failing this req", status);
-            handle_error(rreq, status);
-            return;
-        }
         if (rreq->is_proposer() && rreq->has_state(repl_req_state_t::DATA_COMMITTED)) {
             RD_LOGD("data blks has already been allocated and committed, failing this req");
             handle_error(rreq, ReplServiceError::DATA_DUPLICATED);
@@ -506,30 +504,23 @@ repl_req_ptr_t RaftReplDev::applier_create_req(repl_key const& rkey, journal_typ
     // We need to allocate the block, since entry doesn't exist or if it exist, two threads are trying to do the same
     // thing. So take state mutex and allocate the blk
     std::unique_lock< std::mutex > lg(rreq->m_state_mtx);
-    rreq->init(rkey, code, false /* is_proposer */, user_header, key, data_size);
-
-    // There is no data portion, so there is not need to allocate
+    auto status = rreq->init(rkey, code, false /* is_proposer */, user_header, key, data_size, m_listener);
     if (!rreq->has_linked_data()) { return rreq; }
-    if (rreq->has_state(repl_req_state_t::BLK_ALLOCATED)) { return rreq; }
-
-    auto alloc_status = rreq->alloc_local_blks(m_listener, data_size);
 #ifdef _PRERELEASE
     if (is_data_channel) {
         if (iomgr_flip::instance()->test_flip("fake_reject_append_data_channel")) {
             LOGINFO("Data Channel: Reject append_entries flip is triggered for rkey={}", rkey.to_string());
-            alloc_status = ReplServiceError::NO_SPACE_LEFT;
+            status = ReplServiceError::NO_SPACE_LEFT;
         }
     } else {
         if (iomgr_flip::instance()->test_flip("fake_reject_append_raft_channel")) {
             LOGINFO("Raft Channel: Reject append_entries flip is triggered for rkey={}", rkey.to_string());
-            alloc_status = ReplServiceError::NO_SPACE_LEFT;
+            status = ReplServiceError::NO_SPACE_LEFT;
         }
     }
 #endif
-    if (rreq->has_state(repl_req_state_t::DATA_COMMITTED)) {
-        RD_LOGI("For Repl_key=[{}] data already exists, skip", rkey.to_string());
-    } else if (alloc_status != ReplServiceError::OK) {
-        RD_LOGE("For Repl_key=[{}] alloc hints returned error={}, failing this req", rkey.to_string(), alloc_status);
+    if (status != ReplServiceError::OK) {
+        RD_LOGD("For Repl_key=[{}] alloc hints returned error={}, failing this req", rkey.to_string(), status);
         // Do not call handle_error here, because handle_error is for rreq which needs to be terminated. This one can be
         // retried.
         return nullptr;
@@ -936,8 +927,8 @@ void RaftReplDev::handle_rollback(repl_req_ptr_t rreq) {
     }
 }
 
-void RaftReplDev::handle_commit(repl_req_ptr_t rreq, bool recovery) {
-    commit_blk(rreq);
+    void RaftReplDev::handle_commit(repl_req_ptr_t rreq, bool recovery) {
+    if (!rreq->has_state(repl_req_state_t::DATA_COMMITTED)) { commit_blk(rreq); }
 
     // Remove the request from repl_key map.
     m_repl_key_req_map.erase(rreq->rkey());
@@ -1523,7 +1514,12 @@ void RaftReplDev::on_log_found(logstore_seq_num_t lsn, log_buffer buf, void* ctx
     rreq->set_lsn(repl_lsn);
     // keep lentry in scope for the lyfe cycle of the rreq
     rreq->set_lentry(lentry);
-    rreq->init(rkey, jentry->code, false /* is_proposer */, entry_to_hdr(jentry), entry_to_key(jentry), data_size);
+    auto status = rreq->init(rkey, jentry->code, false /* is_proposer */, entry_to_hdr(jentry), entry_to_key(jentry),
+                             data_size, m_listener);
+    if (status != ReplServiceError::OK) {
+        RD_LOGE("Initializing rreq failed, rreq=[{}], error={}", rreq->to_string(), status);
+    }
+
     // we load the log from log device, implies log flushed.  We only flush log after data is written to data device.
     rreq->add_state(repl_req_state_t::DATA_WRITTEN);
     rreq->add_state(repl_req_state_t::LOG_RECEIVED);


### PR DESCRIPTION
This commit addresses duplication issues on the follower side caused by resync from the leader, it mainly happens when resend snapshot mesg during baseline resync and apply log after snapshot completion. This helps avoid unnecessary GC due to duplicated data.

Key Changes:
- Utilize allocation hints to check data existence via the application listener.
- Introduce `committed_blk_id` in `blk_alloc_hints` to indicate already allocated and committed blocks and pass it from application to HS, preventing reallocation and recommitment.
- In `alloc_local_blks()`, if `committed_blk_id` is returned, also add states `DATA_RECEIVED`, `DATA_WRITTEN`, and `DATA_COMMITTED` to skip async_write() and commit_blk().

On the leader side (`RaftReplDev::async_alloc_write`), duplication is treated as an error, as the leader should not propose duplicate data, which may result from mistakes.

FYI, to make the idea clearer, here is the adaptive changes in HO https://github.com/eBay/HomeObject/pull/244/files.