### PR TITLE
 Fix baseline resync corner cases.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.7.6"
+    version = "6.7.7"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/log_store/home_raft_log_store.h
+++ b/src/lib/replication/log_store/home_raft_log_store.h
@@ -217,7 +217,7 @@ public:
 
     /**
      * Purge all logs in the log store
-     * It is a dangerous operation and is only used in baseline resync now (purge all logs and restore by snapshot).
+     * It is a dangerous operation and not be used currently.
      */
     void purge_all_logs();
 


### PR DESCRIPTION
 1. Leader side: Deny snapshot read if there are uncommitted logs in the snapshot. This prevents the following scenario:
 If a crash occurs during snapshot creation, the snapshot might be persisted while the rd sb is not. This means the durable_commit_lsn is less than the snapshot's log_idx. Upon restart, the changes in uncommitted logs may or may not be included in the snapshot data sent by the leader, depending on the race condition between commit and snapshot read, leading to data inconsistency.
 2. Follower side: Skip replay and commit when BR is in progress and purge logs is no longer supported.
 Purging logs can cause issues such as the commit thread being unable to access logs if they are purged. This change removes the purge logic and adds a new flag to skip replay/commit to avoid log ops accessing unavailable resources after the PG is destroyed by BR.
