### PR TITLE
update last_commit_lsn in commit_config

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.4"
+    version = "6.6.5"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -959,6 +959,20 @@ void RaftReplDev::handle_commit(repl_req_ptr_t rreq, bool recovery) {
     if (!rreq->is_proposer()) { rreq->clear(); }
 }
 
+void RaftReplDev::handle_config_commit(const repl_lsn_t lsn, raft_cluster_config_ptr_t& new_conf) {
+    // when reaching here, the new config has already been applied to the cluster.
+    // since we didn't create repl req for config change, we just need to update m_commit_upto_lsn here.
+
+    // keep this variable in case it is needed later
+    (void) new_conf;
+    auto prev_lsn = m_commit_upto_lsn.load(std::memory_order_relaxed);
+    RD_DBG_ASSERT_GT(lsn, prev_lsn,
+                     "Out of order commit of lsns, it is not expected in RaftReplDev. cur_lsns={}, prev_lsns={}",
+                     lsn, prev_lsn);
+    RD_DBG_ASSERT(m_commit_upto_lsn.compare_exchange_strong(prev_lsn, lsn),
+                  "Raft Channel: unexpected log {} commited before config {} committed", prev_lsn, lsn);
+}
+
 void RaftReplDev::handle_error(repl_req_ptr_t const& rreq, ReplServiceError err) {
     if (err == ReplServiceError::OK) { return; }
     RD_LOGE("Raft Channel: Error in processing rreq=[{}] error={}", rreq->to_string(), err);

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -207,6 +207,7 @@ public:
     //////////////// Methods needed for other Raft classes to access /////////////////
     void use_config(json_superblk raft_config_sb);
     void handle_commit(repl_req_ptr_t rreq, bool recovery = false);
+    void handle_config_commit(const repl_lsn_t lsn, raft_cluster_config_ptr_t& new_conf);
     void handle_rollback(repl_req_ptr_t rreq);
     repl_req_ptr_t repl_key_to_req(repl_key const& rkey) const;
     repl_req_ptr_t applier_create_req(repl_key const& rkey, journal_type_t code, sisl::blob const& user_header,

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -230,6 +230,8 @@ void RaftStateMachine::commit_config(const ulong log_idx, raft_cluster_config_pt
     RD_LOG(INFO, "Raft channel: server ids in new cluster conf : {}, my_id {}, group_id {}", oss.str(), my_id,
            m_rd.group_id_str());
 #endif
+
+    m_rd.handle_config_commit(s_cast< repl_lsn_t >(log_idx), new_conf);
 }
 
 void RaftStateMachine::rollback_config(const ulong log_idx, raft_cluster_config_ptr_t& conf) {


### PR DESCRIPTION
HomeObject call HS `is_ready_for_traffic` before put/get/del, and if it return false, HO will reject requests. In HomeStore, we use `m_commit_upto_lsn>=m_traffic_ready_lsn` to determine if it is ready, so we need to update `m_commit_upto_lsn` every time raft commit a log. Currently we only update it in app log, so this pr add the update in config log.