### PR TITLE
Avoid replaying the last flushed log entry

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.7"
+    version = "6.6.8"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"


### PR DESCRIPTION
This PR also helps fix [the issue5](https://docs.google.com/document/d/1U2LZ_wIou_w9PLgEcGo3DF9MZtQH44GRJ5MVC5xhOcI/edit?tab=t.0#heading=h.mgwn9kjl4vlb)  in baseline resync.