### PR TITLE
Quick fix for SH issues

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.22"
+    version = "6.6.23"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
@@ -54,7 +54,7 @@ class HomestoreConan(ConanFile):
     def requirements(self):
         self.requires("iomgr/[^11.3]@oss/master", transitive_headers=True)
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
-        self.requires("nuraft_mesg/[^3.7.2]@oss/main", transitive_headers=True)
+        self.requires("nuraft_mesg/[^3.7.3]@oss/main", transitive_headers=True)
 
         self.requires("farmhash/cci.20190513@", transitive_headers=True)
         if self.settings.arch in ['x86', 'x86_64']:

--- a/src/include/homestore/superblk_handler.hpp
+++ b/src/include/homestore/superblk_handler.hpp
@@ -80,6 +80,11 @@ public:
         } else {
             m_raw_buf = sisl::make_byte_array(size, 0, sisl::buftag::metablk);
         }
+        // Initialize m_raw_buf with zero to prevent data errors during partial writes.
+        // This ensures that any uninitialized memory does not affect the data being written or loaded.
+        // For example, if a variable in superblk is `char name[50]` and the real name length is 10,
+        // uninitialized memory may cause the name read from the superblk to be longer than 10 characters.
+        std::memset(m_raw_buf->bytes(), 0, m_raw_buf->size());
         m_sb = new (m_raw_buf->bytes()) T();
         return m_sb;
     }


### PR DESCRIPTION
1. Initializing buffer while creating superblk

This ensures that any uninitialized memory does not affect the data being written or loaded in superblk. For example, if a variable in superblk is `char name[50]` and the real name length is 10, uninitialized memory may cause the name read from the superblk to be longer than 10 characters.

2. Update nuraft_mesg version which has https://github.com/eBay/nuraft_mesg/pull/117