### PR TITLE
Destroy upper resources after Raft server shutdown

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.6.25"
+    version = "6.6.26"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -1287,6 +1287,8 @@ std::shared_ptr< nuraft::state_machine > RaftReplDev::get_state_machine() { retu
 
 void RaftReplDev::permanent_destroy() {
     RD_LOGI("Permanent destroy for raft repl dev group_id={}", group_id_str());
+    // let the listener know at first, so that they can cleanup persistent structures before raft repl dev is destroyed
+    m_listener->on_destroy(group_id());
     m_raft_config_sb.destroy();
     m_data_journal->remove_store();
     logstore_service().destroy_log_dev(m_data_journal->logdev_id());
@@ -1313,10 +1315,6 @@ void RaftReplDev::leave() {
     // We update that this repl_dev in destroyed state, actual clean up of resources happen in reaper thread later
     m_stage.update([](auto* stage) { *stage = repl_dev_stage_t::DESTROYED; });
     m_destroyed_time = Clock::now();
-
-    // We let the listener know right away, so that they can cleanup persistent structures soonest. This will
-    // reduce the time window of leaked resources if any
-    m_listener->on_destroy(group_id());
 
     // Persist that destroy pending in superblk, so that in case of crash before cleanup of resources, it can be done
     // post restart.


### PR DESCRIPTION

    
    Previously, upper layer resources were destroyed when a member was removed from the cluster,
    while resources on the repl dev were garbage collected in the reaper thread.
    During this period, the commit thread could still be active, potentially leading to new commits accessing already destroyed resources.
    
    This change moves the destroy of upper layer resources into the garbage collection thread. The steps are now:
    1. Shutdown Raft server
    2. Destroy upper resources
    3. Destroy other resources on the repl dev
