### PR TITLE
Add event callbacks into listener for upper layer

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.25"
+    version = "6.6.26"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.26"
+    version = "6.7.0"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -370,11 +370,10 @@ public:
     /// @brief ask upper layer to decide which data should be returned.
     // @param header - header of the log entry.
     // @param blkid - original blkid of the log entry
-    // @param sgs_vec - vector of sgs to be filled with data
+    // @param sgs - sgs to be filled with data
     // @param lsn - lsn of the log entry
     virtual folly::Future< std::error_code > on_fetch_data(const int64_t lsn, const sisl::blob& header,
-                                                           const MultiBlkId& blkid,
-                                                           std::vector< sisl::sg_list >& sgs_vec) {
+                                                           const MultiBlkId& blkid, sisl::sg_list& sgs) {
         return folly::makeFuture< std::error_code >(std::error_code{});
     }
 

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -11,6 +11,7 @@
 #include <sisl/grpc/generic_service.hpp>
 #include <sisl/grpc/rpc_client.hpp>
 #include <homestore/replication/repl_decls.h>
+#include <homestore/blkdata_service.hpp>
 #include <libnuraft/snapshot.hxx>
 
 namespace nuraft {
@@ -374,7 +375,8 @@ public:
     // @param lsn - lsn of the log entry
     virtual folly::Future< std::error_code > on_fetch_data(const int64_t lsn, const sisl::blob& header,
                                                            const MultiBlkId& blkid, sisl::sg_list& sgs) {
-        return folly::makeFuture< std::error_code >(std::error_code{});
+        // default implementation is reading by blkid directly
+        return data_service().async_read(blkid, sgs, sgs.size);
     }
 
     /// @brief ask upper layer to handle no_space_left event
@@ -384,10 +386,6 @@ public:
 
     /// @brief when restart, after all the logs are replayed and before joining raft group, notify the upper layer
     virtual void on_log_replay_done(const group_id_t& group_id){};
-
-    /// @brief decide whether a particular type of event need to be handled by upper layer
-    // TODD: if we have many events to handle, we can put all the judgement in one function
-    virtual bool need_to_handle_fetch_data() { return false; }
 
 private:
     std::weak_ptr< ReplDev > m_repl_dev;

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -47,6 +47,20 @@ VENUM(journal_type_t, uint16_t,
       HS_CTRL_REPLACE = 3, // Control message to replace a member
 )
 
+// some events need to be handled by upper layer
+VENUM(event_type_t, uint8_t,
+      RD_FETCH_DATA = 0,      // fetch data
+      RD_NO_SPACE_LEFT = 1,   // no space left error
+      RD_LOG_REPLAY_DONE = 2, // log replay done
+                              // add more if needed for other applications.
+)
+
+using fetch_data_handler_t = folly::Future< std::error_code > (*)(int64_t lsn, const sisl::blob& header,
+                                                                  std::vector< sisl::sg_list >& sgs_vec);
+using no_space_left_handler_t = folly::Future< folly::Unit > (*)(uint32_t pdev_id, chunk_num_t chunk_id);
+
+using log_replay_done_handler_t = void (*)();
+
 // magic num comes from the first 8 bytes of 'echo homestore_resync_data | md5sum'
 static constexpr uint64_t HOMESTORE_RESYNC_DATA_MAGIC = 0xa65dbd27c213f327;
 static constexpr uint32_t HOMESTORE_RESYNC_DATA_PROTOCOL_VERSION_V1 = 0x01;
@@ -367,6 +381,10 @@ public:
     /// @brief Free up user-defined context inside the snapshot_obj that is allocated during read_snapshot_obj.
     virtual void free_user_snp_ctx(void*& user_snp_ctx) = 0;
 
+    /// @brief some repl_dev event might be handle by upper layer. This is where homestore gets the callbacks for these
+    /// events.
+    virtual void* get_event_handler(event_type_t event_type) { return nullptr; }
+
 private:
     std::weak_ptr< ReplDev > m_repl_dev;
 };
@@ -449,7 +467,7 @@ public:
     /// @brief Clean up resources on this repl dev.
     virtual void purge() = 0;
 
-    virtual std::shared_ptr<snapshot_context> deserialize_snapshot_context(sisl::io_blob_safe &snp_ctx) = 0;
+    virtual std::shared_ptr< snapshot_context > deserialize_snapshot_context(sisl::io_blob_safe& snp_ctx) = 0;
 
     virtual void attach_listener(shared< ReplDevListener > listener) { m_listener = std::move(listener); }
 
@@ -459,6 +477,8 @@ public:
             m_listener.reset();
         }
     }
+
+    virtual shared< ReplDevListener > get_listener() { return m_listener; }
 
     // we have no shutdown for repl_dev, since shutdown repl_dev is done by repl_service
     void stop() {

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -385,7 +385,7 @@ public:
     virtual void on_log_replay_done(const group_id_t& group_id){};
 
     /// @brief decide whether a particular type of event need to be handled by upper layer
-    // TODD: if we have many events to handle, we can all the judgement in one function
+    // TODD: if we have many events to handle, we can put all the judgement in one function
     virtual bool need_to_handle_fetch_data() { return false; }
 
 private:

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -59,7 +59,7 @@ using fetch_data_handler_t = folly::Future< std::error_code > (*)(int64_t lsn, c
                                                                   std::vector< sisl::sg_list >& sgs_vec);
 using no_space_left_handler_t = folly::Future< folly::Unit > (*)(uint32_t pdev_id, chunk_num_t chunk_id);
 
-using log_replay_done_handler_t = void (*)();
+using log_replay_done_handler_t = void (*)(const group_id_t& group_id);
 
 // magic num comes from the first 8 bytes of 'echo homestore_resync_data | md5sum'
 static constexpr uint64_t HOMESTORE_RESYNC_DATA_MAGIC = 0xa65dbd27c213f327;

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -369,9 +369,11 @@ public:
 
     /// @brief ask upper layer to decide which data should be returned.
     // @param header - header of the log entry.
+    // @param blkid - original blkid of the log entry
     // @param sgs_vec - vector of sgs to be filled with data
     // @param lsn - lsn of the log entry
     virtual folly::Future< std::error_code > on_fetch_data(const int64_t lsn, const sisl::blob& header,
+                                                           const MultiBlkId& blkid,
                                                            std::vector< sisl::sg_list >& sgs_vec) {
         return folly::makeFuture< std::error_code >(std::error_code{});
     }

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -335,7 +335,15 @@ void RaftReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& 
             handle_error(rreq, ReplServiceError::DATA_DUPLICATED);
             return;
         }
+
+#ifdef _PRERELEASE
+        if (iomgr_flip::instance()->test_flip("disable_leader_push_data")) {
+            RD_LOGD("Simulating push data failure, so that all the follower will have to fetch data");
+        } else
+            push_data_to_all_followers(rreq, data);
+#else
         push_data_to_all_followers(rreq, data);
+#endif
 
         COUNTER_INCREMENT(m_metrics, total_write_cnt, 1);
         COUNTER_INCREMENT(m_metrics, outstanding_data_write_cnt, 1);

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -774,6 +774,16 @@ void RaftReplDev::fetch_data_from_remote(std::vector< repl_req_ptr_t > rreqs) {
         });
 }
 
+void RaftReplDev::attach_listener(shared< ReplDevListener > listener) {
+    ReplDev::attach_listener(std::move(listener));
+
+    m_fetch_data_handler =
+        reinterpret_cast< fetch_data_handler_t >(m_listener->get_event_handler(event_type_t::RD_FETCH_DATA));
+
+    m_no_space_left_handler =
+        reinterpret_cast< no_space_left_handler_t >(m_listener->get_event_handler(event_type_t::RD_NO_SPACE_LEFT));
+}
+
 void RaftReplDev::on_fetch_data_received(intrusive< sisl::GenericRpcData >& rpc_data) {
     auto const& incoming_buf = rpc_data->request_blob();
     if (!incoming_buf.cbytes()) {
@@ -793,41 +803,39 @@ void RaftReplDev::on_fetch_data_received(intrusive< sisl::GenericRpcData >& rpc_
     for (auto const& req : *(fetch_req->request()->entries())) {
         auto const& lsn = req->lsn();
         auto const& originator = req->blkid_originator();
-        auto const& remote_blkid = req->remote_blkid();
 
-        // Edit this check if in the future we want to fetch from non-originator;
-        if (originator != server_id()) {
-            auto const error_msg =
-                fmt::format("Did not expect to receive fetch data from "
-                            "remote when I am not the originator of this request, originator={}, my_server_id={}",
-                            originator, server_id());
-            RD_LOGW("{}", error_msg);
-            auto status = ::grpc::Status(::grpc::INVALID_ARGUMENT, error_msg);
-            rpc_data->set_status(status);
-            rpc_data->send_response();
-            return;
+        if (originator != server_id())
+            RD_LOGD("non-originator FetchData received:  dsn={} lsn={} originator={}, my_server_id={}", req->dsn(), lsn,
+                    originator, server_id());
+
+        if (m_fetch_data_handler) {
+            auto const& header = req->user_header();
+            sisl::blob user_header = sisl::blob{header->Data(), header->size()};
+            RD_LOGD("Data Channel: FetchData handled by application: dsn={} lsn={}", req->dsn(), lsn);
+            futs.emplace_back(m_fetch_data_handler(lsn, user_header, sgs_vec));
+        } else {
+            auto const& remote_blkid = req->remote_blkid();
+            // fetch data based on the remote_blkid
+            // We are the originator of the blkid, read data locally;
+            MultiBlkId local_blkid;
+
+            // convert remote_blkid serialized data to local blkid
+            local_blkid.deserialize(sisl::blob{remote_blkid->Data(), remote_blkid->size()}, true /* copy */);
+
+            RD_LOGD("Data Channel: FetchData received: dsn={} lsn={} my_blkid={}", req->dsn(), lsn,
+                    local_blkid.to_string());
+
+            // prepare the sgs data buffer to read into;
+            auto const total_size = local_blkid.blk_count() * get_blk_size();
+            sisl::sg_list sgs;
+            sgs.size = total_size;
+            sgs.iovs.emplace_back(
+                iovec{.iov_base = iomanager.iobuf_alloc(get_blk_size(), total_size), .iov_len = total_size});
+
+            // accumulate the sgs for later use (send back to the requester));
+            sgs_vec.push_back(sgs);
+            futs.emplace_back(async_read(local_blkid, sgs, total_size));
         }
-
-        // fetch data based on the remote_blkid
-        // We are the originator of the blkid, read data locally;
-        MultiBlkId local_blkid;
-
-        // convert remote_blkid serialized data to local blkid
-        local_blkid.deserialize(sisl::blob{remote_blkid->Data(), remote_blkid->size()}, true /* copy */);
-
-        RD_LOGD("Data Channel: FetchData received: dsn={} lsn={} my_blkid={}", req->dsn(), lsn,
-                local_blkid.to_string());
-
-        // prepare the sgs data buffer to read into;
-        auto const total_size = local_blkid.blk_count() * get_blk_size();
-        sisl::sg_list sgs;
-        sgs.size = total_size;
-        sgs.iovs.emplace_back(
-            iovec{.iov_base = iomanager.iobuf_alloc(get_blk_size(), total_size), .iov_len = total_size});
-
-        // accumulate the sgs for later use (send back to the requester));
-        sgs_vec.push_back(sgs);
-        futs.emplace_back(async_read(local_blkid, sgs, total_size));
     }
 
     folly::collectAllUnsafe(futs).thenValue(
@@ -1238,10 +1246,10 @@ void RaftReplDev::save_config(const nuraft::cluster_config& config) {
 
 void RaftReplDev::save_state(const nuraft::srv_state& state) {
     std::unique_lock lg{m_config_mtx};
-    (*m_raft_config_sb)["state"] = nlohmann::json{
-        {"term", state.get_term()}, {"voted_for", state.get_voted_for()},
-        {"election_timer_allowed", state.is_election_timer_allowed()}, {"catching_up", state.is_catching_up()}
-    };
+    (*m_raft_config_sb)["state"] = nlohmann::json{{"term", state.get_term()},
+                                                  {"voted_for", state.get_voted_for()},
+                                                  {"election_timer_allowed", state.is_election_timer_allowed()},
+                                                  {"catching_up", state.is_catching_up()}};
     m_raft_config_sb.write();
     RD_LOGI("Saved state {}", (*m_raft_config_sb)["state"].dump());
 }
@@ -1251,17 +1259,16 @@ nuraft::ptr< nuraft::srv_state > RaftReplDev::read_state() {
     auto& js = *m_raft_config_sb;
     auto state = nuraft::cs_new< nuraft::srv_state >();
     if (js["state"].empty()) {
-        js["state"] = nlohmann::json{
-            {"term", state->get_term()}, {"voted_for", state->get_voted_for()},
-            {"election_timer_allowed", state->is_election_timer_allowed()},
-            {"catching_up", state->is_catching_up()}
-        };
+        js["state"] = nlohmann::json{{"term", state->get_term()},
+                                     {"voted_for", state->get_voted_for()},
+                                     {"election_timer_allowed", state->is_election_timer_allowed()},
+                                     {"catching_up", state->is_catching_up()}};
     } else {
         try {
             state->set_term(uint64_cast(js["state"]["term"]));
             state->set_voted_for(static_cast< int >(js["state"]["voted_for"]));
-            state->allow_election_timer(static_cast<bool>(js["state"]["election_timer_allowed"]));
-            state->set_catching_up(static_cast<bool>(js["state"]["catching_up"]));
+            state->allow_election_timer(static_cast< bool >(js["state"]["election_timer_allowed"]));
+            state->set_catching_up(static_cast< bool >(js["state"]["catching_up"]));
         } catch (std::out_of_range const&) {
             LOGWARN("State data was not in the expected format [group_id={}]!", m_group_id)
         }

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -784,6 +784,12 @@ void RaftReplDev::attach_listener(shared< ReplDevListener > listener) {
         reinterpret_cast< no_space_left_handler_t >(m_listener->get_event_handler(event_type_t::RD_NO_SPACE_LEFT));
 }
 
+void RaftReplDev::detach_listener() {
+    ReplDev::detach_listener();
+    m_fetch_data_handler = nullptr;
+    m_no_space_left_handler = nullptr;
+}
+
 void RaftReplDev::on_fetch_data_received(intrusive< sisl::GenericRpcData >& rpc_data) {
     auto const& incoming_buf = rpc_data->request_blob();
     if (!incoming_buf.cbytes()) {

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -821,16 +821,10 @@ void RaftReplDev::on_fetch_data_received(intrusive< sisl::GenericRpcData >& rpc_
             RD_LOGD("Data Channel: FetchData received:  dsn={} lsn={}", req->dsn(), lsn);
         }
 
-        if (m_listener->need_to_handle_fetch_data()) {
-            auto const& header = req->user_header();
-            sisl::blob user_header = sisl::blob{header->Data(), header->size()};
-            RD_LOGD("Data Channel: FetchData handled by upper layer, my_blkid={}", local_blkid.to_string());
-            futs.emplace_back(std::move(m_listener->on_fetch_data(lsn, user_header, local_blkid, sgs)));
-        } else {
-            // add the default implementation to on_fetch_data will bring a lot of compiling issues
-            RD_LOGD("Data Channel: FetchData received: my_blkid={}", local_blkid.to_string());
-            futs.emplace_back(async_read(local_blkid, sgs, total_size));
-        }
+        auto const& header = req->user_header();
+        sisl::blob user_header = sisl::blob{header->Data(), header->size()};
+        RD_LOGD("Data Channel: FetchData handled, my_blkid={}", local_blkid.to_string());
+        futs.emplace_back(std::move(m_listener->on_fetch_data(lsn, user_header, local_blkid, sgs)));
     }
 
     folly::collectAllUnsafe(futs).thenValue(

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -244,6 +244,7 @@ public:
     }
 
     void attach_listener(shared< ReplDevListener > listener) override;
+    void detach_listener() override;
 
     //////////////// Accessor/shortcut methods ///////////////////////
     nuraft_mesg::repl_service_ctx* group_msg_service();

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -190,9 +190,6 @@ private:
     static std::atomic< uint64_t > s_next_group_ordinal;
     bool m_log_store_replay_done{false};
 
-    fetch_data_handler_t m_fetch_data_handler{nullptr};
-    no_space_left_handler_t m_no_space_left_handler{nullptr};
-
 public:
     friend class RaftStateMachine;
 
@@ -242,9 +239,6 @@ public:
     std::shared_ptr< snapshot_context > deserialize_snapshot_context(sisl::io_blob_safe& snp_ctx) override {
         return std::make_shared< nuraft_snapshot_context >(snp_ctx);
     }
-
-    void attach_listener(shared< ReplDevListener > listener) override;
-    void detach_listener() override;
 
     //////////////// Accessor/shortcut methods ///////////////////////
     nuraft_mesg::repl_service_ctx* group_msg_service();

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -165,7 +165,7 @@ void RaftReplService::start() {
         if (auto listener = rdev->get_listener(); listener) {
             if (auto log_replay_done_handler = listener->get_event_handler(event_type_t::RD_LOG_REPLAY_DONE);
                 log_replay_done_handler) {
-                reinterpret_cast< log_replay_done_handler_t >(log_replay_done_handler)();
+                reinterpret_cast< log_replay_done_handler_t >(log_replay_done_handler)(rdev->group_id());
             }
         }
 

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -156,21 +156,20 @@ void RaftReplService::start() {
     LOGINFO("Starting DataService");
     hs()->data_service().start();
 
-    // Step 6: Iterate all the repl dev and ask each one of the join the raft group.
-    for (auto it = m_rd_map.begin(); it != m_rd_map.end();) {
-        auto rdev = std::dynamic_pointer_cast< RaftReplDev >(it->second);
-        rdev->wait_for_logstore_ready();
+    // Step 6: Iterate all the repl devs and ask each one of them to join the raft group concurrently.
+    std::vector< std::future< bool > > join_group_futures;
+    for (const auto& [_, repl_dev] : m_rd_map)
+        join_group_futures.emplace_back(std::async(std::launch::async, [this, repl_dev]() {
+            auto rdev = std::dynamic_pointer_cast< RaftReplDev >(repl_dev);
+            rdev->wait_for_logstore_ready();
 
-        // upper layer can register a callback to be notified when log replay is done.
-        if (auto listener = rdev->get_listener(); listener) listener->on_log_replay_done(rdev->group_id());
+            // upper layer can register a callback to be notified when log replay is done.
+            if (auto listener = rdev->get_listener(); listener) listener->on_log_replay_done(rdev->group_id());
+            return rdev->join_group();
+        }));
 
-        if (!rdev->join_group()) {
-            HS_REL_ASSERT(false, "FAILED TO JOIN GROUP, PANIC HERE");
-            it = m_rd_map.erase(it);
-        } else {
-            ++it;
-        }
-    }
+    for (auto& future : join_group_futures)
+        if (!future.get()) HS_REL_ASSERT(false, "FAILED TO JOIN GROUP, PANIC HERE");
 
     // Step 7: Register to CPManager to ensure we can flush the superblk.
     hs()->cp_mgr().register_consumer(cp_consumer_t::REPLICATION_SVC, std::make_unique< RaftReplServiceCPHandler >());

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -162,12 +162,7 @@ void RaftReplService::start() {
         rdev->wait_for_logstore_ready();
 
         // upper layer can register a callback to be notified when log replay is done.
-        if (auto listener = rdev->get_listener(); listener) {
-            if (auto log_replay_done_handler = listener->get_event_handler(event_type_t::RD_LOG_REPLAY_DONE);
-                log_replay_done_handler) {
-                reinterpret_cast< log_replay_done_handler_t >(log_replay_done_handler)(rdev->group_id());
-            }
-        }
+        if (auto listener = rdev->get_listener(); listener) listener->on_log_replay_done(rdev->group_id());
 
         if (!rdev->join_group()) {
             HS_REL_ASSERT(false, "FAILED TO JOIN GROUP, PANIC HERE");


### PR DESCRIPTION
some events need to be handled by upper layer. This PR add three event: 

1 fetch_data: upper layer can decide which data to be returned

2 no_space_left: this error should be handled by upper layer if
  necessary

3 on_log_replay_done: after log replay is done and before joining raft
  group, upper layer might do something