### PR TITLE
Issue 716: Fix log periodic cancelt_imer issue and solo repl dev init/destroy ra…

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.13.8"
+    version = "6.13.9"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/logstore/log_dev.cpp
+++ b/src/lib/logstore/log_dev.cpp
@@ -168,9 +168,10 @@ void LogDev::start_timer() {
 
 void LogDev::stop_timer() {
     if (m_flush_timer_hdl != iomgr::null_timer_handle) {
-        // cancel the timer
-        iomanager.run_on_wait(logstore_service().flush_thread(),
-                              [this]() { iomanager.cancel_timer(m_flush_timer_hdl, true); });
+        iomanager.run_on_forget(logstore_service().flush_thread(), [this]() {
+            iomanager.cancel_timer(m_flush_timer_hdl, true);
+            m_flush_timer_hdl = iomgr::null_timer_handle;
+        });
     }
 }
 

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -1,6 +1,7 @@
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 #include "replication/repl_dev/solo_repl_dev.h"
 #include "replication/repl_dev/common.h"
+#include <homestore/homestore.hpp>
 #include <homestore/blkdata_service.hpp>
 #include <homestore/logstore_service.hpp>
 #include <homestore/superblk_handler.hpp>
@@ -10,6 +11,7 @@ namespace homestore {
 SoloReplDev::SoloReplDev(superblk< repl_dev_superblk >&& rd_sb, bool load_existing) :
         m_rd_sb{std::move(rd_sb)}, m_group_id{m_rd_sb->group_id} {
     if (load_existing) {
+        m_logdev_id = m_rd_sb->logdev_id;
         logstore_service().open_logdev(m_rd_sb->logdev_id, flush_mode_t::TIMER);
         logstore_service()
             .open_log_store(m_rd_sb->logdev_id, m_rd_sb->logstore_id, true /* append_mode */)
@@ -17,6 +19,7 @@ SoloReplDev::SoloReplDev(superblk< repl_dev_superblk >&& rd_sb, bool load_existi
                 m_data_journal = std::move(log_store);
                 m_rd_sb->logstore_id = m_data_journal->get_store_id();
                 m_data_journal->register_log_found_cb(bind_this(SoloReplDev::on_log_found, 3));
+                m_is_recovered = true;
             });
     } else {
         m_logdev_id = logstore_service().create_new_logdev(flush_mode_t::TIMER);
@@ -24,6 +27,7 @@ SoloReplDev::SoloReplDev(superblk< repl_dev_superblk >&& rd_sb, bool load_existi
         m_rd_sb->logstore_id = m_data_journal->get_store_id();
         m_rd_sb->logdev_id = m_logdev_id;
         m_rd_sb.write();
+        m_is_recovered = true;
     }
 }
 
@@ -46,6 +50,15 @@ void SoloReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& 
     } else {
         write_journal(std::move(rreq));
     }
+}
+
+void SoloReplDev::destroy() {
+    while (!m_is_recovered) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    hs()->logstore_service().remove_log_store(m_logdev_id, m_data_journal->get_store_id());
+    hs()->logstore_service().destroy_log_dev(m_logdev_id);
 }
 
 void SoloReplDev::write_journal(repl_req_ptr_t rreq) {
@@ -211,6 +224,7 @@ void SoloReplDev::cp_flush(CP*) {
     m_rd_sb.write();
 }
 
-void SoloReplDev::cp_cleanup(CP*) { /* m_data_journal->truncate(m_rd_sb->checkpoint_lsn); */ }
+void SoloReplDev::cp_cleanup(CP*) { /* m_data_journal->truncate(m_rd_sb->checkpoint_lsn); */
+}
 
 } // namespace homestore

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -52,7 +52,9 @@ void SoloReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& 
     }
 }
 
+// destroy is only called in worker thread;
 void SoloReplDev::destroy() {
+    HS_REL_ASSERT(iomanager.am_i_worker_reactor(), "Destroy should be called in worker thread");
     while (!m_is_recovered) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -30,10 +30,11 @@ class CP;
 class SoloReplDev : public ReplDev {
 private:
     logdev_id_t m_logdev_id;
-    std::shared_ptr< HomeLogStore > m_data_journal;
+    std::shared_ptr< HomeLogStore > m_data_journal{nullptr};
     superblk< repl_dev_superblk > m_rd_sb;
     uuid_t m_group_id;
     std::atomic< logstore_seq_num_t > m_commit_upto{-1};
+    std::atomic< bool > m_is_recovered{false};
 
 public:
     SoloReplDev(superblk< repl_dev_superblk >&& rd_sb, bool load_existing);
@@ -94,6 +95,8 @@ public:
 
     void cp_flush(CP* cp);
     void cp_cleanup(CP* cp);
+
+    void destroy();
 
 private:
     void write_journal(repl_req_ptr_t rreq);


### PR DESCRIPTION
…ce issue

For reviewer:
==========
This PR's fix doesn't affect NuObject because 
1. nuObject case doesn't turn on periodic flush for the log dev's flush thread. 
2. Solo Repl dev is not used for nuObject case as well. 

Detailed fix:
=========
1. fix periodic log flush timer cancel_time assert failure in iomgr that complains main fiber can't do sync wait on cancel_timer API.
2. Fix a race issue between solo repl dev init and destroy path.
The root cause is during boot, when we there is a solo repl dev pending on destroy, however during boot, its init is also on-going, there is a race window destroy might arrive before `open_log_store` which is an async call whose `thenValue` hasn't been called yet, in this case, the `m_data_journal` is not properly initialized and will cause ASAN issue.
The fix closed this race window. 

Testing:
======
Cross tested with HomeObj: 
```
conanfile.py (homeobject/2.3.16): RUN: cmake --build "/tmp/source/yk_ho/build/Release" --target test -- -j104
Running tests...
Test project /tmp/source/yk_ho/build/Release
      Start  1: HomestoreTestPg
 1/11 Test  #1: HomestoreTestPg ................................   Passed  111.22 sec
      Start  2: HomestoreTestShard
 2/11 Test  #2: HomestoreTestShard .............................   Passed  131.97 sec
      Start  3: HomestoreTestBlob
 3/11 Test  #3: HomestoreTestBlob ..............................   Passed   48.66 sec
      Start  4: HomestoreTestMisc
 4/11 Test  #4: HomestoreTestMisc ..............................   Passed   38.10 sec
      Start  5: HomestoreTestReplaceMember
 5/11 Test  #5: HomestoreTestReplaceMember .....................   Passed   36.55 sec
      Start  6: HomestoreTestReplaceMemberWithBaselineResync
 6/11 Test  #6: HomestoreTestReplaceMemberWithBaselineResync ...   Passed   30.46 sec
      Start  7: HomestoreResyncTestWithFollowerRestart
 7/11 Test  #7: HomestoreResyncTestWithFollowerRestart .........   Passed  126.51 sec
      Start  8: HomestoreResyncTestWithLeaderRestart
 8/11 Test  #8: HomestoreResyncTestWithLeaderRestart ...........   Passed   50.19 sec
      Start  9: HeapChunkSelectorTest
 9/11 Test  #9: HeapChunkSelectorTest ..........................   Passed    0.05 sec
      Start 10: MemoryTestCPU
10/11 Test #10: MemoryTestCPU ..................................   Passed    0.76 sec
      Start 11: MemoryTestIO
11/11 Test #11: MemoryTestIO ...................................   Passed    0.79 sec

100% tests passed, 0 tests failed out of 11

Total Test time (real) = 575.29 sec
```