### PR TITLE
Remove log store truncation from resource mg

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.5"
+    version = "6.6.6"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/common/resource_mgr.cpp
+++ b/src/lib/common/resource_mgr.cpp
@@ -47,14 +47,16 @@ void ResourceMgr::stop() {
 //
 void ResourceMgr::trigger_truncate() {
     if (hs()->has_repl_data_service()) {
-        // first make sure all repl dev's underlying raft log store make corresponding reservation during
-        // truncate -- set the safe truncate boundary for each raft log store;
-        hs()->repl_service().iterate_repl_devs([](cshared< ReplDev >& rd) {
-            // lock is already taken by repl service layer;
-            std::dynamic_pointer_cast< RaftReplDev >(rd)->truncate(
-                HS_DYNAMIC_CONFIG(resource_limits.raft_logstore_reserve_threshold));
-        });
-
+        /*
+         * DO NOT NEED : raft will truncate logs.
+         * // first make sure all repl dev's underlying raft log store make corresponding reservation during
+         * // truncate -- set the safe truncate boundary for each raft log store;
+         * hs()->repl_service().iterate_repl_devs([](cshared< ReplDev >& rd) {
+         *     // lock is already taken by repl service layer;
+         *     std::dynamic_pointer_cast< RaftReplDev >(rd)->truncate(
+         *     HS_DYNAMIC_CONFIG(resource_limits.raft_logstore_reserve_threshold));
+         *  });
+         */
         // next do device truncate which go through all logdevs and truncate them;
         hs()->logstore_service().device_truncate();
     }

--- a/src/lib/replication/log_store/home_raft_log_store.cpp
+++ b/src/lib/replication/log_store/home_raft_log_store.cpp
@@ -49,6 +49,9 @@ static uint64_t extract_term(const log_buffer& log_bytes) {
     return (*r_cast< uint64_t const* >(raw_ptr));
 }
 
+#if 0
+// Since truncate_lsn can not accross compact_lsn passed down by raft server
+// and compact will truncate logs upto compact_lsn, we don't need to re-truncate in this function now.
 void HomeRaftLogStore::truncate(uint32_t num_reserved_cnt, repl_lsn_t compact_lsn) {
     auto const last_lsn = last_index();
     auto const start_lsn = start_index();
@@ -79,6 +82,7 @@ void HomeRaftLogStore::truncate(uint32_t num_reserved_cnt, repl_lsn_t compact_ls
         m_log_store->truncate(truncate_lsn);
     }
 }
+#endif
 
 HomeRaftLogStore::HomeRaftLogStore(logdev_id_t logdev_id, logstore_id_t logstore_id, log_found_cb_t const& log_found_cb,
                                    log_replay_done_cb_t const& log_replay_done_cb) :

--- a/src/lib/replication/log_store/home_raft_log_store.h
+++ b/src/lib/replication/log_store/home_raft_log_store.h
@@ -204,6 +204,7 @@ public:
      */
     ulong last_index() const;
 
+#if 0
     /**
      * Truncates the log store
      *
@@ -212,6 +213,7 @@ public:
      * LSN;
      */
     void truncate(uint32_t num_reserved_cnt, repl_lsn_t compact_lsn);
+#endif
 
     void wait_for_log_store_ready();
     void set_last_durable_lsn(repl_lsn_t lsn);

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -250,6 +250,7 @@ public:
      */
     void on_create_snapshot(nuraft::snapshot& s, nuraft::async_result< bool >::handler_type& when_done);
 
+#if 0
     /**
      * Truncates the replication log by providing a specified number of reserved entries.
      *
@@ -258,6 +259,7 @@ public:
     void truncate(uint32_t num_reserved_entries) {
         m_data_journal->truncate(num_reserved_entries, m_compact_lsn.load());
     }
+#endif
 
     void wait_for_logstore_ready() { m_data_journal->wait_for_log_store_ready(); }
 

--- a/src/tests/test_common/raft_repl_test_base.hpp
+++ b/src/tests/test_common/raft_repl_test_base.hpp
@@ -420,7 +420,7 @@ public:
 
     void truncate(int num_reserved_entries) {
         auto raft_repl_dev = std::dynamic_pointer_cast< RaftReplDev >(repl_dev());
-        raft_repl_dev->truncate(num_reserved_entries);
+        // raft_repl_dev->truncate(num_reserved_entries);
         LOGINFO("Manually truncated");
     }
 

--- a/src/tests/test_raft_repl_dev.cpp
+++ b/src/tests/test_raft_repl_dev.cpp
@@ -409,7 +409,7 @@ TEST_F(RaftReplDevTest, BaselineTest) {
             // Leader does manual snapshot and truncate
             LOGINFO("Leader create snapshot and truncate");
             this->create_snapshot();
-            this->truncate(0);
+            // this->truncate(0);
         }
     }
 


### PR DESCRIPTION
Currently both resource_mgr and raft can call log store's `truncate`, but resource_mgr will not truncate logs whose lsn less than compact lsn. That means resource_mgr just re-truncate logs which will be / has been truncated in `compact`. But if resource_mgr and raft call truncate concurrently, crash will happen. 
For example, raft truncate logs upto compact_lsn and execute 
```
m_records.truncate(upto_lsn);
m_start_lsn.store(upto_lsn + 1);
```
Then resource_mgr truncate truncate_lsn (which is no large than compact_lsn) and execute `m_trunc_ld_key = m_records.at(upto_lsn).m_trunc_key; ` Since truncate_lsn has been truncated, an exception thrown.

This pr remove truncation from resource_mgr to avoid concurrency.