### PR TITLE
Support async snapshot io config

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.6"
+    version = "6.6.7"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/common/homestore_config.fbs
+++ b/src/lib/common/homestore_config.fbs
@@ -268,6 +268,10 @@ table Consensus {
     // Log difference from leader's point of view,  to determine if the
     // follower is laggy and if so, leader will stop pushing data until it drops under this threshold.
     laggy_threshold: int64 = 2000;
+
+    // Reading snapshot objects will be done by a background thread asynchronously
+    // instead of synchronous read by Raft worker threads
+    use_bg_thread_for_snapshot_io_: bool = true;
 }
 
 table HomeStoreSettings {

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -110,6 +110,7 @@ void RaftReplService::start() {
     // There is no callback available for handling and localizing the log entries within the pack, which could
     // result in data corruption.
     r_params.use_new_joiner_type_ = true;
+    r_params.use_bg_thread_for_snapshot_io_ = HS_DYNAMIC_CONFIG(consensus.use_bg_thread_for_snapshot_io_);
     r_params.return_method_ = nuraft::raft_params::async_handler;
     m_msg_mgr->register_mgr_type(params.default_group_type_, r_params);
 


### PR DESCRIPTION
Default snapshot read logic is in a sync manner which may block other response handling and make the heartbeat timeout  . As a result, the leader will yield its leadership after check_leadership_validity.