### PR TITLE
Bypass dependency bugs in snapshot transmission

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.14"
+    version = "6.6.15"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -178,6 +178,15 @@ AsyncReplResult<> RaftReplDev::replace_member(const replica_member_info& member_
             RD_LOGI("Replace member added member={} to group_id={}", boost::uuids::to_string(member_in.id),
                     group_id_str());
 
+            // If enabled, create a snapshot here to ensure the new member will use the latest snapshot with itself in the config
+            if (raft_server()->get_current_params().snapshot_distance_ > 0) {
+                if (auto idx = raft_server()->create_snapshot(); idx > 0) {
+                    RD_LOGI("Created snapshot idx={} after adding member", idx);
+                } else {
+                    RD_LOGW("Failed to create snapshot after adding member");
+                }
+            }
+
             // Step 3. Append log entry to mark the old member is out and new member is added.
             auto rreq = repl_req_ptr_t(new repl_req_ctx{});
             replace_members_ctx members;


### PR DESCRIPTION
Bypass some NuRaft bugs in specific corner cases:

* Create a snapshot after adding a new member to prevent transmitting a snapshot with outdated configuration.
* Trigger cp_flush on last_obj in case apply_snapshot() is skipped dueto crash.