### PR TITLE
Fix solo repl dev log flush and graceful shutdown.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.9.2"
+    version = "6.9.3"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/logstore/log_store_internal.hpp
+++ b/src/include/homestore/logstore/log_store_internal.hpp
@@ -52,6 +52,12 @@ typedef std::function< void(std::shared_ptr< HomeLogStore >, logstore_seq_num_t)
 
 typedef int64_t logid_t;
 
+VENUM(flush_mode_t, uint32_t, // Various flush modes (can be or'ed together)
+      INLINE = 1 << 0,        // Allow flush inline with the append
+      TIMER = 1 << 1,         // Allow timer based automatic flush
+      EXPLICIT = 1 << 2,      // Allow explcitly user calling flush
+);
+
 struct logdev_key {
     logid_t idx;
     off_t dev_offset;
@@ -172,4 +178,5 @@ struct logstore_superblk {
     logstore_seq_num_t m_first_seq_num{0};
 };
 #pragma pack()
+
 } // namespace homestore

--- a/src/include/homestore/logstore_service.hpp
+++ b/src/include/homestore/logstore_service.hpp
@@ -94,7 +94,7 @@ public:
      * chunks. Logdev can start with zero chunks and dynamically add chunks based on write request.
      * @return Newly created log dev id.
      */
-    logdev_id_t create_new_logdev();
+    logdev_id_t create_new_logdev(flush_mode_t flush_mode);
 
     /**
      * @brief Open a log dev.
@@ -102,7 +102,7 @@ public:
      * @param logdev_id: Logdev ID
      * @return Newly created log dev id.
      */
-    void open_logdev(logdev_id_t logdev_id);
+    void open_logdev(logdev_id_t logdev_id, flush_mode_t flush_mode);
 
     /**
      * @brief Destroy a log dev.
@@ -178,7 +178,7 @@ public:
     void delete_unopened_logdevs();
 
 private:
-    std::shared_ptr< LogDev > create_new_logdev_internal(logdev_id_t logdev_id);
+    std::shared_ptr< LogDev > create_new_logdev_internal(logdev_id_t logdev_id, flush_mode_t flush_mode);
     void on_meta_blk_found(const sisl::byte_view& buf, void* meta_cookie);
     logdev_id_t get_next_logdev_id();
     void logdev_super_blk_found(const sisl::byte_view& buf, void* meta_cookie);

--- a/src/lib/logstore/log_dev.hpp
+++ b/src/lib/logstore/log_dev.hpp
@@ -404,6 +404,8 @@ struct logdev_superblk {
     uint32_t num_stores{0};
     uint64_t start_dev_offset{0};
     logid_t key_idx{0};
+    flush_mode_t flush_mode;
+
     // The meta data starts immediately after the super block
     // Equivalent of:
     // logstore_superblk meta[0];
@@ -481,7 +483,7 @@ public:
     LogDevMetadata& operator=(LogDevMetadata&&) noexcept = delete;
     ~LogDevMetadata() = default;
 
-    logdev_superblk* create(logdev_id_t id);
+    logdev_superblk* create(logdev_id_t id, flush_mode_t);
     void reset();
     std::vector< std::pair< logstore_id_t, logstore_superblk > > load();
     void persist();
@@ -571,12 +573,6 @@ struct logstore_info {
 
 static std::string const logdev_sb_meta_name{"Logdev_sb"};
 static std::string const logdev_rollback_sb_meta_name{"Logdev_rollback_sb"};
-
-VENUM(flush_mode_t, uint32_t, // Various flush modes (can be or'ed together)
-      INLINE = 1 << 0,        // Allow flush inline with the append
-      TIMER = 1 << 1,         // Allow timer based automatic flush
-      EXPLICIT = 1 << 2,      // Allow explcitly user calling flush
-);
 
 class LogDev : public std::enable_shared_from_this< LogDev > {
     friend class HomeLogStore;

--- a/src/lib/logstore/log_store_service.cpp
+++ b/src/lib/logstore/log_store_service.cpp
@@ -142,12 +142,12 @@ logdev_id_t LogStoreService::get_next_logdev_id() {
     return id;
 }
 
-logdev_id_t LogStoreService::create_new_logdev() {
+logdev_id_t LogStoreService::create_new_logdev(flush_mode_t flush_mode) {
     if (is_stopping()) return 0;
     incr_pending_request_num();
     folly::SharedMutexWritePriority::WriteHolder holder(m_logdev_map_mtx);
     logdev_id_t logdev_id = get_next_logdev_id();
-    auto logdev = create_new_logdev_internal(logdev_id);
+    auto logdev = create_new_logdev_internal(logdev_id, flush_mode);
     logdev->start(true /* format */, m_logdev_vdev);
     COUNTER_INCREMENT(m_metrics, logdevs_count, 1);
     HS_LOG(INFO, logstore, "Created log_dev={}", logdev_id);
@@ -189,19 +189,19 @@ void LogStoreService::delete_unopened_logdevs() {
     m_unopened_logdev.clear();
 }
 
-std::shared_ptr< LogDev > LogStoreService::create_new_logdev_internal(logdev_id_t logdev_id) {
-    auto logdev = std::make_shared< LogDev >(logdev_id);
+std::shared_ptr< LogDev > LogStoreService::create_new_logdev_internal(logdev_id_t logdev_id, flush_mode_t flush_mode) {
+    auto logdev = std::make_shared< LogDev >(logdev_id, flush_mode);
     const auto it = m_id_logdev_map.find(logdev_id);
     HS_REL_ASSERT((it == m_id_logdev_map.end()), "logdev id {} already exists", logdev_id);
     m_id_logdev_map.insert(std::make_pair<>(logdev_id, logdev));
     return logdev;
 }
 
-void LogStoreService::open_logdev(logdev_id_t logdev_id) {
+void LogStoreService::open_logdev(logdev_id_t logdev_id, flush_mode_t flush_mode) {
     folly::SharedMutexWritePriority::WriteHolder holder(m_logdev_map_mtx);
     const auto it = m_id_logdev_map.find(logdev_id);
     if (it == m_id_logdev_map.end()) {
-        auto logdev = std::make_shared< LogDev >(logdev_id);
+        auto logdev = std::make_shared< LogDev >(logdev_id, flush_mode);
         m_id_logdev_map.emplace(logdev_id, logdev);
         LOGDEBUGMOD(logstore, "log_dev={} does not exist, created!", logdev_id);
     }
@@ -238,13 +238,14 @@ void LogStoreService::logdev_super_blk_found(const sisl::byte_view& buf, void* m
         folly::SharedMutexWritePriority::WriteHolder holder(m_logdev_map_mtx);
         std::shared_ptr< LogDev > logdev;
         auto id = sb->logdev_id;
+        auto flush_mode = sb->flush_mode;
         const auto it = m_id_logdev_map.find(id);
         // We could update the logdev map either with logdev or rollback superblks found callbacks.
         if (it != m_id_logdev_map.end()) {
             logdev = it->second;
             HS_LOG(DEBUG, logstore, "Log dev superblk found log_dev={}", id);
         } else {
-            logdev = std::make_shared< LogDev >(id);
+            logdev = std::make_shared< LogDev >(id, flush_mode);
             m_id_logdev_map.emplace(id, logdev);
             // when recover logdev meta blk, we get all the logdevs from the superblk. we put them in m_unopened_logdev
             // too. after logdev meta blks are all recovered, when a client opens a logdev, we remove it from

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -58,7 +58,7 @@ public:
     bool is_ready_for_traffic() const override { return true; }
     void purge() override {}
 
-    std::shared_ptr<snapshot_context> deserialize_snapshot_context(sisl::io_blob_safe &snp_ctx) override {
+    std::shared_ptr< snapshot_context > deserialize_snapshot_context(sisl::io_blob_safe& snp_ctx) override {
         return nullptr;
     }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -131,7 +131,7 @@ if (${io_tests})
         add_test(NAME DataService-Epoll COMMAND test_data_service)
         add_test(NAME RaftReplDev-Epoll COMMAND test_raft_repl_dev)
         # add_test(NAME RaftReplDevDynamic-Epoll COMMAND test_raft_repl_dev_dynamic)
-        # add_test(NAME SoloReplDev-Epoll COMMAND test_solo_repl_dev)
+        add_test(NAME SoloReplDev-Epoll COMMAND test_solo_repl_dev)
     endif()
 
     can_build_spdk_io_tests(spdk_tests)

--- a/src/tests/log_store_benchmark.cpp
+++ b/src/tests/log_store_benchmark.cpp
@@ -55,7 +55,7 @@ class BenchLogStore {
 public:
     friend class SampleDB;
     BenchLogStore() {
-        m_logdev_id = logstore_service().create_new_logdev();
+        m_logdev_id = logstore_service().create_new_logdev(flush_mode_t::EXPLICIT);
         m_log_store = logstore_service().create_new_log_store(m_logdev_id, true /* append_mode */);
         m_log_store->register_log_found_cb(bind_this(BenchLogStore::on_log_found, 3));
         m_nth_entry.store(0);

--- a/src/tests/test_log_store.cpp
+++ b/src/tests/test_log_store.cpp
@@ -455,7 +455,7 @@ public:
 
                 for (uint32_t i{0}; i < n_log_stores; ++i) {
                     SampleLogStoreClient* client = m_log_store_clients[i].get();
-                    logstore_service().open_logdev(client->m_logdev_id);
+                    logstore_service().open_logdev(client->m_logdev_id, flush_mode_t::EXPLICIT);
                     logstore_service()
                         .open_log_store(client->m_logdev_id, client->m_store_id, false /* append_mode */)
                         .thenValue([i, this, client](auto log_store) { client->set_log_store(log_store); });
@@ -479,7 +479,7 @@ public:
 
             std::vector< logdev_id_t > logdev_id_vec;
             for (uint32_t i{0}; i < n_log_devs; ++i) {
-                logdev_id_vec.push_back(logstore_service().create_new_logdev());
+                logdev_id_vec.push_back(logstore_service().create_new_logdev(flush_mode_t::EXPLICIT));
             }
 
             for (uint32_t i{0}; i < n_log_stores; ++i) {
@@ -1225,7 +1225,7 @@ TEST_F(LogStoreTest, WriteSyncThenRead) {
 
     for (uint32_t iteration{0}; iteration < iterations; ++iteration) {
         LOGINFO("Iteration {}", iteration);
-        auto logdev_id = logstore_service().create_new_logdev();
+        auto logdev_id = logstore_service().create_new_logdev(flush_mode_t::EXPLICIT);
         auto tmp_log_store = logstore_service().create_new_log_store(logdev_id, false);
         const auto store_id = tmp_log_store->get_store_id();
         LOGINFO("Created new log store -> id {}", store_id);

--- a/src/tests/test_log_store_long_run.cpp
+++ b/src/tests/test_log_store_long_run.cpp
@@ -294,7 +294,7 @@ public:
                 HS_SETTINGS_FACTORY().save();
                 for (uint32_t i{0}; i < n_log_stores; ++i) {
                     SampleLogStoreClient* client = m_log_store_clients[i].get();
-                    logstore_service().open_logdev(client->m_logdev_id);
+                    logstore_service().open_logdev(client->m_logdev_id, flush_mode_t::EXPLICIT);
                     logstore_service()
                         .open_log_store(client->m_logdev_id, client->m_store_id, false /* append_mode */)
                         .thenValue([i, this, client](auto log_store) { client->set_log_store(log_store); });
@@ -318,7 +318,7 @@ public:
 
             std::vector< logdev_id_t > logdev_id_vec;
             for (uint32_t i{0}; i < n_log_devs; ++i)
-                logdev_id_vec.push_back(logstore_service().create_new_logdev());
+                logdev_id_vec.push_back(logstore_service().create_new_logdev(flush_mode_t::EXPLICIT));
 
             for (uint32_t i{0}; i < n_log_stores; ++i)
                 m_log_store_clients.push_back(std::make_unique< SampleLogStoreClient >(
@@ -466,7 +466,7 @@ public:
         validate_num_stores();
 
         // Create a new logstore.
-        auto logdev_id = logstore_service().create_new_logdev();
+        auto logdev_id = logstore_service().create_new_logdev(flush_mode_t::EXPLICIT);
         m_log_store_clients.push_back(std::make_unique< SampleLogStoreClient >(
             logdev_id, bind_this(LogStoreLongRun::on_log_insert_completion, 3)));
         validate_num_stores();


### PR DESCRIPTION
Add flush mode to logdev as nublocks uses timer,
nuobject uses explicit log flush mode. Flush mode has to be stored in superblk to support recovery. Enable solo repl dev UT. Add graceful shutdown for UT to work.