### PR TITLE
Improve safe mode.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -39,6 +39,8 @@ pipeline {
                             script {
                                 if ((env.BRANCH_NAME.startsWith('PR') && !env.CHANGE_TARGET.startsWith('stable')) ||
                                     !env.BRANCH_NAME.startsWith('stable')) {
+                                    sh "conan install --lockfile locks/${BUILD_TYPE}_deps.lock ."
+                                    sh "git clean -fdx"
                                     sh "./update_locks.sh"
                                     sh "git diff -w -- locks"
                                 }

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.8.0"
+    version = "3.8.1"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"

--- a/src/homeblks/home_blks.hpp
+++ b/src/homeblks/home_blks.hpp
@@ -398,7 +398,8 @@ private:
     std::unique_ptr< HomeBlksHttpServer > m_hb_http_server;
 
     std::condition_variable m_cv_init_cmplt;  // wait for init to complete
-    std::condition_variable m_cv_wakeup_init; // wait for init to complete
+    std::condition_variable m_cv_wakeup_init; // wait for safe_mode to wakeup
+    bool woke_up {false}; // wait for safe_mode to wakeup
     std::mutex m_cv_mtx;
     bool m_rdy = false;
 


### PR DESCRIPTION
Safe mode was previously not exitable. It would block indefinitely after receiving the signal and finishing init preventing the AM from finishing initialization. This change makes that possible.