### PR TITLE
Fix missing fields in RaftReplDev::save_state

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.24"
+    version = "6.6.25"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"


### PR DESCRIPTION
Newly added fields in `nuraft::srv_state` should also be persisted/loaded.

Reference: https://github.com/eBay/NuRaft/blob/2724344f530c7d7d8551fb8d2c7bb5ed75e9e8e1/include/libnuraft/srv_state.hxx

https://github.com/eBay/NuRaft/commit/da4a1aa23ec98271347c6cda50c521a290cf14d6
https://github.com/eBay/NuRaft/commit/3008beff7782f9a49c5e429f81135c13d919186d