### PR TITLE
btree fix for the OOM issue in production

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.7.4"
+    version = "3.7.5"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/engine/homeds/btree/writeBack_cache.hpp
+++ b/src/engine/homeds/btree/writeBack_cache.hpp
@@ -439,6 +439,11 @@ public:
                     ++wb_cache_outstanding_cnt;
                     shared_this->m_blkstore->write(wb_req->bid, wb_req->m_mem, 0, wb_req, false);
                     ++write_count;
+
+                    // we are done with this wb_req
+                    HS_REL_ASSERT_EQ(wb_req, wb_req->bn->req[cp_id]);
+                    wb_req->bn->req[cp_id] = nullptr;
+
                     if (wb_cache_outstanding_cnt > ResourceMgrSI().get_dirty_buf_qd()) {
                         CP_PERIODIC_LOG(
                             DEBUG, bt_cp_id,


### PR DESCRIPTION
release a reference to the request of a cp_id after flushing it in wr…ite back cache btree