### PR TITLE
[Solo repl dev] Fix log dev flush timer cancel race 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.13.12"
+    version = "6.13.13"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.13.11"
+    version = "6.13.12"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/logstore/log_dev.cpp
+++ b/src/lib/logstore/log_dev.cpp
@@ -143,8 +143,9 @@ void LogDev::stop() {
     }
 
     folly::SharedMutexWritePriority::ReadHolder holder(m_store_map_mtx);
-    for (auto& [_, store] : m_id_logstore_map)
+    for (auto& [_, store] : m_id_logstore_map) {
         store.log_store->stop();
+    }
 
     // after we call stop, we need to do any pending device truncations
     truncate();
@@ -182,14 +183,6 @@ folly::Future< int > LogDev::stop_timer() {
         }
         p->setValue(0);
     });
-#if 0
-    if (m_flush_timer_hdl != iomgr::null_timer_handle) {
-        iomanager.run_on_forget(logstore_service().flush_thread(), [this]() {
-            iomanager.cancel_timer(m_flush_timer_hdl, true);
-            m_flush_timer_hdl = iomgr::null_timer_handle;
-        });
-    }
-#endif
     return f;
 }
 

--- a/src/lib/logstore/log_dev.hpp
+++ b/src/lib/logstore/log_dev.hpp
@@ -721,7 +721,7 @@ public:
 
 private:
     void start_timer();
-    void stop_timer();
+    folly::Future< int > stop_timer();
 
     bool allow_inline_flush() const { return uint32_cast(m_flush_mode) & uint32_cast(flush_mode_t::INLINE); }
     bool allow_timer_flush() const { return uint32_cast(m_flush_mode) & uint32_cast(flush_mode_t::TIMER); }

--- a/src/tests/test_meta_blk_mgr.cpp
+++ b/src/tests/test_meta_blk_mgr.cpp
@@ -187,7 +187,7 @@ public:
     uint64_t total_size_written(const void* cookie) { return m_mbm->meta_size(cookie); }
 
     void do_write_to_full() {
-        static constexpr uint64_t blkstore_overhead = 4 * 1024ul * 1024ul; // 4MB
+        static constexpr uint64_t blkstore_overhead = 256 * 1024ul * 1024ul; // 256MB
         ssize_t free_size = uint64_cast(m_mbm->total_size() - m_mbm->used_size() - blkstore_overhead);
 
         HS_REL_ASSERT_GT(free_size, 0);
@@ -195,8 +195,10 @@ public:
 
         uint64_t size_written{0};
         while (free_size > 0) {
+            LOGDEBUG("free size: {}, total size: {}, used size: {}, available blks: {}", free_size, m_mbm->total_size(),
+                     m_mbm->used_size(), m_mbm->available_blks());
             // if it is overflow, 2 extra blocks are needed for ovf blk header and meta blk;
-            if (free_size -  2 * m_mbm->block_size()  >= gp.max_wrt_sz) {
+            if (free_size - 2 * m_mbm->block_size() >= gp.max_wrt_sz) {
                 size_written = do_sb_write(do_overflow(), 0);
             } else {
                 size_written = do_sb_write(false, m_mbm->meta_blk_context_sz());

--- a/src/tests/test_scripts/log_meta_test.py
+++ b/src/tests/test_scripts/log_meta_test.py
@@ -85,7 +85,7 @@ def meta_nightly(options, addln_opts):
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 
-    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.random_load_test --gtest_filter=VMetaBlkMgrTest.write_to_full_test --use_file=true"  # write to file instead of real disk to save time;
+    cmd_opts = "--gtest_filter=VMetaBlkMgrTest.write_to_full_test --use_file=true"  # write to file instead of real disk to save time;
     subprocess.check_call(options.dirpath + "test_meta_blk_mgr " + cmd_opts + addln_opts, stderr=subprocess.STDOUT,
                           shell=True)
 


### PR DESCRIPTION
Only impact Solo Repl Dev which enables timer based flush thread:
* Fixed a race (happens ocasionally) that cancel_timer can finish later than the main fiber which will cause asan issue.

Testing:
======
Run 100 times for the test case:
```
for i in {1..100};  do ./Debug/src/tests/test_meta_blk --gtest_filter=VMetaBlkMgrTest.write_to_full_test --use_file=true ; done
```

Cross tested wit HomeBlocks as well to run 100 times. 
