### PR TITLE
Refine variant_node::put return value

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.5.27"
+    version = "6.5.28"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/btree/detail/btree_internal.hpp
+++ b/src/include/homestore/btree/detail/btree_internal.hpp
@@ -201,8 +201,8 @@ VENUM(btree_node_type, uint32_t, FIXED = 0, VAR_VALUE = 1, VAR_KEY = 2, VAR_OBJE
 VENUM(btree_store_type, uint8_t, MEM = 0, SSD = 1)
 #endif
 
-ENUM(btree_status_t, uint32_t, success, not_found, retry, has_more, node_read_failed, put_failed, space_not_avail,
-     cp_mismatch, merge_not_required, merge_failed, crc_mismatch, not_supported, node_freed)
+ENUM(btree_status_t, uint32_t, success, not_found, retry, has_more, node_read_failed, already_exists, filtered_out,
+     space_not_avail, cp_mismatch, merge_not_required, merge_failed, crc_mismatch, not_supported, node_freed)
 
 /*ENUM(btree_node_write_type, uint8_t,
      new_node,     // Node write whenever a new node is created.

--- a/src/include/homestore/btree/detail/btree_mutate_impl.ipp
+++ b/src/include/homestore/btree/detail/btree_mutate_impl.ipp
@@ -56,7 +56,7 @@ retry:
         const auto matched = my_node->match_range(req.working_range(), start_idx, end_idx);
         if (!matched) {
             BT_NODE_LOG_ASSERT(false, my_node, "match_range returns 0 entries for interior node is not valid pattern");
-            ret = btree_status_t::put_failed;
+            ret = btree_status_t::not_found;
             goto out;
         }
     } else if constexpr (std::is_same_v< ReqT, BtreeSinglePutRequest >) {
@@ -182,10 +182,8 @@ btree_status_t Btree< K, V >::mutate_write_leaf_node(const BtreeNodePtr& my_node
             req.shift_working_range();
         }
     } else if constexpr (std::is_same_v< ReqT, BtreeSinglePutRequest >) {
-        if (!to_variant_node(my_node)->put(req.key(), req.value(), req.m_put_type, req.m_existing_val,
-                                           req.m_filter_cb)) {
-            ret = btree_status_t::put_failed;
-        }
+        ret = to_variant_node(my_node)->put(req.key(), req.value(), req.m_put_type, req.m_existing_val,
+                                            req.m_filter_cb);
         COUNTER_INCREMENT(m_metrics, btree_obj_count, 1);
     }
 

--- a/src/tests/btree_helpers/btree_test_helper.hpp
+++ b/src/tests/btree_helpers/btree_test_helper.hpp
@@ -439,8 +439,7 @@ private:
         K key = K{k};
         auto sreq = BtreeSinglePutRequest{&key, &value, put_type, existing_v.get()};
         sreq.enable_route_tracing();
-        bool done = expect_success ? (m_bt->put(sreq) == btree_status_t::success)
-                                   : m_bt->put(sreq) == btree_status_t::put_failed;
+        bool done = expect_success == (m_bt->put(sreq) == btree_status_t::success);
 
         if (put_type == btree_put_type::INSERT) {
             ASSERT_EQ(done, !m_shadow_map.exists(key));


### PR DESCRIPTION
Replace the generic put_failed error status with more specific error messages to enhance clarity and prevent confusion during log analysis.