### PR TITLE
Add multiple blkid's support for solorepldev.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.10.1"
+    version = "6.11.0"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/blkdata_service.hpp
+++ b/src/include/homestore/blkdata_service.hpp
@@ -157,6 +157,16 @@ public:
     BlkAllocStatus alloc_blks(uint32_t size, blk_alloc_hints const& hints, MultiBlkId& out_blkids);
 
     /**
+     * @brief Allocates blocks of disk space of the given size.
+     *
+     * @param size The size of the block to allocate, in bytes.
+     * @param hints Hints for how to allocate the block.
+     * @param out_blkids Output parameter that will be filled with the IDs of the allocated blocks.
+     * @return The status of the block allocation attempt.
+     */
+    BlkAllocStatus alloc_blks(uint32_t size, blk_alloc_hints const& hints, std::vector< BlkId >& out_blkids);
+
+    /**
      * @brief Asynchronously frees the specified block IDs.
      * It is asynchronous because it might need to wait for pending read to complete if same block is being read and not
      * completed yet;

--- a/src/lib/blkdata_svc/blkdata_service.cpp
+++ b/src/lib/blkdata_svc/blkdata_service.cpp
@@ -219,6 +219,18 @@ BlkAllocStatus BlkDataService::alloc_blks(uint32_t size, const blk_alloc_hints& 
     return ret;
 }
 
+BlkAllocStatus BlkDataService::alloc_blks(uint32_t size, const blk_alloc_hints& hints,
+                                          std::vector< BlkId >& out_blkids) {
+    if (is_stopping()) return BlkAllocStatus::FAILED;
+    incr_pending_request_num();
+    HS_DBG_ASSERT_EQ(size % m_blk_size, 0, "Non aligned size requested");
+    blk_count_t nblks = static_cast< blk_count_t >(size / m_blk_size);
+
+    auto ret = m_vdev->alloc_blks(nblks, hints, out_blkids);
+    decr_pending_request_num();
+    return ret;
+}
+
 BlkAllocStatus BlkDataService::commit_blk(MultiBlkId const& blkid) {
     if (is_stopping()) return BlkAllocStatus::FAILED;
     incr_pending_request_num();

--- a/src/lib/replication/repl_dev/common.h
+++ b/src/lib/replication/repl_dev/common.h
@@ -41,6 +41,7 @@ struct repl_journal_entry {
     uint32_t user_header_size;
     uint32_t key_size;
     uint32_t value_size;
+    blkid_alloc_type_t blkid_alloc_type;
     // Followed by user_header, then key, then MultiBlkId/value
 
     std::string to_string() const {

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -88,6 +88,7 @@ public:
     void cp_cleanup(CP* cp);
 
 private:
+    void write_data_local(sisl::sg_list const& value, repl_req_ptr_t rreq);
     void write_journal(repl_req_ptr_t rreq);
     void on_log_found(logstore_seq_num_t lsn, log_buffer buf, void* ctx);
 };


### PR DESCRIPTION
Solorepldev can write single multiblkid or vector of blkid's for nublocks case. Test case modified to support vector of blkids.