### PR TITLE
Make a single on_commit listener function.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.10.3"
+    version = "6.11.0"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -264,20 +264,6 @@ public:
     /// @param lsn - The log sequence number
     /// @param header - Header originally passed with replica_set::write() api
     /// @param key - Key originally passed with replica_set::write() api
-    /// @param blkids - List of blkids where data is written to the storage engine.
-    /// @param ctx - Context passed as part of the replica_set::write() api
-    ///
-    virtual void on_commit(int64_t lsn, sisl::blob const& header, sisl::blob const& key, MultiBlkId const& blkids,
-                           cintrusive< repl_req_ctx >& ctx) = 0;
-
-    /// @brief Called when the log entry has been committed in the replica set.
-    ///
-    /// This function is called from a dedicated commit thread which is different from the original thread calling
-    /// replica_set::write(). There is only one commit thread, and lsn is guaranteed to be monotonically increasing.
-    ///
-    /// @param lsn - The log sequence number
-    /// @param header - Header originally passed with replica_set::write() api
-    /// @param key - Key originally passed with replica_set::write() api
     /// @param blkids - List of independent blkids where data is written to the storage engine.
     /// @param ctx - Context passed as part of the replica_set::write() api
     ///
@@ -402,7 +388,7 @@ public:
     virtual void on_no_space_left(repl_lsn_t lsn, chunk_num_t chunk_id) { return; }
 
     /// @brief when restart, after all the logs are replayed and before joining raft group, notify the upper layer
-    virtual void on_log_replay_done(const group_id_t& group_id){};
+    virtual void on_log_replay_done(const group_id_t& group_id) {};
 
 private:
     std::weak_ptr< ReplDev > m_repl_dev;

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -1020,7 +1020,7 @@ void RaftReplDev::handle_commit(repl_req_ptr_t rreq, bool recovery) {
     } else if (rreq->op_code() == journal_type_t::HS_CTRL_REPLACE) {
         replace_member(rreq);
     } else {
-        m_listener->on_commit(rreq->lsn(), rreq->header(), rreq->key(), rreq->local_blkid(), rreq);
+        m_listener->on_commit(rreq->lsn(), rreq->header(), rreq->key(), {rreq->local_blkid()}, rreq);
     }
 
     if (!recovery) {

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -61,7 +61,7 @@ void SoloReplDev::write_journal(repl_req_ptr_t rreq) {
             if (cur_lsn < lsn) { m_commit_upto.compare_exchange_strong(cur_lsn, lsn); }
 
             data_service().commit_blk(rreq->local_blkid());
-            m_listener->on_commit(rreq->lsn(), rreq->header(), rreq->key(), rreq->local_blkid(), rreq);
+            m_listener->on_commit(rreq->lsn(), rreq->header(), rreq->key(), {rreq->local_blkid()}, rreq);
             decr_pending_request_num();
         });
 }
@@ -92,7 +92,7 @@ void SoloReplDev::on_log_found(logstore_seq_num_t lsn, log_buffer buf, void* ctx
     auto cur_lsn = m_commit_upto.load();
     if (cur_lsn < lsn) { m_commit_upto.compare_exchange_strong(cur_lsn, lsn); }
 
-    m_listener->on_commit(lsn, header, key, blkid, nullptr);
+    m_listener->on_commit(lsn, header, key, {blkid}, nullptr);
 }
 
 folly::Future< std::error_code > SoloReplDev::async_read(MultiBlkId const& bid, sisl::sg_list& sgs, uint32_t size,


### PR DESCRIPTION
Make a single on_commit listener function. List of multiblkids could point to different contigious areas of data.