### PR TITLE
fix dead lock in graceful shutdown

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.22"
+    version = "6.6.23"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -187,10 +187,12 @@ void RaftReplService::stop() {
     }
 
     // stop all repl_devs
-    std::unique_lock lg(m_rd_map_mtx);
-    for (auto it = m_rd_map.begin(); it != m_rd_map.end(); ++it) {
-        auto rdev = std::dynamic_pointer_cast< RaftReplDev >(it->second);
-        rdev->stop();
+    {
+        std::unique_lock lg(m_rd_map_mtx);
+        for (auto it = m_rd_map.begin(); it != m_rd_map.end(); ++it) {
+            auto rdev = std::dynamic_pointer_cast< RaftReplDev >(it->second);
+            rdev->stop();
+        }
     }
 
     // this will stop and shutdown all the repl_dev and grpc server(data channel).


### PR DESCRIPTION
m_rd_map_mtx will be locked when cp_flush repl_service, so we need to release it ASAP in case of other component triggers cp, which will also cp_flush repl_service