### PR TITLE
Remove optimization on blk free operation

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.19"
+    version = "6.6.20"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"


### PR DESCRIPTION
The optimization in blk free may cause the following issue, just remove it and wait for GC handling:
- T1: blob1 is written with LSN 1 — [blkid=10, chunk=1, cnt=5].
- T2: blob1 is deleted with LSN 10, causing the last_append_offset to revert to 10.
- T3: blob2 is written with LSN 11 — [blkid=10, chunk=1, cnt=5].
- T4: The SM is terminated and restarted.
- T5: LSN 1 is replayed, committing block [blkid=10, chunk=1, cnt=5].
- T6: LSN 11 is replayed, committing block [blkid=10, chunk=1, cnt=5].
- T7: LSN 10 is committed, freeing block [blkid=10, chunk=1, cnt=5].
- T8: LSN 11 is committed again, but since the blocks have already been freed, they are not available for LSN 11.