### PR TITLE
Fixes on gc repl devs.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.7.1"
+    version = "6.7.2"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -1409,6 +1409,11 @@ nuraft::cb_func::ReturnCode RaftReplDev::raft_event(nuraft::cb_func::Type type, 
 }
 
 void RaftReplDev::flush_durable_commit_lsn() {
+    if (is_destroyed()) {
+        RD_LOGI("Raft repl dev is destroyed, ignore flush durable commmit lsn");
+        return;
+    }
+
     auto const lsn = m_commit_upto_lsn.load();
     std::unique_lock lg{m_sb_mtx};
     m_rd_sb->durable_commit_lsn = lsn;
@@ -1417,6 +1422,11 @@ void RaftReplDev::flush_durable_commit_lsn() {
 
 ///////////////////////////////////  Private metohds ////////////////////////////////////
 void RaftReplDev::cp_flush(CP* cp, cshared< ReplDevCPContext > ctx) {
+    if (is_destroyed()) {
+        RD_LOGI("Raft repl dev is destroyed, ignore cp flush");
+        return;
+    }
+
     auto const lsn = ctx->cp_lsn;
     auto const clsn = ctx->compacted_to_lsn;
     auto const dsn = ctx->last_applied_dsn;

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -559,6 +559,13 @@ void RaftReplService::gc_repl_reqs() {
 
 void RaftReplService::gc_repl_devs() {
     incr_pending_request_num();
+    // Skip gc when raft repl service is stopping to avoid concurrency issues between repl_dev's stop and destroy ops.
+    if (is_stopping()) {
+        LOGINFOMOD(replication, "ReplSvc is stopping, skipping GC");
+        decr_pending_request_num();
+        return;
+    }
+
     std::vector< group_id_t > groups_to_leave;
     {
         std::shared_lock lg(m_rd_map_mtx);


### PR DESCRIPTION
1. skip gc repl devs when raft repl service is stopping to avoid concurrency issues between repl_dev's stop and destroy ops.
2. skip flush ops on repl dev if repl dev is destroyed