### PR TITLE
issue: 669 update physical superblk's mgaic and product_name to disti…

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.7.4"
+    version = "6.7.5"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/device/hs_super_blk.h
+++ b/src/lib/device/hs_super_blk.h
@@ -75,7 +75,7 @@ struct disk_attr {
 };
 
 struct first_block_header {
-    static constexpr const char* PRODUCT_NAME{"OmStore"};
+    static constexpr const char* PRODUCT_NAME{"HomeStore4x"};
     static constexpr size_t s_product_name_size{64};
     static constexpr uint32_t CURRENT_SUPERBLOCK_VERSION{4};
 
@@ -128,7 +128,7 @@ struct first_block {
     static constexpr uint32_t s_atomic_fb_size{512};       // increase 512 to actual size if in the future first_block
                                                            // can be larger;
     static constexpr uint32_t s_io_fb_size{4096};          // This is the size we do IO on, with padding
-    static constexpr uint32_t HOMESTORE_MAGIC{0xCEEDDEEB}; // Magic written as first bytes on each device
+    static constexpr uint32_t HOMESTORE_MAGIC{0xABBECDCD}; // Magic written as first bytes on each device
 
 public:
     uint64_t magic{0};                // Header magic expected to be at the top of block


### PR DESCRIPTION
…nguish homestore 4.x with 1.3 which is massive written in prod

Issue is originally discussed here: https://ebay-eng.slack.com/archives/C042B751V7X/p1742494377908479

I noticed HomeStore 4.x persists the same Product_Name and Magic to first super block on physical device as 1.x NuBlox HomeStore is written.
Since there is a discussion that Tess will rely on SDS team to zero disks by ourselves, we don't want to have NuObject Pods to accidentally boot up with 1.x HomeStore previously written disks and being treated as a recovery boot by mistake, because we rely on physical device's first super block's magic and product name to decide whether it is a "valid" device previously written or not.
Although the placement of 1st block differs from 4.x and 1.x, it would still be better to make the difference for safety purpose.
In short, changes to be made is two things, and this change should have no impact to existing feature or testing.
```
static constexpr uint32_t HOMESTORE_MAGIC{0xCEEDDEEB}; ==> "0xABBECDCD"
static constexpr const char* PRODUCT_NAME{"OmStore"};  ==> "HomeStore4x" 
```