### PR TITLE
Add submit_io_batch api in blk service

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.13.14"
+    version = "6.14.0"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/blkdata_service.hpp
+++ b/src/include/homestore/blkdata_service.hpp
@@ -152,6 +152,13 @@ public:
                                                 bool part_of_batch = false);
 
     /**
+     * @brief Submit the io batch, which is a mandatory method to be called if read/write are issued with part_of_batch
+     * is set to true. In those cases, without this method, IOs might not be even issued. No-op if previous io requests
+     * are not part of batch.
+     * */
+    void submit_io_batch();
+
+    /**
      * @brief Commits the block with the given MultiBlkId.
      *
      * @param bid The MultiBlkId of the block to commit.

--- a/src/lib/blkdata_svc/blkdata_service.cpp
+++ b/src/lib/blkdata_svc/blkdata_service.cpp
@@ -222,6 +222,8 @@ BlkDataService::async_write(sisl::sg_list const& sgs, std::vector< MultiBlkId > 
     return collect_all_futures(s_futs);
 }
 
+void BlkDataService::submit_io_batch() { m_vdev->submit_batch(); }
+
 BlkAllocStatus BlkDataService::alloc_blks(uint32_t size, const blk_alloc_hints& hints, MultiBlkId& out_blkids) {
     if (is_stopping()) return BlkAllocStatus::FAILED;
     incr_pending_request_num();


### PR DESCRIPTION
Use submit_io_batch when part_of_batch is set to true for read/write.