### PR TITLE
fix twice call of leave

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.26"
+    version = "6.5.27"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -229,7 +229,9 @@ public:
      *
      * @param num_reserved_entries The number of reserved entries of the replication log.
      */
-    void truncate(uint32_t num_reserved_entries) { m_data_journal->truncate(num_reserved_entries, m_compact_lsn.load()); }
+    void truncate(uint32_t num_reserved_entries) {
+        m_data_journal->truncate(num_reserved_entries, m_compact_lsn.load());
+    }
 
     void wait_for_logstore_ready() { m_data_journal->wait_for_log_store_ready(); }
 

--- a/src/tests/test_common/raft_repl_test_base.hpp
+++ b/src/tests/test_common/raft_repl_test_base.hpp
@@ -182,16 +182,12 @@ public:
         return make_async_success<>();
     }
 
-    static int64_t get_next_lsn(uint64_t& obj_id) {
-        return obj_id & ((1ULL << 63) - 1);
-    }
-    static void set_resync_msg_type_bit(uint64_t& obj_id) {
-        obj_id |= 1ULL << 63;
-    }
+    static int64_t get_next_lsn(uint64_t& obj_id) { return obj_id & ((1ULL << 63) - 1); }
+    static void set_resync_msg_type_bit(uint64_t& obj_id) { obj_id |= 1ULL << 63; }
 
     int read_snapshot_obj(shared< snapshot_context > context, shared< snapshot_obj > snp_data) override {
         auto s = std::dynamic_pointer_cast< nuraft_snapshot_context >(context)->nuraft_snapshot();
-        if(RaftStateMachine::is_hs_snp_obj(snp_data->offset)) {
+        if (RaftStateMachine::is_hs_snp_obj(snp_data->offset)) {
             LOGERRORMOD(replication, "invalid snapshot offset={}", snp_data->offset);
             return -1;
         }


### PR DESCRIPTION
Removed From cluster will be called twice when committing config_change log and journal_type_t::HS_CTRL_DESTROY in the moved out member, so the destroy future will be setvalue twice , which will lead to an error. this PR fixes this bug