### PR TITLE
Logging improvement for repl dev

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.7.8"
+    version = "6.8.0"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -54,10 +54,10 @@ static constexpr uint64_t HOMESTORE_RESYNC_DATA_MAGIC = 0xa65dbd27c213f327;
 static constexpr uint32_t HOMESTORE_RESYNC_DATA_PROTOCOL_VERSION_V1 = 0x01;
 
 struct repl_key {
-    int32_t server_id{0}; // Server Id which this req is originated from
-    uint64_t term;        // RAFT term number
-    uint64_t dsn{0};      // Data sequence number to tie the data with the raft journal entry
-    uint64_t traceID{0};  // tracing ID provided by application that connects logs.
+    int32_t server_id{0};  // Server Id which this req is originated from
+    uint64_t term;         // RAFT term number
+    uint64_t dsn{0};       // Data sequence number to tie the data with the raft journal entry
+    trace_id_t traceID{0}; // tracing ID provided by application that connects logs.
 
     struct Hasher {
         size_t operator()(repl_key const& rk) const {
@@ -68,8 +68,7 @@ struct repl_key {
 
     bool operator==(repl_key const& other) const = default;
     std::string to_string() const {
-        return fmt::format("server={}, term={}, dsn={}, hash={}, traceID={}", server_id, term, dsn, Hasher()(*this),
-                           traceID);
+        return fmt::format("server={}, term={}, dsn={}, hash={}", server_id, term, dsn, Hasher()(*this));
     }
 };
 
@@ -123,7 +122,7 @@ public:
     repl_key const& rkey() const { return m_rkey; }
     uint64_t dsn() const { return m_rkey.dsn; }
     uint64_t term() const { return m_rkey.term; }
-    uint64_t traceID() const { return m_rkey.traceID; }
+    trace_id_t traceID() const { return m_rkey.traceID; }
     int64_t lsn() const { return m_lsn; }
     bool is_proposer() const { return m_is_proposer; }
     journal_type_t op_code() const { return m_op_code; }

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -57,6 +57,7 @@ struct repl_key {
     int32_t server_id{0}; // Server Id which this req is originated from
     uint64_t term;        // RAFT term number
     uint64_t dsn{0};      // Data sequence number to tie the data with the raft journal entry
+    uint64_t traceID{0};  // tracing ID provided by application that connects logs.
 
     struct Hasher {
         size_t operator()(repl_key const& rk) const {
@@ -67,7 +68,8 @@ struct repl_key {
 
     bool operator==(repl_key const& other) const = default;
     std::string to_string() const {
-        return fmt::format("server={}, term={}, dsn={}, hash={}", server_id, term, dsn, Hasher()(*this));
+        return fmt::format("server={}, term={}, dsn={}, hash={}, traceID={}", server_id, term, dsn, Hasher()(*this),
+                           traceID);
     }
 };
 
@@ -121,6 +123,7 @@ public:
     repl_key const& rkey() const { return m_rkey; }
     uint64_t dsn() const { return m_rkey.dsn; }
     uint64_t term() const { return m_rkey.term; }
+    uint64_t traceID() const { return m_rkey.traceID; }
     int64_t lsn() const { return m_lsn; }
     bool is_proposer() const { return m_is_proposer; }
     journal_type_t op_code() const { return m_op_code; }

--- a/src/lib/replication/log_store/repl_log_store.cpp
+++ b/src/lib/replication/log_store/repl_log_store.cpp
@@ -107,6 +107,7 @@ void ReplLogStore::end_of_append_batch(ulong start_lsn, ulong count) {
 }
 
 std::string ReplLogStore::rdev_name() const { return m_rd.rdev_name(); }
+std::string ReplLogStore::identify_str() const { return m_rd.identify_str(); }
 
 bool ReplLogStore::compact(ulong compact_upto_lsn) {
     RD_LOG(DEBUG, "Raft Channel: compact_to_lsn={}", compact_upto_lsn);

--- a/src/lib/replication/log_store/repl_log_store.h
+++ b/src/lib/replication/log_store/repl_log_store.h
@@ -30,6 +30,7 @@ public:
 
 private:
     std::string rdev_name() const;
+    std::string identify_str() const;
 };
 
 } // namespace homestore

--- a/src/lib/replication/push_data_rpc.fbs
+++ b/src/lib/replication/push_data_rpc.fbs
@@ -2,6 +2,7 @@ native_include "boost/uuid/uuid.hpp";
 namespace homestore;
 
 table PushDataRequest {
+    traceID: uint64;             // traceID for the REQ
     issuer_replica_id : int32;   // Replica id of the issuer
     raft_term : uint64;          // Raft term number
     dsn : uint64;                // Data Sequence number

--- a/src/lib/replication/repl_dev/common.cpp
+++ b/src/lib/replication/repl_dev/common.cpp
@@ -31,9 +31,7 @@ ReplServiceError repl_req_ctx::init(repl_key rkey, journal_type_t op_code, bool 
     std::unique_lock< std::mutex > lg(m_state_mtx);
     if (has_linked_data() && !has_state(repl_req_state_t::BLK_ALLOCATED)) {
         auto alloc_status = alloc_local_blks(listener, data_size);
-        if (alloc_status != ReplServiceError::OK) {
-            LOGERROR("Allocate blk for rreq failed error={}", alloc_status);
-        }
+        if (alloc_status != ReplServiceError::OK) { LOGERROR("Allocate blk for rreq failed error={}", alloc_status); }
         return alloc_status;
     }
     return ReplServiceError::OK;

--- a/src/lib/replication/repl_dev/common.cpp
+++ b/src/lib/replication/repl_dev/common.cpp
@@ -54,6 +54,7 @@ void repl_req_ctx::create_journal_entry(bool is_raft_buf, int32_t server_id) {
     }
 
     m_journal_entry->code = m_op_code;
+    m_journal_entry->traceID = m_rkey.traceID;
     m_journal_entry->server_id = server_id;
     m_journal_entry->dsn = m_rkey.dsn;
     m_journal_entry->user_header_size = m_header.size();

--- a/src/lib/replication/repl_dev/common.h
+++ b/src/lib/replication/repl_dev/common.h
@@ -35,9 +35,9 @@ struct repl_journal_entry {
     uint16_t minor_version{JOURNAL_ENTRY_MINOR};
 
     journal_type_t code;
-    uint64_t traceID;  // traceID provided by application, mostly for consolidate logs.
-    int32_t server_id; // Server id from where journal entry is originated
-    uint64_t dsn;      // Data seq number
+    trace_id_t traceID; // traceID provided by application, mostly for consolidate logs.
+    int32_t server_id;  // Server id from where journal entry is originated
+    uint64_t dsn;       // Data seq number
     uint32_t user_header_size;
     uint32_t key_size;
     uint32_t value_size;

--- a/src/lib/replication/repl_dev/common.h
+++ b/src/lib/replication/repl_dev/common.h
@@ -35,6 +35,7 @@ struct repl_journal_entry {
     uint16_t minor_version{JOURNAL_ENTRY_MINOR};
 
     journal_type_t code;
+    uint64_t traceID;  // traceID provided by application, mostly for consolidate logs.
     int32_t server_id; // Server id from where journal entry is originated
     uint64_t dsn;      // Data seq number
     uint32_t user_header_size;

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -156,6 +156,7 @@ private:
     nuraft_mesg::Manager& m_msg_mgr;
     group_id_t m_group_id;     // Replication Group id
     std::string m_rdev_name;   // Short name for the group for easy debugging
+    std::string m_identify_str; // combination of rdev_name:group_id
     replica_id_t m_my_repl_id; // This replica's uuid
     int32_t m_raft_server_id;  // Server ID used by raft (unique within raft group)
     shared< ReplLogStore > m_data_journal;
@@ -205,10 +206,10 @@ public:
 
     //////////////// All ReplDev overrides/implementation ///////////////////////
     void async_alloc_write(sisl::blob const& header, sisl::blob const& key, sisl::sg_list const& value,
-                           repl_req_ptr_t ctx) override;
+                           repl_req_ptr_t ctx, trace_id_t tid = 0) override;
     folly::Future< std::error_code > async_read(MultiBlkId const& blkid, sisl::sg_list& sgs, uint32_t size,
-                                                bool part_of_batch = false) override;
-    folly::Future< std::error_code > async_free_blks(int64_t lsn, MultiBlkId const& blkid) override;
+                                                bool part_of_batch = false, trace_id_t tid = 0) override;
+    folly::Future< std::error_code > async_free_blks(int64_t lsn, MultiBlkId const& blkid, trace_id_t tid = 0) override;
     AsyncReplResult<> become_leader() override;
     bool is_leader() const override;
     replica_id_t get_leader_id() const override;
@@ -216,7 +217,8 @@ public:
     std::set< replica_id_t > get_active_peers() const;
     group_id_t group_id() const override { return m_group_id; }
     std::string group_id_str() const { return boost::uuids::to_string(m_group_id); }
-    std::string rdev_name() const { return m_rdev_name; }
+    std::string rdev_name() const { return m_rdev_name; };
+    std::string identify_str() const { return m_identify_str; };
     std::string my_replica_id_str() const { return boost::uuids::to_string(m_my_repl_id); }
     uint32_t get_blk_size() const override;
     repl_lsn_t get_last_commit_lsn() const override { return m_commit_upto_lsn.load(); }

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -231,7 +231,9 @@ public:
         auto committed_lsn = m_commit_upto_lsn.load();
         auto gate = m_traffic_ready_lsn.load();
         bool ready = committed_lsn >= gate;
-        if (!ready) { RD_LOGD("Not yet ready for traffic, committed to {} but gate is {}", committed_lsn, gate); }
+        if (!ready) {
+            RD_LOGD(NO_TRACE_ID, "Not yet ready for traffic, committed to {} but gate is {}", committed_lsn, gate);
+        }
         return ready;
     }
     // purge all resources (e.g., logs in logstore) is a very dangerous operation, it is not supported yet.
@@ -270,12 +272,12 @@ public:
             // was a follower, m_traffic_ready_lsn should be zero on follower.
             RD_REL_ASSERT(existing_gate == 0, "existing gate should be zero");
         }
-        RD_LOGD("become_leader_cb: setting traffic_ready_lsn from {} to {}", existing_gate, new_gate);
+        RD_LOGD(NO_TRACE_ID, "become_leader_cb: setting traffic_ready_lsn from {} to {}", existing_gate, new_gate);
     };
     void become_follower_cb() {
         // m_traffic_ready_lsn should be zero on follower.
         m_traffic_ready_lsn.store(0);
-        RD_LOGD("become_follower_cb setting  traffic_ready_lsn to 0");
+        RD_LOGD(NO_TRACE_ID, "become_follower_cb setting  traffic_ready_lsn to 0");
     }
 
     /// @brief This method is called when the data journal is compacted
@@ -379,7 +381,7 @@ private:
     void set_log_store_last_durable_lsn(store_lsn_t lsn);
     void commit_blk(repl_req_ptr_t rreq);
     void replace_member(repl_req_ptr_t rreq);
-    void reset_quorum_size(uint32_t commit_quorum);
+    void reset_quorum_size(uint32_t commit_quorum, uint64_t trace_id);
     void create_snp_resync_data(raft_buf_ptr_t& data_out);
     bool save_snp_resync_data(nuraft::buffer& data, nuraft::snapshot& s);
 };

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -121,7 +121,7 @@ repl_req_ptr_t RaftStateMachine::localize_journal_entry_prepare(nuraft::log_entr
 
 out:
     if (rreq == nullptr) {
-        RD_LOGE(rreq->traceID(),
+        RD_LOGE(rkey.traceID,
                 "Failed to localize journal entry rkey={} jentry=[{}], we return error and let Raft resend this req",
                 rkey.to_string(), jentry->to_string());
     }

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -74,7 +74,8 @@ repl_req_ptr_t RaftStateMachine::localize_journal_entry_prepare(nuraft::log_entr
                           jentry->value_size};
     };
 
-    repl_key const rkey{.server_id = jentry->server_id, .term = lentry.get_term(), .dsn = jentry->dsn};
+    repl_key const rkey{
+        .server_id = jentry->server_id, .term = lentry.get_term(), .dsn = jentry->dsn, .traceID = jentry->traceID};
 
     // Create a new rreq (or) Pull rreq from the map given the repl_key, header and key. Any new rreq will
     // allocate the blks (in case of large data). We will use the new blkid and transform the current journal entry's
@@ -150,7 +151,8 @@ repl_req_ptr_t RaftStateMachine::localize_journal_entry_finish(nuraft::log_entry
     RELEASE_ASSERT_EQ(jentry->major_version, repl_journal_entry::JOURNAL_ENTRY_MAJOR,
                       "Mismatched version of journal entry received from RAFT peer");
 
-    repl_key rkey{.server_id = jentry->server_id, .term = lentry.get_term(), .dsn = jentry->dsn};
+    repl_key rkey{
+        .server_id = jentry->server_id, .term = lentry.get_term(), .dsn = jentry->dsn, .traceID = jentry->traceID};
 
     auto rreq = m_rd.repl_key_to_req(rkey);
     if ((rreq == nullptr) || (rreq->is_localize_pending())) {

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -429,6 +429,6 @@ nuraft::ptr< nuraft::snapshot > RaftStateMachine::last_snapshot() {
 
 void RaftStateMachine::free_user_snp_ctx(void*& user_snp_ctx) { m_rd.m_listener->free_user_snp_ctx(user_snp_ctx); }
 
-std::string RaftStateMachine::rdev_name() const { return m_rd.rdev_name(); }
+std::string RaftStateMachine::identify_str() const { return m_rd.identify_str(); }
 
 } // namespace homestore

--- a/src/lib/replication/repl_dev/raft_state_machine.h
+++ b/src/lib/replication/repl_dev/raft_state_machine.h
@@ -24,7 +24,9 @@ namespace homestore {
 class ReplicaSetImpl;
 class StateMachineStore;
 
-#define RD_LOG(level, msg, ...) LOG##level##MOD(replication, "[{}] " msg, identify_str(), ##__VA_ARGS__)
+#define NO_TRACE_ID "n/a"
+#define RD_LOG(level, traceID, msg, ...)                                                                               \
+    LOG##level##MOD(replication, "[traceID={}] [{}] " msg, traceID, identify_str(), ##__VA_ARGS__)
 
 #define RD_ASSERT_CMP(assert_type, val1, cmp, val2, ...)                                                               \
     {                                                                                                                  \
@@ -69,12 +71,12 @@ class StateMachineStore;
 #define RD_REL_ASSERT_GT(val1, val2, ...) RD_ASSERT_CMP(RELEASE, val1, >, val2, ##__VA_ARGS__)
 #define RD_REL_ASSERT_GE(val1, val2, ...) RD_ASSERT_CMP(RELEASE, val1, >=, val2, ##__VA_ARGS__)
 
-#define RD_LOGT(...) RD_LOG(TRACE, ##__VA_ARGS__)
-#define RD_LOGD(...) RD_LOG(DEBUG, ##__VA_ARGS__)
-#define RD_LOGI(...) RD_LOG(INFO, ##__VA_ARGS__)
-#define RD_LOGW(...) RD_LOG(WARN, ##__VA_ARGS__)
-#define RD_LOGE(...) RD_LOG(ERROR, ##__VA_ARGS__)
-#define RD_LOGC(...) RD_LOG(CRITICAL, ##__VA_ARGS__)
+#define RD_LOGT(traceID, ...) RD_LOG(TRACE, traceID, ##__VA_ARGS__)
+#define RD_LOGD(traceID, ...) RD_LOG(DEBUG, traceID, ##__VA_ARGS__)
+#define RD_LOGI(traceID, ...) RD_LOG(INFO, traceID, ##__VA_ARGS__)
+#define RD_LOGW(traceID, ...) RD_LOG(WARN, traceID, ##__VA_ARGS__)
+#define RD_LOGE(traceID, ...) RD_LOG(ERROR, traceID, ##__VA_ARGS__)
+#define RD_LOGC(traceID, ...) RD_LOG(CRITICAL, traceID, ##__VA_ARGS__)
 
 // For the logic snapshot obj_id, we use the highest bit to indicate the type of the snapshot message.
 // 0 is for HS, 1 is for Application.

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -28,7 +28,7 @@ SoloReplDev::SoloReplDev(superblk< repl_dev_superblk >&& rd_sb, bool load_existi
 }
 
 void SoloReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& key, sisl::sg_list const& value,
-                                    repl_req_ptr_t rreq) {
+                                    repl_req_ptr_t rreq, trace_id_t tid) {
     if (!rreq) { auto rreq = repl_req_ptr_t(new repl_req_ctx{}); }
     auto status = rreq->init(repl_key{.server_id = 0, .term = 1, .dsn = 1},
                              value.size ? journal_type_t::HS_DATA_LINKED : journal_type_t::HS_DATA_INLINED, true,
@@ -94,11 +94,11 @@ void SoloReplDev::on_log_found(logstore_seq_num_t lsn, log_buffer buf, void* ctx
 }
 
 folly::Future< std::error_code > SoloReplDev::async_read(MultiBlkId const& bid, sisl::sg_list& sgs, uint32_t size,
-                                                         bool part_of_batch) {
+                                                         bool part_of_batch, trace_id_t tid) {
     return data_service().async_read(bid, sgs, size, part_of_batch);
 }
 
-folly::Future< std::error_code > SoloReplDev::async_free_blks(int64_t, MultiBlkId const& bid) {
+folly::Future< std::error_code > SoloReplDev::async_free_blks(int64_t, MultiBlkId const& bid, trace_id_t tid) {
     return data_service().async_free_blk(bid);
 }
 
@@ -111,7 +111,6 @@ void SoloReplDev::cp_flush(CP*) {
     m_rd_sb.write();
 }
 
-void SoloReplDev::cp_cleanup(CP*) { /* m_data_journal->truncate(m_rd_sb->checkpoint_lsn); */
-}
+void SoloReplDev::cp_cleanup(CP*) { /* m_data_journal->truncate(m_rd_sb->checkpoint_lsn); */ }
 
 } // namespace homestore

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -30,7 +30,7 @@ SoloReplDev::SoloReplDev(superblk< repl_dev_superblk >&& rd_sb, bool load_existi
 void SoloReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& key, sisl::sg_list const& value,
                                     repl_req_ptr_t rreq, trace_id_t tid) {
     if (!rreq) { auto rreq = repl_req_ptr_t(new repl_req_ctx{}); }
-    auto status = rreq->init(repl_key{.server_id = 0, .term = 1, .dsn = 1},
+    auto status = rreq->init(repl_key{.server_id = 0, .term = 1, .dsn = 1, .traceID = tid},
                              value.size ? journal_type_t::HS_DATA_LINKED : journal_type_t::HS_DATA_INLINED, true,
                              header, key, value.size, m_listener);
     HS_REL_ASSERT_EQ(status, ReplServiceError::OK, "Error in allocating local blks");

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -42,12 +42,12 @@ public:
     // TODO: implement graceful shutdown for solo repl dev
 
     void async_alloc_write(sisl::blob const& header, sisl::blob const& key, sisl::sg_list const& value,
-                           repl_req_ptr_t ctx) override;
+                           repl_req_ptr_t ctx, trace_id_t tid = 0) override;
 
     folly::Future< std::error_code > async_read(MultiBlkId const& bid, sisl::sg_list& sgs, uint32_t size,
-                                                bool part_of_batch = false) override;
+                                                bool part_of_batch = false, trace_id_t tid = 0) override;
 
-    folly::Future< std::error_code > async_free_blks(int64_t lsn, MultiBlkId const& blkid) override;
+    folly::Future< std::error_code > async_free_blks(int64_t lsn, MultiBlkId const& blkid, trace_id_t tid = 0) override;
 
     AsyncReplResult<> become_leader() override { return make_async_error(ReplServiceError::OK); }
     bool is_leader() const override { return true; }

--- a/src/tests/test_common/raft_repl_test_base.hpp
+++ b/src/tests/test_common/raft_repl_test_base.hpp
@@ -357,7 +357,7 @@ public:
                 test_common::HSTestHelper::create_sgs(data_size, max_size_per_iov, req->jheader.data_pattern);
         }
 
-        repl_dev()->async_alloc_write(req->header_blob(), req->key_blob(), req->write_sgs, req);
+        repl_dev()->async_alloc_write(req->header_blob(), req->key_blob(), req->write_sgs, req, s_uniq_num);
     }
 
     void validate_db_data() {


### PR DESCRIPTION
The general idea is application (user of HS) can optionally pass in a trace_id, now it is a uint64.  The trace_id will be included in all loggings relate with this rreq , and the trace_id will be pushed to follower through both raft channel and data channel.

With this , when application see an issue , with the trace_id, we can use a single search pattern to search across all replicas and get all related log for that request.


Note this is a breaking change as we change raft journal format.