### PR TITLE
update sisl to enable obj life counter in release builds. 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "3.7.6"
+    version = "3.7.7"
 
     homepage = "https://github.corp.ebay.com/SDS/homestore"
     description = "HomeStore"
@@ -56,7 +56,7 @@ class HomestoreConan(ConanFile):
 
     def requirements(self):
         self.requires("iomgr/8.8.1")
-        self.requires("sisl/8.9.1")
+        self.requires("sisl/8.9.2")
 
         # FOSS, rarely updated
         self.requires("boost/1.79.0")

--- a/src/engine/homeds/btree/writeBack_cache.hpp
+++ b/src/engine/homeds/btree/writeBack_cache.hpp
@@ -440,10 +440,6 @@ public:
                     shared_this->m_blkstore->write(wb_req->bid, wb_req->m_mem, 0, wb_req, false);
                     ++write_count;
 
-                    // we are done with this wb_req
-                    HS_REL_ASSERT_EQ(wb_req, wb_req->bn->req[cp_id]);
-                    wb_req->bn->req[cp_id] = nullptr;
-
                     if (wb_cache_outstanding_cnt > ResourceMgrSI().get_dirty_buf_qd()) {
                         CP_PERIODIC_LOG(
                             DEBUG, bt_cp_id,


### PR DESCRIPTION
Update sisl to enable obj life counter in release builds and revert the unstable OOM fix