### PR TITLE
Issue 713: Fix index table destroy race with wb_cache cp flush

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.13.6"
+    version = "6.13.8"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/index/index_internal.hpp
+++ b/src/include/homestore/index/index_internal.hpp
@@ -96,7 +96,7 @@ struct IndexBuffer : public sisl::ObjLifeCounter< IndexBuffer > {
     cp_id_t m_created_cp_id{-1};                                        // CP id when this buffer is created.
     std::atomic< index_buf_state_t > m_state{index_buf_state_t::CLEAN}; // Is buffer yet to persist?
     uint8_t* m_bytes{nullptr};                                          // Actual data buffer
-    uint32_t m_node_level{0};                                            //levels of the node in the btree
+    uint32_t m_node_level{0};                                           // levels of the node in the btree
 
     std::shared_ptr< IndexBuffer > m_up_buffer;             // Parent buffer in the chain to persisted
     sisl::atomic_counter< int > m_wait_for_down_buffers{0}; // Number of children need to wait for before persisting
@@ -145,6 +145,7 @@ struct MetaIndexBuffer : public IndexBuffer {
     virtual ~MetaIndexBuffer();
     void copy_sb_to_buf();
 
+    bool m_valid{true};
     superblk< index_table_sb >& m_sb;
 };
 

--- a/src/include/homestore/index/index_table.hpp
+++ b/src/include/homestore/index/index_table.hpp
@@ -109,6 +109,7 @@ public:
         auto cpg = cp_mgr().cp_guard();
         Btree< K, V >::destroy_btree(cpg.context(cp_consumer_t::INDEX_SVC));
         m_sb.destroy();
+        m_sb_buffer->m_valid = false;
         decr_pending_request_num();
         return btree_status_t::success;
     }
@@ -438,420 +439,435 @@ protected:
     }
 
     //
-        btree_status_t repair_links(BtreeNodePtr const& parent_node, void* cp_ctx) {
-            LOGTRACEMOD(wbcache, "Repairing links for parent node [{}]", parent_node->to_string());
-            // TODO: is it possible that repairing many nodes causes an increase to level of btree? If so, then this
-            // needs to be handled. Get the last key in the node
+    btree_status_t repair_links(BtreeNodePtr const& parent_node, void* cp_ctx) {
+        LOGTRACEMOD(wbcache, "Repairing links for parent node [{}]", parent_node->to_string());
+        // TODO: is it possible that repairing many nodes causes an increase to level of btree? If so, then this
+        // needs to be handled. Get the last key in the node
 
-            auto last_parent_key = parent_node->get_last_key< K >();
-            auto const is_parent_edge_node = parent_node->has_valid_edge();
-            if ((parent_node->total_entries() == 0) && !is_parent_edge_node) {
-                BT_LOG_ASSERT(false, "Parent node={} is empty and not an edge node but was asked to repair",
-                              parent_node->node_id());
-                return btree_status_t::not_found;
-            }
+        auto last_parent_key = parent_node->get_last_key< K >();
+        auto const is_parent_edge_node = parent_node->has_valid_edge();
+        if ((parent_node->total_entries() == 0) && !is_parent_edge_node) {
+            BT_LOG_ASSERT(false, "Parent node={} is empty and not an edge node but was asked to repair",
+                          parent_node->node_id());
+            return btree_status_t::not_found;
+        }
 
-            // Get all original child ids as a support to check if we are beyond the last child node
-            std::unordered_map< bnodeid_t, K > orig_child_infos;
-            for (uint32_t i = 0; i < parent_node->total_entries(); ++i) {
-                BtreeLinkInfo link_info;
-                parent_node->get_nth_value(i, &link_info, true);
-                orig_child_infos[link_info.bnode_id()] = parent_node->get_nth_key< K >(i, false /* copy */);
-            }
-            LOGTRACEMOD(wbcache, "Repairing node=[{}] with last_parent_key={}", parent_node->to_string(),
-                        last_parent_key.to_string());
+        // Get all original child ids as a support to check if we are beyond the last child node
+        std::unordered_map< bnodeid_t, K > orig_child_infos;
+        for (uint32_t i = 0; i < parent_node->total_entries(); ++i) {
+            BtreeLinkInfo link_info;
+            parent_node->get_nth_value(i, &link_info, true);
+            orig_child_infos[link_info.bnode_id()] = parent_node->get_nth_key< K >(i, false /* copy */);
+        }
+        LOGTRACEMOD(wbcache, "Repairing node=[{}] with last_parent_key={}", parent_node->to_string(),
+                    last_parent_key.to_string());
 
-            // Get the first child node and its link info
-            BtreeLinkInfo child_info;
-            BtreeNodePtr child_node;
-            BtreeNodePtr pre_child_node;
-            auto ret = this->get_child_and_lock_node(parent_node, 0, child_info, child_node, locktype_t::READ,
-                                                     locktype_t::READ, cp_ctx);
-            if (ret != btree_status_t::success) {
-                BT_LOG_ASSERT(false, "Parent node={} repair failed, because first child_node get has failed with ret={}", parent_node->node_id(), enum_name(ret));
-                return ret;
-            }
+        // Get the first child node and its link info
+        BtreeLinkInfo child_info;
+        BtreeNodePtr child_node;
+        BtreeNodePtr pre_child_node;
+        auto ret = this->get_child_and_lock_node(parent_node, 0, child_info, child_node, locktype_t::READ,
+                                                 locktype_t::READ, cp_ctx);
+        if (ret != btree_status_t::success) {
+            BT_LOG_ASSERT(false, "Parent node={} repair failed, because first child_node get has failed with ret={}",
+                          parent_node->node_id(), enum_name(ret));
+            return ret;
+        }
 
-            // update the last key of parent for issue
-            // 1- last key is X for parent (P)
-            // 2- check the non deleted last child (A) last key  (here is Y)
-            // start from first child and store the last key of the child node, then traverse to next sibling
-            //        2-1- if this is greater than parent last key, traverse for sibling of parent until reaches to
-             //siblings which has keys more than Y or end of list (name this parent sibling node F),
-            //        2-2- Put last key of F to last key of P
-            //        2-3 - set F as Next of A
-            BtreeNodeList siblings;
-            BtreeNodePtr next_cur_child;
-            BT_DBG_ASSERT(parent_node->has_valid_edge() || parent_node->total_entries(),
-                          "parent node {} doesn't have valid edge and no entries ", parent_node->to_string());
-            if (parent_node->total_entries() > 0) {
-                auto updated_last_key = last_parent_key;
-                K last_child_last_key;
-                K last_child_neighbor_key;
-                BtreeNodePtr cur_child;
-                BtreeLinkInfo cur_child_info;
+        // update the last key of parent for issue
+        // 1- last key is X for parent (P)
+        // 2- check the non deleted last child (A) last key  (here is Y)
+        // start from first child and store the last key of the child node, then traverse to next sibling
+        //        2-1- if this is greater than parent last key, traverse for sibling of parent until reaches to
+        // siblings which has keys more than Y or end of list (name this parent sibling node F),
+        //        2-2- Put last key of F to last key of P
+        //        2-3 - set F as Next of A
+        BtreeNodeList siblings;
+        BtreeNodePtr next_cur_child;
+        BT_DBG_ASSERT(parent_node->has_valid_edge() || parent_node->total_entries(),
+                      "parent node {} doesn't have valid edge and no entries ", parent_node->to_string());
+        if (parent_node->total_entries() > 0) {
+            auto updated_last_key = last_parent_key;
+            K last_child_last_key;
+            K last_child_neighbor_key;
+            BtreeNodePtr cur_child;
+            BtreeLinkInfo cur_child_info;
 
-                bool found_child = false;
-                uint32_t nentries = parent_node->total_entries() + parent_node->has_valid_edge() ? 1 : 0;
+            bool found_child = false;
+            uint32_t nentries = parent_node->total_entries() + parent_node->has_valid_edge() ? 1 : 0;
 
-                for (uint32_t i = nentries; i-- > 0;) {
-                    parent_node->get_nth_value(i, &cur_child_info, false /* copy */);
-                    if (auto ret = read_node_impl(cur_child_info.bnode_id(), cur_child); ret ==
-                    btree_status_t::success) {
-                        if (!cur_child->is_node_deleted() && cur_child->total_entries()) {
-                            last_child_last_key = cur_child->get_last_key< K >();
-                            if (cur_child->next_bnode() != empty_bnodeid &&
-                                read_node_impl(cur_child->next_bnode(), next_cur_child) == btree_status_t::success) {
-                                LOGTRACEMOD(wbcache,
-                                            "Last child last key {} for child_node [{}] parent node [{}],  next neigbor is [{}]", last_child_last_key.to_string(),
-                                            cur_child->to_string(), parent_node->to_string(),
-                                            next_cur_child->to_string());
-                                found_child = true;
-                                break;
-                            }
+            for (uint32_t i = nentries; i-- > 0;) {
+                parent_node->get_nth_value(i, &cur_child_info, false /* copy */);
+                if (auto ret = read_node_impl(cur_child_info.bnode_id(), cur_child); ret == btree_status_t::success) {
+                    if (!cur_child->is_node_deleted() && cur_child->total_entries()) {
+                        last_child_last_key = cur_child->get_last_key< K >();
+                        if (cur_child->next_bnode() != empty_bnodeid &&
+                            read_node_impl(cur_child->next_bnode(), next_cur_child) == btree_status_t::success) {
+                            LOGTRACEMOD(
+                                wbcache,
+                                "Last child last key {} for child_node [{}] parent node [{}],  next neigbor is [{}]",
+                                last_child_last_key.to_string(), cur_child->to_string(), parent_node->to_string(),
+                                next_cur_child->to_string());
                             found_child = true;
                             break;
                         }
-                        LOGTRACEMOD(wbcache, "PASSING child node {} so we need to check next child node",
-                                    cur_child->to_string());
+                        found_child = true;
+                        break;
                     }
-                }
-
-                if (found_child) {
-                    LOGTRACEMOD(wbcache, "Last child last key {} for parent node {}, child_node {}",
-                                last_child_last_key.to_string(), parent_node->to_string(), cur_child->to_string());
-                    if (last_child_last_key.compare(last_parent_key) > 0) {
-                        if (next_cur_child) {
-                            last_child_neighbor_key = next_cur_child->get_last_key< K >();
-                            LOGTRACEMOD(wbcache,
-                                        "Voila !! last child_key of child [{}] is greater than its parents [{}] and its next neighbor key is {}", cur_child->to_string(),
-                                        parent_node->to_string(), last_child_neighbor_key.to_string());
-                        } else {
-                            LOGTRACEMOD(
-                                wbcache,
-                                "Last child_key of child [{}] is greater than its parents [{}] and it has no next neighbor", cur_child->to_string(), parent_node->to_string());
-                        }
-
-                        // 2-1 traverse for sibling of parent until reaches to siblings which has keys more than 7563
-//                        or end
-                        // of list (put all siblings in a list, here is F) ,
-                        BtreeNodePtr sibling;
-                        BtreeNodePtr true_sibling;
-                        BtreeLinkInfo sibling_info;
-
-                        auto sibling_node_id = parent_node->next_bnode();
-                        while (sibling_node_id != empty_bnodeid) {
-                            if (auto ret = read_node_impl(sibling_node_id, sibling); ret == btree_status_t::success) {
-                                if (sibling->is_node_deleted()) {
-                                    // Do we need to free the sibling node here?
-                                    siblings.push_back(sibling);
-                                    sibling_node_id = sibling->next_bnode();
-                                    LOGTRACEMOD(wbcache, "Sibling node [{}] is deleted, continue to next sibling",
-                                                sibling->to_string());
-                                    continue;
-                                }
-                                auto sibling_last_key = sibling->get_last_key< K >();
-                                if (next_cur_child && sibling_last_key.compare(last_child_neighbor_key) < 0) {
-                                    siblings.push_back(sibling);
-                                    sibling_node_id = sibling->next_bnode();
-                                } else {
-                                    true_sibling = sibling;
-                                    break;
-                                }
-                            }
-                        }
-                        if (true_sibling) {
-                            LOGTRACEMOD(wbcache, "True sibling [{}] for parent_node {}",
-                            true_sibling->to_string(),
-                                        parent_node->to_string());
-                        } else {
-                            LOGTRACEMOD(wbcache, "No true sibling found for parent_node [{}]",
-                                        parent_node->to_string());
-                        }
-                        if (sibling_node_id != empty_bnodeid) {
-                            last_parent_key = last_child_last_key;
-                            parent_node->set_next_bnode(true_sibling->node_id());
-                            for (auto sibling : siblings) {
-                                LOGTRACEMOD(wbcache, "Sibling list [{}]", sibling->to_string());
-                            }
-                            LOGTRACEMOD(wbcache, "True sibling [{}]", true_sibling->to_string());
-                            BtreeLinkInfo first_child_info;
-                            parent_node->get_nth_value(0, &first_child_info, false);
-                        }
-                    } else {
-                        LOGTRACEMOD(wbcache,
-                                    "No undeleted child found for parent_node [{}], keep normal repair (regular recovery)", parent_node->to_string());
-                        next_cur_child = nullptr;
-                    }
+                    LOGTRACEMOD(wbcache, "PASSING child node {} so we need to check next child node",
+                                cur_child->to_string());
                 }
             }
 
-            // Keep a copy of the node buffer, in case we need to revert back
-            uint8_t* tmp_buffer = new uint8_t[this->m_node_size];
-            std::memcpy(tmp_buffer, parent_node->m_phys_node_buf, this->m_node_size);
-
-            // Remove all the entries in parent_node and let walk across child_nodes rebuild this node
-            parent_node->remove_all(this->m_bt_cfg);
-
-            // Walk across all child nodes until it gets the last_parent_key and keep fixing them.
-            auto cur_parent = parent_node;
-            BtreeNodeList new_parent_nodes;
-            do {
-                if (child_node->has_valid_edge() || (child_node->is_leaf() && child_node->next_bnode() == empty_bnodeid)) {
-                    if (child_node->is_node_deleted()) {
-                        // Edge node is merged, we need to set the current last entry as edge
-                        if (cur_parent->total_entries() > 0) {
-                            auto prev_val = V{};
-                            cur_parent->get_nth_value(cur_parent->total_entries() - 1, &prev_val, true);
-                            cur_parent->remove(cur_parent->total_entries() - 1);
-                            cur_parent->set_edge_value(prev_val);
-                            LOGTRACEMOD(wbcache,
-                                        "Reparing node={}, child_node=[{}] is deleted, set previous as edge_value={}",
-                                        cur_parent->node_id(), child_node->to_string(), prev_val.to_string());
-                        } else {
-                            LOGTRACEMOD(wbcache, "Found an empty interior node {} with maybe all childs deleted",
-                                        cur_parent->node_id());
-                        }
-                    } else {
-                        // Update edge and finish
-                        if (is_parent_edge_node) {
-                            cur_parent->set_edge_value(BtreeLinkInfo{child_node->node_id(),
-                            child_node->link_version()});
-                        } else {
-                            auto tsib_id = find_true_sibling(cur_parent);
-                            if (tsib_id != empty_bnodeid) {
-                                cur_parent->set_next_bnode(tsib_id);
-                                LOGTRACEMOD(wbcache,
-                                            "True sibling [{}] for parent_node [{}], So don't add child [{}] here ",
-                                            tsib_id, cur_parent->to_string(), child_node->to_string());
-                            } else {
-                                cur_parent->set_next_bnode(empty_bnodeid);
-                                // if this child node previously belonged to this parent node, we need to add it but as edge o.w, not this node
-                                if (orig_child_infos.contains(child_node->node_id())){
-                                        cur_parent->set_edge_value(BtreeLinkInfo{child_node->node_id(),
-                                                                                 child_node->link_version()});
-                                        LOGTRACEMOD(wbcache,
-                                                        "Child node [{}] is an edge node and previously belong to this parent, so we need to add it as edge",
-                                                        child_node->to_string());
-                                        } else {
-                                        LOGTRACEMOD(wbcache, "No true sibling found for parent_node [{}]",
-                                                    cur_parent->to_string());
-                                        }
-                                    BT_REL_ASSERT(cur_parent->total_entries() != 0 || cur_parent->has_valid_edge(),
-                                              "Parent node [{}] cannot be empty", cur_parent->to_string());
-                            }
-                        }
-
-//
-//                        }
-                        break;
-                    }
-                    break;
-                }
-
-                auto child_last_key = child_node->get_last_key< K >();
-                LOGTRACEMOD(wbcache, "Repairing node={}, child_node=[{}] child_last_key={}", cur_parent->node_id(),
-                            child_node->to_string(), child_last_key.to_string());
-
-                // Check if we are beyond the last child node.
-                //
-                // There can be cases where the child level merge is successfully persisted but the parent level is
-                // not. In this case, you may have your rightmost child node with last key greater than the
-                // last_parent_key. That's why here we have to check if the child node is one of the original child
-                // nodes first.
-                if (!is_parent_edge_node && !orig_child_infos.contains(child_node->node_id())) {
-                    if (child_last_key.compare(last_parent_key) > 0) {
-                        // We have reached a child beyond this parent, we can stop now
-                        // TODO this case if child last key is less than last parent key to update the parent node.
-                        // this case can potentially break the btree for put and remove op.
-                        break;
-                    }
-                    if (child_node->total_entries() == 0) {
-                        // this child has no entries, but maybe in the middle of the parent node, we need to update the key
-                        // of parent as previous one and go on
+            if (found_child) {
+                LOGTRACEMOD(wbcache, "Last child last key {} for parent node {}, child_node {}",
+                            last_child_last_key.to_string(), parent_node->to_string(), cur_child->to_string());
+                if (last_child_last_key.compare(last_parent_key) > 0) {
+                    if (next_cur_child) {
+                        last_child_neighbor_key = next_cur_child->get_last_key< K >();
                         LOGTRACEMOD(wbcache,
-                                    "Reach to an empty child node {}, and this child doesn't belong to this parent; Hence loop ends", child_node->to_string());
-                        // now update  the next of parent node by skipping all deleted siblings of this parent node
-                        auto valid_sibling = cur_parent->next_bnode();
-                        while (valid_sibling != empty_bnodeid) {
-                            BtreeNodePtr sibling;
-                            if (read_node_impl(valid_sibling, sibling) == btree_status_t::success) {
-                                if (sibling->is_node_deleted()) {
-                                    valid_sibling = sibling->next_bnode();
-                                    continue;
-                                }
-                                // cur_parent->set_next_bnode(sibling->node_id());
+                                    "Voila !! last child_key of child [{}] is greater than its parents [{}] and its "
+                                    "next neighbor key is {}",
+                                    cur_child->to_string(), parent_node->to_string(),
+                                    last_child_neighbor_key.to_string());
+                    } else {
+                        LOGTRACEMOD(
+                            wbcache,
+                            "Last child_key of child [{}] is greater than its parents [{}] and it has no next neighbor",
+                            cur_child->to_string(), parent_node->to_string());
+                    }
+
+                    // 2-1 traverse for sibling of parent until reaches to siblings which has keys more than 7563
+                    //                        or end
+                    // of list (put all siblings in a list, here is F) ,
+                    BtreeNodePtr sibling;
+                    BtreeNodePtr true_sibling;
+                    BtreeLinkInfo sibling_info;
+
+                    auto sibling_node_id = parent_node->next_bnode();
+                    while (sibling_node_id != empty_bnodeid) {
+                        if (auto ret = read_node_impl(sibling_node_id, sibling); ret == btree_status_t::success) {
+                            if (sibling->is_node_deleted()) {
+                                // Do we need to free the sibling node here?
+                                siblings.push_back(sibling);
+                                sibling_node_id = sibling->next_bnode();
+                                LOGTRACEMOD(wbcache, "Sibling node [{}] is deleted, continue to next sibling",
+                                            sibling->to_string());
+                                continue;
+                            }
+                            auto sibling_last_key = sibling->get_last_key< K >();
+                            if (next_cur_child && sibling_last_key.compare(last_child_neighbor_key) < 0) {
+                                siblings.push_back(sibling);
+                                sibling_node_id = sibling->next_bnode();
+                            } else {
+                                true_sibling = sibling;
                                 break;
                             }
-                            LOGTRACEMOD(wbcache, "Failed to read child node {} for parent node [{}] reason {}",
-                                        valid_sibling, cur_parent->to_string(), ret);
                         }
-                        if (valid_sibling != empty_bnodeid) {
-                            cur_parent->set_next_bnode(valid_sibling);
-                            LOGTRACEMOD(wbcache, "Repairing node={}, child_node=[{}] is an edge node, end loop",
-                                        cur_parent->node_id(), child_node->to_string());
+                    }
+                    if (true_sibling) {
+                        LOGTRACEMOD(wbcache, "True sibling [{}] for parent_node {}", true_sibling->to_string(),
+                                    parent_node->to_string());
+                    } else {
+                        LOGTRACEMOD(wbcache, "No true sibling found for parent_node [{}]", parent_node->to_string());
+                    }
+                    if (sibling_node_id != empty_bnodeid) {
+                        last_parent_key = last_child_last_key;
+                        parent_node->set_next_bnode(true_sibling->node_id());
+                        for (auto sibling : siblings) {
+                            LOGTRACEMOD(wbcache, "Sibling list [{}]", sibling->to_string());
+                        }
+                        LOGTRACEMOD(wbcache, "True sibling [{}]", true_sibling->to_string());
+                        BtreeLinkInfo first_child_info;
+                        parent_node->get_nth_value(0, &first_child_info, false);
+                    }
+                } else {
+                    LOGTRACEMOD(wbcache,
+                                "No undeleted child found for parent_node [{}], keep normal repair (regular recovery)",
+                                parent_node->to_string());
+                    next_cur_child = nullptr;
+                }
+            }
+        }
 
+        // Keep a copy of the node buffer, in case we need to revert back
+        uint8_t* tmp_buffer = new uint8_t[this->m_node_size];
+        std::memcpy(tmp_buffer, parent_node->m_phys_node_buf, this->m_node_size);
+
+        // Remove all the entries in parent_node and let walk across child_nodes rebuild this node
+        parent_node->remove_all(this->m_bt_cfg);
+
+        // Walk across all child nodes until it gets the last_parent_key and keep fixing them.
+        auto cur_parent = parent_node;
+        BtreeNodeList new_parent_nodes;
+        do {
+            if (child_node->has_valid_edge() || (child_node->is_leaf() && child_node->next_bnode() == empty_bnodeid)) {
+                if (child_node->is_node_deleted()) {
+                    // Edge node is merged, we need to set the current last entry as edge
+                    if (cur_parent->total_entries() > 0) {
+                        auto prev_val = V{};
+                        cur_parent->get_nth_value(cur_parent->total_entries() - 1, &prev_val, true);
+                        cur_parent->remove(cur_parent->total_entries() - 1);
+                        cur_parent->set_edge_value(prev_val);
+                        LOGTRACEMOD(wbcache,
+                                    "Reparing node={}, child_node=[{}] is deleted, set previous as edge_value={}",
+                                    cur_parent->node_id(), child_node->to_string(), prev_val.to_string());
+                    } else {
+                        LOGTRACEMOD(wbcache, "Found an empty interior node {} with maybe all childs deleted",
+                                    cur_parent->node_id());
+                    }
+                } else {
+                    // Update edge and finish
+                    if (is_parent_edge_node) {
+                        cur_parent->set_edge_value(BtreeLinkInfo{child_node->node_id(), child_node->link_version()});
+                    } else {
+                        auto tsib_id = find_true_sibling(cur_parent);
+                        if (tsib_id != empty_bnodeid) {
+                            cur_parent->set_next_bnode(tsib_id);
+                            LOGTRACEMOD(wbcache,
+                                        "True sibling [{}] for parent_node [{}], So don't add child [{}] here ",
+                                        tsib_id, cur_parent->to_string(), child_node->to_string());
                         } else {
                             cur_parent->set_next_bnode(empty_bnodeid);
-                            LOGTRACEMOD(wbcache, "Repairing node={}, child_node=[{}] is an edge node, end loop",
-                                        cur_parent->node_id(), child_node->to_string());
+                            // if this child node previously belonged to this parent node, we need to add it but as edge
+                            // o.w, not this node
+                            if (orig_child_infos.contains(child_node->node_id())) {
+                                cur_parent->set_edge_value(
+                                    BtreeLinkInfo{child_node->node_id(), child_node->link_version()});
+                                LOGTRACEMOD(wbcache,
+                                            "Child node [{}] is an edge node and previously belong to this parent, so "
+                                            "we need to add it as edge",
+                                            child_node->to_string());
+                            } else {
+                                LOGTRACEMOD(wbcache, "No true sibling found for parent_node [{}]",
+                                            cur_parent->to_string());
+                            }
+                            BT_REL_ASSERT(cur_parent->total_entries() != 0 || cur_parent->has_valid_edge(),
+                                          "Parent node [{}] cannot be empty", cur_parent->to_string());
                         }
-
-                        break;
-                    }
-                }
-
-                if (!cur_parent->has_room_for_put(btree_put_type::INSERT, K::get_max_size(),
-                                                  BtreeLinkInfo::get_fixed_size())) {
-                    // No room in the parent_node, let us split the parent_node and continue
-                    auto new_parent = this->alloc_interior_node();
-                    if (new_parent == nullptr) {
-                        ret = btree_status_t::space_not_avail;
-                        break;
                     }
 
-                    new_parent->set_next_bnode(cur_parent->next_bnode());
-                    cur_parent->set_next_bnode(new_parent->node_id());
-                    new_parent->set_level(cur_parent->level());
-                    cur_parent->inc_link_version();
-
-                    new_parent_nodes.push_back(new_parent);
-                    cur_parent = std::move(new_parent);
+                    //
+                    //                        }
+                    break;
                 }
+                break;
+            }
 
-                // Insert the last key of the child node into parent node
-                if (!child_node->is_node_deleted()) {
-                    if (child_node->total_entries() == 0) {
-                        if (orig_child_infos.contains(child_node->node_id())) {
-                            child_last_key = orig_child_infos[child_node->node_id()];
-                            LOGTRACEMOD(wbcache,
-                                        "Reach to an empty child node [{}], but not the end of the parent node, so we need to update the key of parent node as original one {}",
-                                        child_node->to_string(), child_last_key.to_string());
-                        } else {
-                            LOGTRACEMOD(wbcache,
-                                        "Reach to an empty child node [{}] but not belonging to this parent (probably next parent sibling); Hence end loop", child_node->to_string());
+            auto child_last_key = child_node->get_last_key< K >();
+            LOGTRACEMOD(wbcache, "Repairing node={}, child_node=[{}] child_last_key={}", cur_parent->node_id(),
+                        child_node->to_string(), child_last_key.to_string());
+
+            // Check if we are beyond the last child node.
+            //
+            // There can be cases where the child level merge is successfully persisted but the parent level is
+            // not. In this case, you may have your rightmost child node with last key greater than the
+            // last_parent_key. That's why here we have to check if the child node is one of the original child
+            // nodes first.
+            if (!is_parent_edge_node && !orig_child_infos.contains(child_node->node_id())) {
+                if (child_last_key.compare(last_parent_key) > 0) {
+                    // We have reached a child beyond this parent, we can stop now
+                    // TODO this case if child last key is less than last parent key to update the parent node.
+                    // this case can potentially break the btree for put and remove op.
+                    break;
+                }
+                if (child_node->total_entries() == 0) {
+                    // this child has no entries, but maybe in the middle of the parent node, we need to update the key
+                    // of parent as previous one and go on
+                    LOGTRACEMOD(wbcache,
+                                "Reach to an empty child node {}, and this child doesn't belong to this parent; Hence "
+                                "loop ends",
+                                child_node->to_string());
+                    // now update  the next of parent node by skipping all deleted siblings of this parent node
+                    auto valid_sibling = cur_parent->next_bnode();
+                    while (valid_sibling != empty_bnodeid) {
+                        BtreeNodePtr sibling;
+                        if (read_node_impl(valid_sibling, sibling) == btree_status_t::success) {
+                            if (sibling->is_node_deleted()) {
+                                valid_sibling = sibling->next_bnode();
+                                continue;
+                            }
+                            // cur_parent->set_next_bnode(sibling->node_id());
                             break;
                         }
+                        LOGTRACEMOD(wbcache, "Failed to read child node {} for parent node [{}] reason {}",
+                                    valid_sibling, cur_parent->to_string(), ret);
                     }
-                    cur_parent->insert(cur_parent->total_entries(), child_last_key,
-                                       BtreeLinkInfo{child_node->node_id(), child_node->link_version()});
-                } else {
-                    // Node deleted indicates it's freed & no longer used during recovery
-                    LOGTRACEMOD(wbcache, "Repairing node={}, child node=[{}] is deleted, skipping the insert",
-                                cur_parent->node_id(), child_node->to_string());
-                    if (pre_child_node) {
-                        // We need to update the next of the previous child node to this child node
+                    if (valid_sibling != empty_bnodeid) {
+                        cur_parent->set_next_bnode(valid_sibling);
+                        LOGTRACEMOD(wbcache, "Repairing node={}, child_node=[{}] is an edge node, end loop",
+                                    cur_parent->node_id(), child_node->to_string());
 
-                        LOGTRACEMOD(wbcache,
-                                    "Repairing node={}, child_node=[{}] is deleted, set next of previous child node [{}] to this child node [{}]", cur_parent->node_id(), child_node->to_string(),
-                                    pre_child_node->to_string(), child_node->next_bnode());
-                        pre_child_node->set_next_bnode(child_node->next_bnode());
-                        // repairing the next of previous child node
-                        // We need to set the state of the previous child node to clean, so that it can be flushed
-                        IndexBtreeNode* idx_node = static_cast< IndexBtreeNode* >(pre_child_node.get());
-                        idx_node->m_idx_buf->set_state(index_buf_state_t::CLEAN);
-                        write_node_impl(pre_child_node, cp_ctx);
-                        // update the key of last entry of the parent with the last key of deleted child
+                    } else {
+                        cur_parent->set_next_bnode(empty_bnodeid);
+                        LOGTRACEMOD(wbcache, "Repairing node={}, child_node=[{}] is an edge node, end loop",
+                                    cur_parent->node_id(), child_node->to_string());
+                    }
+
+                    break;
+                }
+            }
+
+            if (!cur_parent->has_room_for_put(btree_put_type::INSERT, K::get_max_size(),
+                                              BtreeLinkInfo::get_fixed_size())) {
+                // No room in the parent_node, let us split the parent_node and continue
+                auto new_parent = this->alloc_interior_node();
+                if (new_parent == nullptr) {
+                    ret = btree_status_t::space_not_avail;
+                    break;
+                }
+
+                new_parent->set_next_bnode(cur_parent->next_bnode());
+                cur_parent->set_next_bnode(new_parent->node_id());
+                new_parent->set_level(cur_parent->level());
+                cur_parent->inc_link_version();
+
+                new_parent_nodes.push_back(new_parent);
+                cur_parent = std::move(new_parent);
+            }
+
+            // Insert the last key of the child node into parent node
+            if (!child_node->is_node_deleted()) {
+                if (child_node->total_entries() == 0) {
+                    if (orig_child_infos.contains(child_node->node_id())) {
                         child_last_key = orig_child_infos[child_node->node_id()];
-                        LOGTRACEMOD(wbcache, "updating parent [{}] current last key with {}", cur_parent->to_string(),
-                                    child_last_key.to_string());
-                        // update it here to go to the next child node and unlock this node
-                        LOGTRACEMOD(wbcache, "update the child node next to the next of previous child node");
-                        child_node->set_next_bnode(child_node->next_bnode());
+                        LOGTRACEMOD(wbcache,
+                                    "Reach to an empty child node [{}], but not the end of the parent node, so we need "
+                                    "to update the key of parent node as original one {}",
+                                    child_node->to_string(), child_last_key.to_string());
+                    } else {
+                        LOGTRACEMOD(wbcache,
+                                    "Reach to an empty child node [{}] but not belonging to this parent (probably next "
+                                    "parent sibling); Hence end loop",
+                                    child_node->to_string());
+                        break;
                     }
                 }
+                cur_parent->insert(cur_parent->total_entries(), child_last_key,
+                                   BtreeLinkInfo{child_node->node_id(), child_node->link_version()});
+            } else {
+                // Node deleted indicates it's freed & no longer used during recovery
+                LOGTRACEMOD(wbcache, "Repairing node={}, child node=[{}] is deleted, skipping the insert",
+                            cur_parent->node_id(), child_node->to_string());
+                if (pre_child_node) {
+                    // We need to update the next of the previous child node to this child node
 
-                    LOGTRACEMOD(wbcache, "Repairing node={}, repaired so_far=[{}]", cur_parent->node_id(),
-                            cur_parent->to_string());
+                    LOGTRACEMOD(wbcache,
+                                "Repairing node={}, child_node=[{}] is deleted, set next of previous child node [{}] "
+                                "to this child node [{}]",
+                                cur_parent->node_id(), child_node->to_string(), pre_child_node->to_string(),
+                                child_node->next_bnode());
+                    pre_child_node->set_next_bnode(child_node->next_bnode());
+                    // repairing the next of previous child node
+                    // We need to set the state of the previous child node to clean, so that it can be flushed
+                    IndexBtreeNode* idx_node = static_cast< IndexBtreeNode* >(pre_child_node.get());
+                    idx_node->m_idx_buf->set_state(index_buf_state_t::CLEAN);
+                    write_node_impl(pre_child_node, cp_ctx);
+                    // update the key of last entry of the parent with the last key of deleted child
+                    child_last_key = orig_child_infos[child_node->node_id()];
+                    LOGTRACEMOD(wbcache, "updating parent [{}] current last key with {}", cur_parent->to_string(),
+                                child_last_key.to_string());
+                    // update it here to go to the next child node and unlock this node
+                    LOGTRACEMOD(wbcache, "update the child node next to the next of previous child node");
+                    child_node->set_next_bnode(child_node->next_bnode());
+                }
+            }
 
-                // Move to the next child node
-                auto const next_node_id = child_node->next_bnode();
-                this->unlock_node(child_node, locktype_t::READ);
+            LOGTRACEMOD(wbcache, "Repairing node={}, repaired so_far=[{}]", cur_parent->node_id(),
+                        cur_parent->to_string());
+
+            // Move to the next child node
+            auto const next_node_id = child_node->next_bnode();
+            this->unlock_node(child_node, locktype_t::READ);
+            if (!child_node->is_node_deleted()) {
+                // We need to free the child node
+                pre_child_node = child_node;
+            }
+            if (next_node_id == empty_bnodeid) {
+                // This can be a deleted edge node - only check if it is still valid
                 if (!child_node->is_node_deleted()) {
-                    // We need to free the child node
-                    pre_child_node = child_node;
+                    BT_LOG_ASSERT(false,
+                                  "Child node={} next_node_id is empty, while its not a edge node, parent_node={} "
+                                  "repair is partial",
+                                  child_node->node_id(), parent_node->node_id());
+                    ret = btree_status_t::not_found;
                 }
-                if (next_node_id == empty_bnodeid) {
-                    // This can be a deleted edge node - only check if it is still valid
-                    if (!child_node->is_node_deleted()) {
-                        BT_LOG_ASSERT(false,
-                                      "Child node={} next_node_id is empty, while its not a edge node, parent_node={} repair is partial", child_node->node_id(), parent_node->node_id());
-                        ret = btree_status_t::not_found;
-                    }
-                    child_node = nullptr;
-                    break;
-                }
-                if (next_cur_child && next_node_id == next_cur_child->node_id()) {
-                    // We are at the last child node, we can stop now
-                    LOGTRACEMOD(
-                        wbcache,
-                        "REACH Repairing node={}, child_node=[{}] is the true child of sibling parent; Hence, end loop", child_node->node_id(), next_cur_child->to_string());
-                    child_node = nullptr;
-                    break;
-                }
-                ret = this->read_and_lock_node(next_node_id, child_node, locktype_t::READ, locktype_t::READ, cp_ctx);
-                if (ret != btree_status_t::success) {
-                    BT_LOG_ASSERT(false, "Parent node={} repair is partial, because child_node get has failed with ret={}",
-                                  parent_node->node_id(), enum_name(ret));
-                    child_node = nullptr;
-                    break;
-                }
-
-            } while (true);
-
-            if (child_node) { this->unlock_node(child_node, locktype_t::READ); }
-            // if last parent has the key less than the last child key, then we need to update the parent node with
-            // the last child key if it doesn't have edge.
-            auto last_parent = parent_node;
-            if (new_parent_nodes.size() > 0) { last_parent = new_parent_nodes[new_parent_nodes.size() - 1]; }
-            if (last_parent->total_entries() && !last_parent->has_valid_edge()) {
-                if (last_parent->compare_nth_key(last_parent_key, last_parent->total_entries() - 1) < 0) {
-                    BtreeLinkInfo child_info;
-                    last_parent->get_nth_value(last_parent->total_entries() - 1, &child_info, false /* copy */);
-                    parent_node->update(parent_node->total_entries() - 1, last_parent_key, child_info);
-                    LOGTRACEMOD(wbcache, "Repairing parent node={} with last_parent_key={} and child_info={}",
-                                parent_node->node_id(), last_parent_key.to_string(), child_info.to_string());
-                }
-                // if last key of children is less than the last key of parent, then we need to update the last key of non interior child
-                if (last_parent->level() > 1 && !last_parent->has_valid_edge()) {
-                    // read last child
-                    BtreeNodePtr last_child;
-                    BtreeLinkInfo child_info;
-                    auto total_entries = last_parent->total_entries();
-                    last_parent->get_nth_value(total_entries - 1, &child_info, false /* copy */);
-                    if (ret = read_node_impl(child_info.bnode_id(), last_child); ret == btree_status_t::success) {
-                        // get last key of cur child
-                        auto last_child_key = last_child->get_last_key< K >();
-                        BtreeLinkInfo last_child_info;
-                        last_child->get_nth_value(last_child->total_entries() - 1, &last_child_info, false /* copy*/);
-                        if (last_parent->compare_nth_key(last_child_key, total_entries - 1) > 0) {
-                            auto cur_child_st = last_child->to_string();
-                            last_child->update(last_child->total_entries() - 1, last_parent_key, last_child_info);
-                            LOGTRACEMOD(wbcache,
-                                        "Updating interior child node={} with last_parent_key={} and child_info={}",
-                                        cur_child_st, last_parent_key.to_string(), last_child_info.to_string());
-                            write_node_impl(last_child, cp_ctx);
-                        }
-                    }
-                }
+                child_node = nullptr;
+                break;
             }
-
-            if (ret == btree_status_t::success) {
-                // Make write_buf happy for the parent node in case of multiple write (stale repair and link repair)
-                IndexBtreeNode* p_node = static_cast< IndexBtreeNode* >(parent_node.get());
-                p_node->m_idx_buf->set_state(index_buf_state_t::CLEAN);
-                ret = transact_nodes(new_parent_nodes, {}, parent_node, nullptr, cp_ctx);
+            if (next_cur_child && next_node_id == next_cur_child->node_id()) {
+                // We are at the last child node, we can stop now
+                LOGTRACEMOD(
+                    wbcache,
+                    "REACH Repairing node={}, child_node=[{}] is the true child of sibling parent; Hence, end loop",
+                    child_node->node_id(), next_cur_child->to_string());
+                child_node = nullptr;
+                break;
             }
-
+            ret = this->read_and_lock_node(next_node_id, child_node, locktype_t::READ, locktype_t::READ, cp_ctx);
             if (ret != btree_status_t::success) {
-                BT_LOG(ERROR, "An error occurred status={} during repair of parent_node={}, aborting the repair",
-                       enum_name(ret), parent_node->node_id());
-                std::memcpy(parent_node->m_phys_node_buf, tmp_buffer, this->m_bt_cfg.node_size());
+                BT_LOG_ASSERT(false, "Parent node={} repair is partial, because child_node get has failed with ret={}",
+                              parent_node->node_id(), enum_name(ret));
+                child_node = nullptr;
+                break;
             }
 
-            delete[] tmp_buffer;
-            return ret;
+        } while (true);
+
+        if (child_node) { this->unlock_node(child_node, locktype_t::READ); }
+        // if last parent has the key less than the last child key, then we need to update the parent node with
+        // the last child key if it doesn't have edge.
+        auto last_parent = parent_node;
+        if (new_parent_nodes.size() > 0) { last_parent = new_parent_nodes[new_parent_nodes.size() - 1]; }
+        if (last_parent->total_entries() && !last_parent->has_valid_edge()) {
+            if (last_parent->compare_nth_key(last_parent_key, last_parent->total_entries() - 1) < 0) {
+                BtreeLinkInfo child_info;
+                last_parent->get_nth_value(last_parent->total_entries() - 1, &child_info, false /* copy */);
+                parent_node->update(parent_node->total_entries() - 1, last_parent_key, child_info);
+                LOGTRACEMOD(wbcache, "Repairing parent node={} with last_parent_key={} and child_info={}",
+                            parent_node->node_id(), last_parent_key.to_string(), child_info.to_string());
+            }
+            // if last key of children is less than the last key of parent, then we need to update the last key of non
+            // interior child
+            if (last_parent->level() > 1 && !last_parent->has_valid_edge()) {
+                // read last child
+                BtreeNodePtr last_child;
+                BtreeLinkInfo child_info;
+                auto total_entries = last_parent->total_entries();
+                last_parent->get_nth_value(total_entries - 1, &child_info, false /* copy */);
+                if (ret = read_node_impl(child_info.bnode_id(), last_child); ret == btree_status_t::success) {
+                    // get last key of cur child
+                    auto last_child_key = last_child->get_last_key< K >();
+                    BtreeLinkInfo last_child_info;
+                    last_child->get_nth_value(last_child->total_entries() - 1, &last_child_info, false /* copy*/);
+                    if (last_parent->compare_nth_key(last_child_key, total_entries - 1) > 0) {
+                        auto cur_child_st = last_child->to_string();
+                        last_child->update(last_child->total_entries() - 1, last_parent_key, last_child_info);
+                        LOGTRACEMOD(wbcache,
+                                    "Updating interior child node={} with last_parent_key={} and child_info={}",
+                                    cur_child_st, last_parent_key.to_string(), last_child_info.to_string());
+                        write_node_impl(last_child, cp_ctx);
+                    }
+                }
+            }
         }
+
+        if (ret == btree_status_t::success) {
+            // Make write_buf happy for the parent node in case of multiple write (stale repair and link repair)
+            IndexBtreeNode* p_node = static_cast< IndexBtreeNode* >(parent_node.get());
+            p_node->m_idx_buf->set_state(index_buf_state_t::CLEAN);
+            ret = transact_nodes(new_parent_nodes, {}, parent_node, nullptr, cp_ctx);
+        }
+
+        if (ret != btree_status_t::success) {
+            BT_LOG(ERROR, "An error occurred status={} during repair of parent_node={}, aborting the repair",
+                   enum_name(ret), parent_node->node_id());
+            std::memcpy(parent_node->m_phys_node_buf, tmp_buffer, this->m_bt_cfg.node_size());
+        }
+
+        delete[] tmp_buffer;
+        return ret;
+    }
 
     bnodeid_t find_true_sibling(BtreeNodePtr const& node) {
         if (node == nullptr) return empty_bnodeid;
@@ -868,7 +884,8 @@ protected:
             if (read_node_impl(sibling_id, sibling_node) != btree_status_t::success) { return empty_bnodeid; }
 
             if (sibling_node->is_node_deleted()) {
-                LOGTRACEMOD(wbcache, "Sibling node [{}] is not the sibling for parent_node {}", sibling_node->to_string(), node->to_string());
+                LOGTRACEMOD(wbcache, "Sibling node [{}] is not the sibling for parent_node {}",
+                            sibling_node->to_string(), node->to_string());
                 return find_true_sibling(sibling_node);
             } else {
                 return sibling_id;
@@ -894,7 +911,6 @@ protected:
             }
         }
     }
-
 };
 
 } // namespace homestore

--- a/src/lib/index/index_service.cpp
+++ b/src/lib/index/index_service.cpp
@@ -277,7 +277,8 @@ void IndexBuffer::remove_down_buffer(const IndexBufferPtr& buf) {
             }
         }
     }
-    HS_DBG_ASSERT(found, "Down buffer {} is linked to up_buf, but up_buf {} doesn't have down_buf in its list", buf->to_string(), buf->m_up_buffer? buf->m_up_buffer->to_string(): std::string("nulptr"));
+    HS_DBG_ASSERT(found, "Down buffer {} is linked to up_buf, but up_buf {} doesn't have down_buf in its list",
+                  buf->to_string(), buf->m_up_buffer ? buf->m_up_buffer->to_string() : std::string("nulptr"));
 #endif
 }
 
@@ -307,6 +308,7 @@ MetaIndexBuffer::~MetaIndexBuffer() {
         hs_utils::iobuf_free(m_bytes, sisl::buftag::metablk);
         m_bytes = nullptr;
     }
+    m_valid = false;
 }
 
 void MetaIndexBuffer::copy_sb_to_buf() { std::memcpy(m_bytes, m_sb.raw_buf()->cbytes(), m_sb.size()); }


### PR DESCRIPTION
To reviewers:
Please kindly  change setting hide whitespace and reload, a recent PR seems didn't apply clang-format on a few files. 

There is only one line change in `index_table.hpp` which I commented in the PR.

Passed test against HomeStore consumer HomeObject.
```
conanfile.py (homeobject/2.3.16): RUN: cmake --build "/tmp/source/HomeObject/build/Debug" --target test -- -j104
Running tests...
Test project /tmp/source/HomeObject/build/Debug
      Start  1: HomestoreTestPg
 1/11 Test  #1: HomestoreTestPg ................................   Passed  273.15 sec
      Start  2: HomestoreTestShard
 2/11 Test  #2: HomestoreTestShard .............................   Passed  133.87 sec
      Start  3: HomestoreTestBlob
 3/11 Test  #3: HomestoreTestBlob ..............................   Passed  226.44 sec
      Start  4: HomestoreTestMisc
 4/11 Test  #4: HomestoreTestMisc ..............................   Passed   39.42 sec
      Start  5: HomestoreTestReplaceMember
 5/11 Test  #5: HomestoreTestReplaceMember .....................   Passed   42.52 sec
      Start  6: HomestoreTestReplaceMemberWithBaselineResync
 6/11 Test  #6: HomestoreTestReplaceMemberWithBaselineResync ...   Passed   31.49 sec
      Start  7: HomestoreResyncTestWithFollowerRestart
 7/11 Test  #7: HomestoreResyncTestWithFollowerRestart .........   Passed  140.71 sec
      Start  8: HomestoreResyncTestWithLeaderRestart
 8/11 Test  #8: HomestoreResyncTestWithLeaderRestart ...........   Passed   52.13 sec
      Start  9: HeapChunkSelectorTest
 9/11 Test  #9: HeapChunkSelectorTest ..........................   Passed    0.10 sec
      Start 10: MemoryTestCPU
10/11 Test #10: MemoryTestCPU ..................................   Passed    1.55 sec
      Start 11: MemoryTestIO
11/11 Test #11: MemoryTestIO ...................................   Passed    1.91 sec

100% tests passed, 0 tests failed out of 11

Total Test time (real) = 943.32 sec 
```
