### PR TITLE
skip append dummy logs to log dev

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.8"
+    version = "6.6.10"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/logstore/log_store.hpp
+++ b/src/include/homestore/logstore/log_store.hpp
@@ -173,6 +173,15 @@ public:
 
     logdev_key get_trunc_ld_key() const { return m_trunc_ld_key; }
 
+    /**
+     * @brief Get the truncation information for this log store. It is called during log device truncation
+     *
+     * @return tuple of (start_lsn, trunc_ld_key, tail_lsn) If the log store is empty, it will return
+     * an out_of_bound_ld_key as trunc_ld_key.
+     *
+     * @note ensure that no new logs are flushed between calling this function and completing the truncation,
+     * as this could result in an inaccurate out_of_bound_ld_key.
+     * */
     std::tuple< logstore_seq_num_t, logdev_key, logstore_seq_num_t > truncate_info() const;
 
     sisl::StreamTracker< logstore_record >& log_records() { return m_records; }
@@ -232,6 +241,7 @@ public:
 
     auto start_lsn() const { return m_start_lsn.load(std::memory_order_acquire); }
     auto tail_lsn() const { return m_tail_lsn.load(std::memory_order_acquire); }
+    auto next_lsn() const { return m_next_lsn.load(std::memory_order_acquire); }
 
     nlohmann::json dump_log_store(const log_dump_req& dump_req = log_dump_req());
 

--- a/src/include/homestore/logstore/log_store_internal.hpp
+++ b/src/include/homestore/logstore/log_store_internal.hpp
@@ -85,7 +85,8 @@ struct logdev_key {
     std::string to_string() const { return fmt::format("Logid={} devoffset={}", idx, dev_offset); }
 
     static const logdev_key& out_of_bound_ld_key() {
-        static constexpr logdev_key s_out_of_bound_ld_key{std::numeric_limits< logid_t >::max(), 0};
+        static constexpr logdev_key s_out_of_bound_ld_key{std::numeric_limits< logid_t >::max(),
+                                                          std::numeric_limits< off_t >::max()};
         return s_out_of_bound_ld_key;
     }
 };

--- a/src/lib/logstore/log_dev.hpp
+++ b/src/lib/logstore/log_dev.hpp
@@ -795,8 +795,9 @@ private:
     std::multimap< logid_t, logstore_id_t > m_garbage_store_ids;
     Clock::time_point m_last_flush_time;
 
-    logid_t m_last_flush_idx{-1}; // Track last flushed, last device offset and truncated log idx
-    logid_t m_last_truncate_idx{std::numeric_limits< logid_t >::min()}; // logdev truncate up to this idx
+    logid_t m_last_flush_idx{-1};           // Track last flushed, last device offset and truncated log idx
+    logdev_key m_last_flush_ld_key{0,0};    // Left interval of the last flush, 0 indicates the very beginning of logdev
+    logid_t m_last_truncate_idx{-1};        // Logdev truncate up to this idx
     crc32_t m_last_crc{INVALID_CRC32_VALUE};
 
     // LogDev Info block related fields

--- a/src/lib/replication/log_store/home_raft_log_store.cpp
+++ b/src/lib/replication/log_store/home_raft_log_store.cpp
@@ -361,12 +361,10 @@ bool HomeRaftLogStore::compact(ulong compact_lsn) {
         // release this assert if for some use case, we should tolorant this case;
         // for now, don't expect this case to happen.
         // RELEASE_ASSERT(false, "compact_lsn={} is beyond the current max_lsn={}", compact_lsn, cur_max_lsn);
-        REPL_STORE_LOG(DEBUG, "Adding dummy entries during compact from={} upto={}", cur_max_lsn + 1,
-                       to_store_lsn(compact_lsn));
-        // We need to fill the remaining entries with dummy data.
-        for (auto lsn{cur_max_lsn + 1}; lsn <= to_store_lsn(compact_lsn); ++lsn) {
-            append(m_dummy_log_entry);
-        }
+
+        // if compact_lsn is beyond the current max_lsn, it indicates a hole from cur_max_lsn to compact_lsn.
+        // we directly compact and truncate up to compact_lsn assuming there are dummy logs.
+        REPL_STORE_LOG(DEBUG, "Compact with log holes from {} to={}", cur_max_lsn + 1, to_store_lsn(compact_lsn));
     }
     m_log_store->truncate(to_store_lsn(compact_lsn));
     return true;


### PR DESCRIPTION
During the baseline resynchronization process, when a follower successfully receives a snapshot, it calls the compact function to truncate all logs that are no larger than snapshot.last_log_idx. In the current implementation, compact initially appends dummy logs up to snapshot.last_log_idx before truncating them. This operation is resource-intensive, and the size of the data waiting to be flushed can exceed the journal vdev's chunk size, posing a risk of system crashes.

This change eliminates the need to append dummy logs to the log device by directly updating certain indices. It also removes the dependency of log dev truncation on log store's LSN.