### PR TITLE
fix HomeRaftLogStore::last_entry

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.2"
+    version = "6.6.3"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/logstore/log_store.hpp
+++ b/src/include/homestore/logstore/log_store.hpp
@@ -231,6 +231,7 @@ public:
     bool rollback(logstore_seq_num_t to_lsn);
 
     auto start_lsn() const { return m_start_lsn.load(std::memory_order_acquire); }
+    auto tail_lsn() const { return m_tail_lsn.load(std::memory_order_acquire); }
 
     nlohmann::json dump_log_store(const log_dump_req& dump_req = log_dump_req());
 

--- a/src/lib/replication/log_store/home_raft_log_store.cpp
+++ b/src/lib/replication/log_store/home_raft_log_store.cpp
@@ -147,8 +147,11 @@ nuraft::ptr< nuraft::log_entry > HomeRaftLogStore::last_entry() const {
         auto log_bytes = m_log_store->read_sync(max_seq);
         nle = to_nuraft_log_entry(log_bytes);
     } catch (const std::exception& e) {
-        REPL_STORE_LOG(ERROR, "last_entry() out_of_range={}", max_seq);
-        throw e;
+        // all the log entries are truncated, so we should return a dummy log entry.
+        REPL_STORE_LOG(ERROR, "last_entry() out_of_range={}, {}", max_seq, e.what());
+        // according to the contract, we should return a dummy log entry if the index is out of range.
+        // https://github.com/eBay/NuRaft/blob/50e2f949503081262cb21923e633eaa8dacad8fa/include/libnuraft/log_store.hxx#L56
+        nle = m_dummy_log_entry;
     }
 
     return nle;

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -313,9 +313,10 @@ private:
      */
     void handle_error(repl_req_ptr_t const& rreq, ReplServiceError err);
 
-    bool wait_for_data_receive(std::vector < repl_req_ptr_t > const &rreqs, uint64_t timeout_ms,
-                               std::vector < repl_req_ptr_t > *timeout_rreqs = nullptr);
+    bool wait_for_data_receive(std::vector< repl_req_ptr_t > const& rreqs, uint64_t timeout_ms,
+                               std::vector< repl_req_ptr_t >* timeout_rreqs = nullptr);
     void on_log_found(logstore_seq_num_t lsn, log_buffer buf, void* ctx);
+    void set_log_store_last_durable_lsn(store_lsn_t lsn);
     void commit_blk(repl_req_ptr_t rreq);
     void replace_member(repl_req_ptr_t rreq);
     void reset_quorum_size(uint32_t commit_quorum);


### PR DESCRIPTION
according to the contract, we should return a dummy log entry if the index is out of range.