### PR TITLE
Adjust cp_io num_fiber to Prevent Deadlock

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.10"
+    version = "6.6.11"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"


### PR DESCRIPTION
Description:

Resolved a potential deadlock issue with sync_io fibers. When multiple sync_io fibers are active,
a fiber (e.g., fiber1) may acquire a thread-level mutex and perform synchronous I/O using io_uring. This causes fiber1 to call boost::fibers::promise::get_future(), blocking itself and allowing other fibers in the same thread to be scheduled.

If another fiber (e.g., fiber2) is scheduled and attempts to acquire the same mutex, a deadlock occurs. By adjusting the num_fiber in cp_io, we prevent this deadlock scenario.