### PR TITLE
Modify snapshot_context structure for persistency

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.21"
+    version = "6.6.22"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/homestore_decl.hpp
+++ b/src/include/homestore/homestore_decl.hpp
@@ -20,6 +20,7 @@
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid_hash.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include <sisl/utility/enum.hpp>
 #include <sisl/fds/utils.hpp>

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -58,6 +58,10 @@ public:
     bool is_ready_for_traffic() const override { return true; }
     void purge() override {}
 
+    std::shared_ptr<snapshot_context> deserialize_snapshot_context(sisl::io_blob_safe &snp_ctx) override {
+        return nullptr;
+    }
+
     uuid_t group_id() const override { return m_group_id; }
 
     repl_lsn_t get_last_commit_lsn() const override { return 0; }


### PR DESCRIPTION
Previous snapshot_context interface is insufficient for decoupling homestore from customers on snapshot implementations. This commit replaces deserialize() with a virtual function of ReplDev for constructing particular snapshot_context instance from byte buffer.

**This PR is a prerequisite for snapshot persistency in HomeObject.**