### PR TITLE
Clean up old logs at the beginning of baseline resync.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.17"
+    version = "6.6.18"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -477,6 +477,9 @@ public:
     /// @return true if ready, false otherwise
     virtual bool is_ready_for_traffic() const = 0;
 
+    /// @brief Clean up resources on this repl dev.
+    virtual void purge() = 0;
+
     virtual void attach_listener(shared< ReplDevListener > listener) { m_listener = std::move(listener); }
 
     virtual void detach_listener() {

--- a/src/lib/replication/log_store/home_raft_log_store.cpp
+++ b/src/lib/replication/log_store/home_raft_log_store.cpp
@@ -380,6 +380,13 @@ ulong HomeRaftLogStore::last_durable_index() {
     return to_repl_lsn(m_last_durable_lsn);
 }
 
+void HomeRaftLogStore::purge_all_logs() {
+    auto last_lsn = m_log_store->get_contiguous_issued_seq_num(m_last_durable_lsn);
+    REPL_STORE_LOG(INFO, "Store={} LogDev={}: Purging all logs in the log store, last_lsn={}",
+                   m_logstore_id, m_logdev_id, last_lsn);
+    m_log_store->truncate(last_lsn, false /* in_memory_truncate_only */);
+}
+
 void HomeRaftLogStore::wait_for_log_store_ready() { m_log_store_future.wait(); }
 
 void HomeRaftLogStore::set_last_durable_lsn(repl_lsn_t lsn) { m_last_durable_lsn = to_store_lsn(lsn); }

--- a/src/lib/replication/log_store/home_raft_log_store.h
+++ b/src/lib/replication/log_store/home_raft_log_store.h
@@ -215,6 +215,12 @@ public:
     void truncate(uint32_t num_reserved_cnt, repl_lsn_t compact_lsn);
 #endif
 
+    /**
+     * Purge all logs in the log store
+     * It is a dangerous operation and is only used in baseline resync now (purge all logs and restore by snapshot).
+     */
+    void purge_all_logs();
+
     void wait_for_log_store_ready();
     void set_last_durable_lsn(repl_lsn_t lsn);
 

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -198,6 +198,10 @@ public:
         if (!ready) { RD_LOGD("Not yet ready for traffic, committed to {} but gate is {}", committed_lsn, gate); }
         return ready;
     }
+    void purge() override {
+        // clean up existing logs in log store
+        m_data_journal->purge_all_logs();
+    }
 
     //////////////// Accessor/shortcut methods ///////////////////////
     nuraft_mesg::repl_service_ctx* group_msg_service();

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -54,6 +54,7 @@ public:
         return std::vector< peer_info >{peer_info{.id_ = m_group_id, .replication_idx_ = 0, .last_succ_resp_us_ = 0}};
     }
     bool is_ready_for_traffic() const override { return true; }
+    void purge() override {}
 
     uuid_t group_id() const override { return m_group_id; }
 


### PR DESCRIPTION
If the follower restarts during baseline resync, it will replay remaining logs first. However, we have already cleared shard info at the beginning of resync, so we cannot get shard while replaying logs, which will raise errors.
This change clean up old logs in log store at the beginning of baseline resync to avoid this situation.