### PR TITLE
Flush log store meta when compacting log

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.13"
+    version = "6.6.14"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/log_store/home_raft_log_store.cpp
+++ b/src/lib/replication/log_store/home_raft_log_store.cpp
@@ -366,7 +366,7 @@ bool HomeRaftLogStore::compact(ulong compact_lsn) {
         // we directly compact and truncate up to compact_lsn assuming there are dummy logs.
         REPL_STORE_LOG(DEBUG, "Compact with log holes from {} to={}", cur_max_lsn + 1, to_store_lsn(compact_lsn));
     }
-    m_log_store->truncate(to_store_lsn(compact_lsn));
+    m_log_store->truncate(to_store_lsn(compact_lsn), false);
     return true;
 }
 

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -1570,7 +1570,7 @@ void RaftReplDev::create_snp_resync_data(raft_buf_ptr_t& data_out) {
     std::memcpy(data_out->data_begin(), &msg, msg_size);
 }
 
-bool RaftReplDev::apply_snp_resync_data(nuraft::buffer& data) {
+bool RaftReplDev::save_snp_resync_data(nuraft::buffer& data) {
     auto msg = r_cast< snp_repl_dev_data* >(data.data_begin());
     if (msg->magic_num != HOMESTORE_RESYNC_DATA_MAGIC ||
         msg->protocol_version != HOMESTORE_RESYNC_DATA_PROTOCOL_VERSION_V1) {

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -324,7 +324,7 @@ private:
     void replace_member(repl_req_ptr_t rreq);
     void reset_quorum_size(uint32_t commit_quorum);
     void create_snp_resync_data(raft_buf_ptr_t& data_out);
-    bool apply_snp_resync_data(nuraft::buffer& data);
+    bool save_snp_resync_data(nuraft::buffer& data);
 };
 
 } // namespace homestore

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -354,9 +354,9 @@ void RaftStateMachine::save_logical_snp_obj(nuraft::snapshot& s, ulong& obj_id, 
                                             bool is_last_obj) {
     if (is_hs_snp_obj(obj_id)) {
         // Homestore preserved msg
-        if (m_rd.apply_snp_resync_data(data)) {
+        if (m_rd.save_snp_resync_data(data)) {
             obj_id = snp_obj_id_type_app;
-            LOGDEBUG("apply_snp_resync_data success, next obj_id={}", obj_id);
+            LOGDEBUG("save_snp_resync_data success, next obj_id={}", obj_id);
         }
         return;
     }


### PR DESCRIPTION
In baseline resync scenario, log truncation won't flush the truncate result immediately(periodically flushed by resource manager), thus if durable_commit_lsn has been flushed but start_lsn of the logstore hasn't been flushed, it will trigger the [issue6](https://docs.google.com/document/d/1U2LZ_wIou_w9PLgEcGo3DF9MZtQH44GRJ5MVC5xhOcI/edit?tab=t.0#heading=h.y491romdh9x).
Add a flush meta function in logstore, and manually trigger flush in log truncation.