### PR TITLE
reset rreq time every time we reuse a rreq

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.2"
+    version = "6.6.3"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -489,8 +489,9 @@ repl_req_ptr_t RaftReplDev::applier_create_req(repl_key const& rkey, journal_typ
     auto rreq = it->second;
 
     if (!happened) {
-        // We already have the entry in the map, check if we are already allocated the blk by previous caller, in
-        // that case we need to return the req.
+        // We already have the entry in the map, reset its start time to prevent it from being incorrectly gc during use.
+        rreq->set_created_time();
+        // Check if we are already allocated the blk by previous caller, in that case we need to return the req.
         if (rreq->has_state(repl_req_state_t::BLK_ALLOCATED)) {
             // Do validation if we have the correct mapping
             // RD_REL_ASSERT(blob_equals(user_header, rreq->header), "User header mismatch for repl_key={}",


### PR DESCRIPTION
The `applier_create_req` function will insert rreq to `m_repl_key_req_map` at the first time, then it try to allocate local blks, and if failed to allocate blks, the rreq will not be removed until gc. And if we retry to create req again, the rreq will be reused without update for the timer, which may hit the following issue:

T1: failed to alloc blk for data while receiving it from data channel
T2: recevied log from raft channel and reuse rreq
T3: gc, the corresponding rreq is removed (raft channel is lower than data channel since there are lots of create/seal shard req)
T4:  append process cannot find rreq at `localize_journal_entry_finish` and try to prepare rreq again, so the rreq is new but the entry is old, leading mismatch.

So we reset timer for rreq every time we reuse it.