### PR TITLE
Fix prefix - reload CompactBitSet

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,8 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.13.12"
-
+    version = "6.13.13"
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
     topics = ("ebay", "nublox")

--- a/src/include/homestore/btree/detail/btree_node.hpp
+++ b/src/include/homestore/btree/detail/btree_node.hpp
@@ -472,7 +472,13 @@ protected:
     }
 
 public:
-    void update_phys_buf(uint8_t* buf) { m_phys_node_buf = buf; }
+    void update_phys_buf(uint8_t* buf) {
+        m_phys_node_buf = buf;
+        on_update_phys_buf();
+    }
+    // This method is called when the physical buffer is updated.
+    // Derived classes can override this method to perform additional actions.
+    virtual void on_update_phys_buf() = 0;
     persistent_hdr_t* get_persistent_header() { return r_cast< persistent_hdr_t* >(m_phys_node_buf); }
     const persistent_hdr_t* get_persistent_header_const() const {
         return r_cast< const persistent_hdr_t* >(m_phys_node_buf);

--- a/src/include/homestore/btree/detail/prefix_node.hpp
+++ b/src/include/homestore/btree/detail/prefix_node.hpp
@@ -160,7 +160,10 @@ public:
     }
 
     virtual ~FixedPrefixNode() = default;
-
+    virtual void on_update_phys_buf() override {
+        // Update the prefix bitset with the new buffer
+        prefix_bitset_ = sisl::CompactBitSet{sisl::blob{bitset_area(), prefix_bitset_.size() / 8}, false};
+    }
     ///////////////////////////// All overrides of BtreeIntervalNode ///////////////////////////////////
     /// @brief Upserts a batch of entries into a prefix node.
     ///

--- a/src/include/homestore/btree/detail/variant_node.hpp
+++ b/src/include/homestore/btree/detail/variant_node.hpp
@@ -313,5 +313,6 @@ public:
         }
         return ret;
     }
+    virtual void on_update_phys_buf() override {};
 };
 } // namespace homestore

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -71,7 +71,7 @@ if (${io_tests})
     set(TEST_INDEXBTREE_SOURCE_FILES test_index_btree.cpp)
     add_executable(test_index_btree ${TEST_INDEXBTREE_SOURCE_FILES})
     target_link_libraries(test_index_btree homestore ${COMMON_TEST_DEPS} GTest::gtest)
-    add_test(NAME IndexBtree COMMAND test_index_btree --gtest_filter=*/0.*)
+    add_test(NAME IndexBtree COMMAND test_index_btree)
     set_property(TEST IndexBtree PROPERTY ENVIRONMENT "ASAN_OPTIONS=detect_stack_use_after_return=true")
     set_tests_properties(IndexBtree PROPERTIES TIMEOUT 1200)
 

--- a/src/tests/test_index_btree.cpp
+++ b/src/tests/test_index_btree.cpp
@@ -133,7 +133,7 @@ struct BtreeTest : public BtreeTestHelper< TestType >, public ::testing::Test {
     test_common::HSTestHelper m_helper;
 };
 
-using BtreeTypes = testing::Types< FixedLenBtree, VarKeySizeBtree, VarValueSizeBtree, VarObjSizeBtree >;
+using BtreeTypes = testing::Types< FixedLenBtree, PrefixIntervalBtree, VarKeySizeBtree, VarValueSizeBtree, VarObjSizeBtree >;
 
 TYPED_TEST_SUITE(BtreeTest, BtreeTypes);
 

--- a/src/tests/test_mem_btree.cpp
+++ b/src/tests/test_mem_btree.cpp
@@ -50,8 +50,8 @@ SISL_OPTION_GROUP(
      ::cxxopts::value< std::vector< std::string > >(), "operations [...]"),
     (preload_size, "", "preload_size", "number of entries to preload tree with",
      ::cxxopts::value< uint32_t >()->default_value("1000"), "number"),
-    (max_keys_in_node, "", "max_keys_in_node", "max_keys_in_node",
-     ::cxxopts::value< uint32_t >()->default_value("0"), ""),
+    (max_keys_in_node, "", "max_keys_in_node", "max_keys_in_node", ::cxxopts::value< uint32_t >()->default_value("0"),
+     ""),
     (seed, "", "seed", "random engine seed, use random if not defined",
      ::cxxopts::value< uint64_t >()->default_value("0"), "number"),
     (run_time, "", "run_time", "run time for io", ::cxxopts::value< uint32_t >()->default_value("360000"), "seconds"))
@@ -111,16 +111,14 @@ struct BtreeTest : public BtreeTestHelper< TestType >, public ::testing::Test {
 #endif
         this->m_cfg.m_max_merge_level = SISL_OPTIONS["max_merge_level"].as< uint8_t >();
         this->m_cfg.m_merge_turned_on = !SISL_OPTIONS["disable_merge"].as< bool >();
-        //if TestType is PrefixIntervalBtreeTest print here something
-        if constexpr (std::is_same_v<TestType, PrefixIntervalBtreeTest>) {
-            this->m_cfg.m_merge_turned_on = false;
-        }
+        // if TestType is PrefixIntervalBtreeTest print here something
+        if constexpr (std::is_same_v< TestType, PrefixIntervalBtreeTest >) { this->m_cfg.m_merge_turned_on = false; }
         this->m_bt = std::make_shared< typename T::BtreeType >(this->m_cfg);
     }
 };
 
-using BtreeTypes = testing::Types<  FixedLenBtreeTest, VarKeySizeBtreeTest,
-                                   VarValueSizeBtreeTest, VarObjSizeBtreeTest, PrefixIntervalBtreeTest >;
+using BtreeTypes = testing::Types< FixedLenBtreeTest, PrefixIntervalBtreeTest, VarKeySizeBtreeTest,
+                                   VarValueSizeBtreeTest, VarObjSizeBtreeTest >;
 TYPED_TEST_SUITE(BtreeTest, BtreeTypes);
 
 TYPED_TEST(BtreeTest, SequentialInsert) {
@@ -317,9 +315,7 @@ struct BtreeConcurrentTest : public BtreeTestHelper< TestType >, public ::testin
 #endif
         this->m_cfg.m_max_merge_level = SISL_OPTIONS["max_merge_level"].as< uint8_t >();
         this->m_cfg.m_merge_turned_on = !SISL_OPTIONS["disable_merge"].as< bool >();
-        if constexpr (std::is_same_v<TestType, PrefixIntervalBtreeTest>) {
-            this->m_cfg.m_merge_turned_on = false;
-        }
+        if constexpr (std::is_same_v< TestType, PrefixIntervalBtreeTest >) { this->m_cfg.m_merge_turned_on = false; }
         this->m_bt = std::make_shared< typename T::BtreeType >(this->m_cfg);
     }
 


### PR DESCRIPTION
Reload CompactBitSet after updating node phys buffer.

When a multiple happens and previous cp X is in flushing state and a node buffer is getting freed, the node buffer is copied for the working cp X+1. This leads to updating the physical node buffer. If there is any class object in a node type, the object still has the previous address which can result in either corruption of flushing buffer or head-use-after-free right after cp X flushing is complete and freeing the dirty index buffer. 