### PR TITLE
Persist logstore superblock when logdev truncation is unnecessary

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.16"
+    version = "6.6.17"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"


### PR DESCRIPTION
This change ensures that the logstore can get the correct start LSN during recovery. Avoid the following scenario:

T1: Follower1 appends logs up to 100, then is stopped by a sigkill.
T2: Upon restart, since the leader's log range is 1000-2500, a baseline resync is triggered using snapshot 2000.
T3: Follower1 completes the baseline resync (start_lsn=2001, tail_lsn=2000), but m_trunc_ld_key is not updated since we cannot get a valid device offset for LSN 2000.
T4: Follower1 appends logs from 2001 to 2500, making tail_lsn greater than 2000.
T5: During logdev truncation, the truncation info is found at first. Since trunc_lsn < tail_lsn, it returns m_trunc_ld_key (still {0,0}), then exits without persist the logstore sb.
T6: Follower1 is killed again, and upon restart, its start index in the store superblock remains 0, incorrectly interpreting the range as [1,2500].