### PR TITLE
Add async_read api which takes a vector of MultiBlkIds

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.13.3"
+    version = "6.13.4"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/blkdata_service.hpp
+++ b/src/include/homestore/blkdata_service.hpp
@@ -140,6 +140,18 @@ public:
                                                 bool part_of_batch = false);
 
     /**
+     * @brief Asynchronously reads data from the specified block ID.
+     *
+     * @param bids List of block IDs to read from.
+     * @param sgs The scatter-gather list to store the read data.
+     * @param part_of_batch Whether this read is part of a batch.
+     *
+     * @return A `folly::Future` that will contain the error code of the read operation.
+     */
+    folly::Future< std::error_code > async_read(std::vector<MultiBlkId> const& bids, sisl::sg_list& sgs, uint32_t size,
+                                                bool part_of_batch = false);
+
+    /**
      * @brief Commits the block with the given MultiBlkId.
      *
      * @param bid The MultiBlkId of the block to commit.

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -445,6 +445,17 @@ public:
     virtual folly::Future< std::error_code > async_read(MultiBlkId const& blkid, sisl::sg_list& sgs, uint32_t size,
                                                         bool part_of_batch = false, trace_id_t tid = 0) = 0;
 
+
+    /// @brief Reads the data and returns a future to continue on
+    /// @param blkids List of block ids to read
+    /// @param sgs Scatter gather buffer list to which blkids are to be read into
+    /// @param part_of_batch Is read is part of a batch. If part of the batch, then submit_batch needs to be called at
+    /// the end
+    /// @return A Future with std::error_code to notify if it has successfully read the data or any error code in case
+    /// of failure
+    virtual folly::Future< std::error_code > async_read(std::vector<MultiBlkId> const& blkids, sisl::sg_list& sgs, uint32_t size,
+                                                        bool part_of_batch = false, trace_id_t tid = 0) = 0;                                       
+        
     /// @brief After data is replicated and on_commit to the listener is called. the blkids can be freed.
     ///
     /// @param lsn - LSN of the old blkids that is being freed

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -229,6 +229,11 @@ public:
     folly::SemiFuture< ReplServiceError > destroy_group();
 
     //////////////// All ReplDev overrides/implementation ///////////////////////
+    folly::Future< std::error_code > async_read(std::vector<MultiBlkId> const& blkids, sisl::sg_list& sgs, uint32_t size,
+        bool part_of_batch = false, trace_id_t tid = 0) override {
+            RD_REL_ASSERT(false, "NOT SUPPORTED");
+            return folly::makeFuture< std::error_code >(std::make_error_code(std::errc::operation_not_supported));
+    }
     void async_alloc_write(sisl::blob const& header, sisl::blob const& key, sisl::sg_list const& value,
                            repl_req_ptr_t ctx, bool part_of_batch = false, trace_id_t tid = 0) override;
     folly::Future< std::error_code > async_read(MultiBlkId const& blkid, sisl::sg_list& sgs, uint32_t size,

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -107,6 +107,18 @@ folly::Future< std::error_code > SoloReplDev::async_read(MultiBlkId const& bid, 
     return result;
 }
 
+folly::Future< std::error_code > SoloReplDev::async_read(std::vector<MultiBlkId> const& blkids, sisl::sg_list& sgs, uint32_t size,
+    bool part_of_batch, trace_id_t tid) {
+    if (is_stopping()) {
+        LOGINFO("repl dev is being shutdown!");
+        return folly::makeFuture< std::error_code >(std::make_error_code(std::errc::operation_canceled));
+    }
+    incr_pending_request_num();
+    auto result = data_service().async_read(blkids, sgs, size, part_of_batch);
+    decr_pending_request_num();
+    return result;
+}
+
 folly::Future< std::error_code > SoloReplDev::async_free_blks(int64_t, MultiBlkId const& bid, trace_id_t tid) {
     if (is_stopping()) {
         LOGINFO("repl dev is being shutdown!");

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -46,6 +46,9 @@ public:
 
     folly::Future< std::error_code > async_read(MultiBlkId const& bid, sisl::sg_list& sgs, uint32_t size,
                                                 bool part_of_batch = false, trace_id_t tid = 0) override;
+        
+    virtual folly::Future< std::error_code > async_read(std::vector<MultiBlkId> const& blkids, sisl::sg_list& sgs, uint32_t size,
+                                                    bool part_of_batch = false, trace_id_t tid = 0) override;
 
     folly::Future< std::error_code > async_free_blks(int64_t lsn, MultiBlkId const& blkid, trace_id_t tid = 0) override;
 


### PR DESCRIPTION
Add the API 
```
virtual folly::Future< std::error_code > async_read(std::vector<MultiBlkId> const& blkids, sisl::sg_list& sgs, uint32_t size,
                                                        bool part_of_batch = false, trace_id_t tid = 0) = 0;                              
```
This is to remove the complexity of collecting futures during the read of a list of BlkIds