### PR TITLE
Redesign replacemember API

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.14.0"
+    version = "6.15.0"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_decls.h
+++ b/src/include/homestore/replication/repl_decls.h
@@ -36,14 +36,9 @@ VENUM(ReplServiceError, int32_t,
       NO_SPACE_LEFT = -20000,
       DRIVE_WRITE_ERROR = -20001,
       DATA_DUPLICATED = -20002,
-      QUIENCE_STATE = -20003, 
+      QUIENCE_STATE = -20003,
+      QUORUM_NOT_MET = -20004,
       FAILED = -32768);
-
-VENUM(PeerRole, uint8_t,
-      UNKNOWN = 0,
-      LEADER = 1,
-      FOLLOWER = 2,
-      LEARNER = 3);
 // clang-format on
 
 template < typename V, typename E >
@@ -87,10 +82,8 @@ struct peer_info {
     uint64_t last_succ_resp_us_ = 0;
     // The priority for leader election
     uint32_t priority_ = 0;
-    // The peer role in replication group
-    PeerRole role_ = PeerRole::UNKNOWN;
-    // If this peer is myself
-    bool is_self_ = false;
+    // Whether the peer can vote. If a peer is learner, this will be false. Hide the raft details.
+    bool can_vote = true;
 };
 
 struct replica_member_info {

--- a/src/include/homestore/replication/repl_decls.h
+++ b/src/include/homestore/replication/repl_decls.h
@@ -38,6 +38,12 @@ VENUM(ReplServiceError, int32_t,
       DATA_DUPLICATED = -20002,
       QUIENCE_STATE = -20003, 
       FAILED = -32768);
+
+VENUM(PeerRole, uint8_t,
+      UNKNOWN = 0,
+      LEADER = 1,
+      FOLLOWER = 2,
+      LEARNER = 3);
 // clang-format on
 
 template < typename V, typename E >
@@ -76,15 +82,15 @@ struct peer_info {
     // Peer ID.
     replica_id_t id_;
     // The last replication index that the peer has, from this server's point of view.
-    uint64_t replication_idx_;
+    uint64_t replication_idx_ = 0;
     // The elapsed time since the last successful response from this peer, set to 0 on leader
-    uint64_t last_succ_resp_us_;
+    uint64_t last_succ_resp_us_ = 0;
     // The priority for leader election
-    uint32_t priority_;
-    // The peer is learner or not
-    bool is_learner_;
-    // The peer is new joiner or not
-    bool is_new_joiner_;
+    uint32_t priority_ = 0;
+    // The peer role in replication group
+    PeerRole role_ = PeerRole::UNKNOWN;
+    // If this peer is myself
+    bool is_self_ = false;
 };
 
 struct replica_member_info {

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -46,7 +46,8 @@ VENUM(journal_type_t, uint16_t,
       HS_DATA_LINKED = 0,  // Linked data where each entry will store physical blkid where data reside
       HS_DATA_INLINED = 1, // Data is inlined in the header of journal entry
       HS_CTRL_DESTROY = 2, // Control message to destroy the repl_dev
-      HS_CTRL_REPLACE = 3, // Control message to replace a member
+      HS_CTRL_START_REPLACE = 3, // Control message to start replace a member
+      HS_CTRL_COMPLETE_REPLACE = 4, // Control message to complete replace a member
 )
 
 // magic num comes from the first 8 bytes of 'echo homestore_resync_data | md5sum'
@@ -367,8 +368,13 @@ public:
     /// after restart in case crash happened during the destroy.
     virtual void on_destroy(const group_id_t& group_id) = 0;
 
-    /// @brief Called when replace member is performed.
-    virtual void on_replace_member(const replica_member_info& member_out, const replica_member_info& member_in) = 0;
+    /// @brief Called when start replace member.
+    virtual void on_start_replace_member(const replica_member_info& member_out, const replica_member_info& member_in,
+                                         trace_id_t tid) = 0;
+
+    /// @brief Called when complete replace member.
+    virtual void on_complete_replace_member(const replica_member_info& member_out, const replica_member_info& member_in,
+                                            trace_id_t tid) = 0;
 
     /// @brief Called when the snapshot is being created by nuraft
     virtual AsyncReplResult<> create_snapshot(shared< snapshot_context > context) = 0;

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -41,10 +41,16 @@ public:
     /// @return A Future which gets called after schedule to release (before garbage collection is kicked in)
     virtual folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) = 0;
 
-    virtual AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
-                                             const replica_member_info& member_in,
-                                             uint32_t commit_quorum = 0, uint64_t trace_id = 0) const = 0;
+    virtual AsyncReplResult<> start_replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                                   const replica_member_info& member_in, uint32_t commit_quorum = 0,
+                                                   uint64_t trace_id = 0) const = 0;
 
+    virtual AsyncReplResult<> complete_replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                                      const replica_member_info& member_in, uint32_t commit_quorum = 0,
+                                                      uint64_t trace_id = 0) const = 0;
+
+    virtual AsyncReplResult<> flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target, uint32_t commit_quorum,
+                                        bool wait_and_verify = true, uint64_t trace_id = 0) const = 0;
     /// @brief Get the repl dev for a given group id if it is already created or opened
     /// @param group_id Group id interested in
     /// @return ReplDev is opened or ReplServiceError::SERVER_NOT_FOUND if it doesn't exist

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -41,13 +41,15 @@ public:
     /// @return A Future which gets called after schedule to release (before garbage collection is kicked in)
     virtual folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) = 0;
 
-    virtual AsyncReplResult<> start_replace_member(group_id_t group_id, const replica_member_info& member_out,
+    /// @brief Replace one of the members with a new one.
+    /// @param group_id Group where the replace member happens
+    /// @param member_out The member which is going to be replaced
+    /// @param member_in The member which is going to be added in place of member_out
+    /// @param commit_quorum Commit quorum to be used for this operation. If 0, it will use the default commit quorum.
+    /// @return A Future on replace the member accepted or Future ReplServiceError upon error
+    virtual AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
                                                    const replica_member_info& member_in, uint32_t commit_quorum = 0,
                                                    uint64_t trace_id = 0) const = 0;
-
-    virtual AsyncReplResult<> complete_replace_member(group_id_t group_id, const replica_member_info& member_out,
-                                                      const replica_member_info& member_in, uint32_t commit_quorum = 0,
-                                                      uint64_t trace_id = 0) const = 0;
 
     virtual AsyncReplResult<> flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target, uint32_t commit_quorum,
                                         bool wait_and_verify = true, uint64_t trace_id = 0) const = 0;

--- a/src/lib/common/homestore_config.fbs
+++ b/src/lib/common/homestore_config.fbs
@@ -297,6 +297,9 @@ table Consensus {
 
     // The time to wait for config change to be applied in ms
     wait_for_config_change_ms: uint32 = 500;
+
+    // The interval in ms to check if the new member in replace_member is fully synced and ready to take over
+    replace_member_sync_check_interval_ms: uint64 = 60000;
 }
 
 table HomeStoreSettings {

--- a/src/lib/common/homestore_config.fbs
+++ b/src/lib/common/homestore_config.fbs
@@ -250,7 +250,8 @@ table Consensus {
     stale_log_gap_lo_threshold: int32 = 30;
 
     // Minimum log gap a replica has to be from leader before joining the replica set.
-    min_log_gap_to_join: int32 = 2147483647;
+    // 0 indicates the new member will join in cluster immediately.
+    min_log_gap_to_join: int32 = 0;
     
     // amount of time in millis to wait on data write before fetch data from remote;
     wait_data_write_timer_ms: uint64 = 1500 (hotswap);
@@ -290,6 +291,12 @@ table Consensus {
     // then decay the target_priority and wait again until its priority >= target_priority. This setting helps us to set proper priority for peers.
     // 0 means all members have the same priority.
     max_wait_rounds_of_priority_election: uint32 = 2;
+
+    // Maximum number of retries when raft is undergoing config changing
+    config_changing_error_retries: int32 = 3;
+
+    // The time to wait for config change to be applied in ms
+    wait_for_config_change_ms: uint32 = 500;
 }
 
 table HomeStoreSettings {

--- a/src/lib/common/homestore_utils.hpp
+++ b/src/lib/common/homestore_utils.hpp
@@ -53,4 +53,8 @@ public:
     static bool topological_sort(std::unordered_map< std::string, std::vector< std::string > >& DAG,
                                  std::vector< std::string >& ordered_entries);
 };
+
+static bool wait_and_check(const std::function< bool() >& check_func, uint32_t timeout_ms,
+                           uint32_t interval_ms = 100);
+
 } // namespace homestore

--- a/src/lib/replication/repl_dev/common.cpp
+++ b/src/lib/replication/repl_dev/common.cpp
@@ -266,7 +266,7 @@ std::string repl_req_ctx::to_string() const {
 }
 
 std::string repl_req_ctx::to_compact_string() const {
-    if (m_op_code == journal_type_t::HS_CTRL_DESTROY || m_op_code == journal_type_t::HS_CTRL_START_REPLACE || m_op_code == journal_type_t::HS_CTRL_START_REPLACE) {
+    if (m_op_code == journal_type_t::HS_CTRL_DESTROY || m_op_code == journal_type_t::HS_CTRL_START_REPLACE || m_op_code == journal_type_t::HS_CTRL_COMPLETE_REPLACE) {
         return fmt::format("term={} lsn={} op={}", m_rkey.term, m_lsn, enum_name(m_op_code));
     }
 

--- a/src/lib/replication/repl_dev/common.cpp
+++ b/src/lib/replication/repl_dev/common.cpp
@@ -266,7 +266,7 @@ std::string repl_req_ctx::to_string() const {
 }
 
 std::string repl_req_ctx::to_compact_string() const {
-    if (m_op_code == journal_type_t::HS_CTRL_DESTROY || m_op_code == journal_type_t::HS_CTRL_REPLACE) {
+    if (m_op_code == journal_type_t::HS_CTRL_DESTROY || m_op_code == journal_type_t::HS_CTRL_START_REPLACE || m_op_code == journal_type_t::HS_CTRL_START_REPLACE) {
         return fmt::format("term={} lsn={} op={}", m_rkey.term, m_lsn, enum_name(m_op_code));
     }
 

--- a/src/lib/replication/repl_dev/common.h
+++ b/src/lib/replication/repl_dev/common.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <boost/intrusive_ptr.hpp>
-
+#include <random>
 #include <homestore/replication/repl_decls.h>
 #include <homestore/replication_service.hpp>
 #include <homestore/replication/repl_dev.h>
@@ -93,6 +93,13 @@ auto make_async_success(V v) {
 template < class V = folly::Unit >
 auto make_async_success() {
     return folly::makeSemiFuture< ReplResult< folly::Unit > >(folly::Unit{});
+}
+
+inline uint64_t generateRandomTraceId() {
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::uniform_int_distribution< uint64_t > dis;
+    return dis(gen);
 }
 
 } // namespace homestore

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -16,6 +16,7 @@
 
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 #include <boost/intrusive_ptr.hpp>
+#include <boost/uuid/nil_generator.hpp>
 
 #include <homestore/replication_service.hpp>
 #include <homestore/replication/repl_dev.h>
@@ -61,12 +62,8 @@ public:
     bool is_leader() const override { return true; }
     replica_id_t get_leader_id() const override { return m_group_id; }
     std::vector< peer_info > get_replication_status() const override {
-        return std::vector< peer_info >{peer_info{.id_ = m_group_id,
-                                                  .replication_idx_ = 0,
-                                                  .last_succ_resp_us_ = 0,
-                                                  .priority_ = 1,
-                                                  .is_learner_ = false,
-                                                  .is_new_joiner_ = false}};
+        return std::vector< peer_info >{
+            peer_info{.id_ = m_group_id, .replication_idx_ = 0, .last_succ_resp_us_ = 0, .priority_ = 1, .is_self_ = true}};
     }
     bool is_ready_for_traffic() const override { return true; }
     void purge() override {}

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -63,7 +63,7 @@ public:
     replica_id_t get_leader_id() const override { return m_group_id; }
     std::vector< peer_info > get_replication_status() const override {
         return std::vector< peer_info >{
-            peer_info{.id_ = m_group_id, .replication_idx_ = 0, .last_succ_resp_us_ = 0, .priority_ = 1, .is_self_ = true}};
+            peer_info{.id_ = m_group_id, .replication_idx_ = 0, .last_succ_resp_us_ = 0, .priority_ = 1}};
     }
     bool is_ready_for_traffic() const override { return true; }
     void purge() override {}

--- a/src/lib/replication/service/generic_repl_svc.cpp
+++ b/src/lib/replication/service/generic_repl_svc.cpp
@@ -193,9 +193,20 @@ void SoloReplService::load_repl_dev(sisl::byte_view const& buf, void* meta_cooki
     }
 }
 
-AsyncReplResult<> SoloReplService::replace_member(group_id_t group_id, const replica_member_info& member_out,
-                                                  const replica_member_info& member_in, uint32_t commit_quorum,
-                                                  uint64_t trace_id) const {
+AsyncReplResult<> SoloReplService::start_replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                                        const replica_member_info& member_in, uint32_t commit_quorum,
+                                                        uint64_t trace_id) const {
+    return make_async_error<>(ReplServiceError::NOT_IMPLEMENTED);
+}
+
+AsyncReplResult<> SoloReplService::complete_replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                                           const replica_member_info& member_in, uint32_t commit_quorum,
+                                                           uint64_t trace_id) const {
+    return make_async_error<>(ReplServiceError::NOT_IMPLEMENTED);
+}
+
+AsyncReplResult<> SoloReplService::flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target,
+                                    uint32_t commit_quorum, bool wait_and_verify, uint64_t trace_id) const {
     return make_async_error<>(ReplServiceError::NOT_IMPLEMENTED);
 }
 

--- a/src/lib/replication/service/generic_repl_svc.cpp
+++ b/src/lib/replication/service/generic_repl_svc.cpp
@@ -193,15 +193,9 @@ void SoloReplService::load_repl_dev(sisl::byte_view const& buf, void* meta_cooki
     }
 }
 
-AsyncReplResult<> SoloReplService::start_replace_member(group_id_t group_id, const replica_member_info& member_out,
+AsyncReplResult<> SoloReplService::replace_member(group_id_t group_id, const replica_member_info& member_out,
                                                         const replica_member_info& member_in, uint32_t commit_quorum,
                                                         uint64_t trace_id) const {
-    return make_async_error<>(ReplServiceError::NOT_IMPLEMENTED);
-}
-
-AsyncReplResult<> SoloReplService::complete_replace_member(group_id_t group_id, const replica_member_info& member_out,
-                                                           const replica_member_info& member_in, uint32_t commit_quorum,
-                                                           uint64_t trace_id) const {
     return make_async_error<>(ReplServiceError::NOT_IMPLEMENTED);
 }
 

--- a/src/lib/replication/service/generic_repl_svc.h
+++ b/src/lib/replication/service/generic_repl_svc.h
@@ -89,9 +89,15 @@ public:
                                                          std::set< replica_id_t > const& members) override;
     folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) override;
     void load_repl_dev(sisl::byte_view const& buf, void* meta_cookie) override;
-    AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
-                                     const replica_member_info& member_in, uint32_t commit_quorum = 0,
-                                     uint64_t trace_id = 0) const override;
+    AsyncReplResult<> start_replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                           const replica_member_info& member_in, uint32_t commit_quorum = 0,
+                                           uint64_t trace_id = 0) const override;
+    AsyncReplResult<> complete_replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                              const replica_member_info& member_in, uint32_t commit_quorum = 0,
+                                              uint64_t trace_id = 0) const override;
+    AsyncReplResult<> flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target,
+                                        uint32_t commit_quorum, bool wait_and_verify = true,
+                                        uint64_t trace_id = 0) const override;
 };
 
 class SoloReplServiceCPHandler : public CPCallbacks {

--- a/src/lib/replication/service/generic_repl_svc.h
+++ b/src/lib/replication/service/generic_repl_svc.h
@@ -89,12 +89,9 @@ public:
                                                          std::set< replica_id_t > const& members) override;
     folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) override;
     void load_repl_dev(sisl::byte_view const& buf, void* meta_cookie) override;
-    AsyncReplResult<> start_replace_member(group_id_t group_id, const replica_member_info& member_out,
+    AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
                                            const replica_member_info& member_in, uint32_t commit_quorum = 0,
                                            uint64_t trace_id = 0) const override;
-    AsyncReplResult<> complete_replace_member(group_id_t group_id, const replica_member_info& member_out,
-                                              const replica_member_info& member_in, uint32_t commit_quorum = 0,
-                                              uint64_t trace_id = 0) const override;
     AsyncReplResult<> flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target,
                                         uint32_t commit_quorum, bool wait_and_verify = true,
                                         uint64_t trace_id = 0) const override;

--- a/src/lib/replication/service/raft_repl_service.h
+++ b/src/lib/replication/service/raft_repl_service.h
@@ -52,6 +52,7 @@ private:
     iomgr::timer_handle_t m_rdev_fetch_timer_hdl;
     iomgr::timer_handle_t m_rdev_gc_timer_hdl;
     iomgr::timer_handle_t m_flush_durable_commit_timer_hdl;
+    iomgr::timer_handle_t m_replace_member_sync_check_timer_hdl;
     iomgr::io_fiber_t m_reaper_fiber;
     std::mutex raft_restart_mutex;
 
@@ -78,12 +79,9 @@ protected:
                                                          std::set< replica_id_t > const& members) override;
     folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) override;
     void load_repl_dev(sisl::byte_view const& buf, void* meta_cookie) override;
-    AsyncReplResult<> start_replace_member(group_id_t group_id, const replica_member_info& member_out,
+    AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
                                            const replica_member_info& member_in, uint32_t commit_quorum = 0,
                                            uint64_t trace_id = 0) const override;
-    AsyncReplResult<> complete_replace_member(group_id_t group_id, const replica_member_info& member_out,
-                                              const replica_member_info& member_in, uint32_t commit_quorum,
-                                              uint64_t trace_id = 0) const override;
 
     AsyncReplResult<> flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target,
                                         uint32_t commit_quorum, bool wait_and_verify = true,
@@ -97,6 +95,7 @@ private:
     void gc_repl_devs();
     void gc_repl_reqs();
     void flush_durable_commit_lsn();
+    void check_replace_member_status();
     void monitor_cert_changes();
     void restart_raft_svc(const std::string filepath, const bool deleted);
     bool wait_for_cert(const std::string& filepath);

--- a/src/lib/replication/service/raft_repl_service.h
+++ b/src/lib/replication/service/raft_repl_service.h
@@ -78,9 +78,16 @@ protected:
                                                          std::set< replica_id_t > const& members) override;
     folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) override;
     void load_repl_dev(sisl::byte_view const& buf, void* meta_cookie) override;
-    AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
-                                     const replica_member_info& member_in, uint32_t commit_quorum = 0,
-                                     uint64_t trace_id = 0) const override;
+    AsyncReplResult<> start_replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                           const replica_member_info& member_in, uint32_t commit_quorum = 0,
+                                           uint64_t trace_id = 0) const override;
+    AsyncReplResult<> complete_replace_member(group_id_t group_id, const replica_member_info& member_out,
+                                              const replica_member_info& member_in, uint32_t commit_quorum,
+                                              uint64_t trace_id = 0) const override;
+
+    AsyncReplResult<> flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target,
+                                        uint32_t commit_quorum, bool wait_and_verify = true,
+                                        uint64_t trace_id = 0) const override;
 
 private:
     RaftReplDev* raft_group_config_found(sisl::byte_view const& buf, void* meta_cookie);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -130,7 +130,7 @@ if (${io_tests})
         add_test(NAME MetaBlkMgr-Epoll COMMAND test_meta_blk_mgr)
         add_test(NAME DataService-Epoll COMMAND test_data_service)
         add_test(NAME RaftReplDev-Epoll COMMAND test_raft_repl_dev)
-        # add_test(NAME RaftReplDevDynamic-Epoll COMMAND test_raft_repl_dev_dynamic)
+        add_test(NAME RaftReplDevDynamic-Epoll COMMAND test_raft_repl_dev_dynamic --override_config homestore_config.consensus.replace_member_sync_check_interval_ms=1000)
         add_test(NAME SoloReplDev-Epoll COMMAND test_solo_repl_dev)
     endif()
 

--- a/src/tests/test_common/hs_repl_test_common.hpp
+++ b/src/tests/test_common/hs_repl_test_common.hpp
@@ -301,7 +301,8 @@ public:
 
             auto v = hs()->repl_service().create_repl_dev(repl_group_id, members).get();
             ASSERT_EQ(v.hasValue(), true)
-                << "Error in creating repl dev for group_id=" << boost::uuids::to_string(repl_group_id).c_str();
+                << "Error in creating repl dev for group_id=" << boost::uuids::to_string(repl_group_id).c_str()
+                << ", err=" << v.error();
             auto& raftService = dynamic_cast< RaftReplService& >(hs()->repl_service());
             auto follower_priority = raftService.compute_raft_follower_priority();
             auto repl_dev = v.value();

--- a/src/tests/test_common/raft_repl_test_base.hpp
+++ b/src/tests/test_common/raft_repl_test_base.hpp
@@ -742,7 +742,7 @@ public:
     void create_snapshot() { dbs_[0]->create_snapshot(); }
     void truncate(int num_reserved_entries) { dbs_[0]->truncate(num_reserved_entries); }
 
-    void start_replace_member(std::shared_ptr< TestReplicatedDB > db, replica_id_t member_out, replica_id_t member_in,
+    void replace_member(std::shared_ptr< TestReplicatedDB > db, replica_id_t member_out, replica_id_t member_in,
                         uint32_t commit_quorum = 0, ReplServiceError error = ReplServiceError::OK) {
         this->run_on_leader(db, [this, error, db, member_out, member_in, commit_quorum]() {
             LOGINFO("Start replace member out={} in={}", boost::uuids::to_string(member_out),
@@ -750,32 +750,12 @@ public:
 
             replica_member_info out{member_out, ""};
             replica_member_info in{member_in, ""};
-            auto result = hs()->repl_service().start_replace_member(db->repl_dev()->group_id(), out, in, commit_quorum).get();
+            auto result = hs()->repl_service().replace_member(db->repl_dev()->group_id(), out, in, commit_quorum).get();
             if (error == ReplServiceError::OK) {
                 ASSERT_EQ(result.hasError(), false) << "Error in replacing member, err=" << result.error();
             } else {
-                ASSERT_EQ(result.hasError(), true) << "Error in replacing member, err="<< result.error();
-                ASSERT_EQ(result.error(), error);
-            }
-        });
-    }
-
-    void complete_replace_member(std::shared_ptr< TestReplicatedDB > db, replica_id_t member_out,
-                                 replica_id_t member_in, uint32_t commit_quorum = 0,
-                                 ReplServiceError error = ReplServiceError::OK) {
-        this->run_on_leader(db, [this, error, db, member_out, member_in, commit_quorum]() {
-            LOGINFO("Complete replace member out={} in={}", boost::uuids::to_string(member_out),
-                    boost::uuids::to_string(member_in));
-
-            replica_member_info out{member_out, ""};
-            replica_member_info in{member_in, ""};
-            auto result =
-                hs()->repl_service().complete_replace_member(db->repl_dev()->group_id(), out, in, commit_quorum).get();
-            if (error == ReplServiceError::OK) {
-                ASSERT_EQ(result.hasError(), false) << "Error in replacing member, err=" << result.error();
-            } else {
-                ASSERT_EQ(result.hasError(), true) << "Error in replacing member, err=" << result.error();
-                ASSERT_EQ(result.error(), error);
+                ASSERT_EQ(result.hasError(), true);
+                ASSERT_EQ(result.error(), error) << "Error in replacing member, err=" << result.error();
             }
         });
     }

--- a/src/tests/test_common/raft_repl_test_base.hpp
+++ b/src/tests/test_common/raft_repl_test_base.hpp
@@ -48,7 +48,7 @@
 using namespace homestore;
 
 SISL_LOGGING_DEF(test_raft_repl_dev)
-SISL_LOGGING_INIT(HOMESTORE_LOG_MODS, nuraft_mesg)
+SISL_LOGGING_INIT(HOMESTORE_LOG_MODS, nuraft_mesg, nuraft)
 
 SISL_OPTION_GROUP(test_raft_repl_dev,
                   (block_size, "", "block_size", "block size to io",
@@ -344,8 +344,13 @@ public:
         }
         return blk_alloc_hints{};
     }
-    void on_replace_member(const replica_member_info& member_out, const replica_member_info& member_in) override {
-        LOGINFO("[Replica={}] replace member out {} in {}", g_helper->replica_num(),
+    void on_start_replace_member(const replica_member_info& member_out, const replica_member_info& member_in, trace_id_t tid) override {
+        LOGINFO("[Replica={}] start replace member out {} in {}", g_helper->replica_num(),
+                boost::uuids::to_string(member_out.id), boost::uuids::to_string(member_in.id));
+    }
+
+    void on_complete_replace_member(const replica_member_info& member_out, const replica_member_info& member_in, trace_id_t tid) override {
+        LOGINFO("[Replica={}] complete replace member out {} in {}", g_helper->replica_num(),
                 boost::uuids::to_string(member_out.id), boost::uuids::to_string(member_in.id));
     }
 
@@ -737,19 +742,39 @@ public:
     void create_snapshot() { dbs_[0]->create_snapshot(); }
     void truncate(int num_reserved_entries) { dbs_[0]->truncate(num_reserved_entries); }
 
-    void replace_member(std::shared_ptr< TestReplicatedDB > db, replica_id_t member_out, replica_id_t member_in,
+    void start_replace_member(std::shared_ptr< TestReplicatedDB > db, replica_id_t member_out, replica_id_t member_in,
                         uint32_t commit_quorum = 0, ReplServiceError error = ReplServiceError::OK) {
         this->run_on_leader(db, [this, error, db, member_out, member_in, commit_quorum]() {
-            LOGINFO("Replace member out={} in={}", boost::uuids::to_string(member_out),
+            LOGINFO("Start replace member out={} in={}", boost::uuids::to_string(member_out),
                     boost::uuids::to_string(member_in));
 
             replica_member_info out{member_out, ""};
             replica_member_info in{member_in, ""};
-            auto result = hs()->repl_service().replace_member(db->repl_dev()->group_id(), out, in, commit_quorum).get();
+            auto result = hs()->repl_service().start_replace_member(db->repl_dev()->group_id(), out, in, commit_quorum).get();
             if (error == ReplServiceError::OK) {
-                ASSERT_EQ(result.hasError(), false) << "Error in replacing member";
+                ASSERT_EQ(result.hasError(), false) << "Error in replacing member, err=" << result.error();
             } else {
-                ASSERT_EQ(result.hasError(), true) << "Error in replacing member";
+                ASSERT_EQ(result.hasError(), true) << "Error in replacing member, err="<< result.error();
+                ASSERT_EQ(result.error(), error);
+            }
+        });
+    }
+
+    void complete_replace_member(std::shared_ptr< TestReplicatedDB > db, replica_id_t member_out,
+                                 replica_id_t member_in, uint32_t commit_quorum = 0,
+                                 ReplServiceError error = ReplServiceError::OK) {
+        this->run_on_leader(db, [this, error, db, member_out, member_in, commit_quorum]() {
+            LOGINFO("Complete replace member out={} in={}", boost::uuids::to_string(member_out),
+                    boost::uuids::to_string(member_in));
+
+            replica_member_info out{member_out, ""};
+            replica_member_info in{member_in, ""};
+            auto result =
+                hs()->repl_service().complete_replace_member(db->repl_dev()->group_id(), out, in, commit_quorum).get();
+            if (error == ReplServiceError::OK) {
+                ASSERT_EQ(result.hasError(), false) << "Error in replacing member, err=" << result.error();
+            } else {
+                ASSERT_EQ(result.hasError(), true) << "Error in replacing member, err=" << result.error();
                 ASSERT_EQ(result.error(), error);
             }
         });

--- a/src/tests/test_solo_repl_dev.cpp
+++ b/src/tests/test_solo_repl_dev.cpp
@@ -131,7 +131,8 @@ public:
                       cintrusive< repl_req_ctx >& ctx) override {
             LOGINFO("Received error={} on repl_dev", enum_name(error));
         }
-        void on_replace_member(const replica_member_info& member_out, const replica_member_info& member_in) override {}
+        void on_start_replace_member(const replica_member_info& member_out, const replica_member_info& member_in, trace_id_t tid) override {}
+        void on_complete_replace_member(const replica_member_info& member_out, const replica_member_info& member_in, trace_id_t tid) override {}
         void on_destroy(const group_id_t& group_id) override {}
         void notify_committed_lsn(int64_t lsn) override {}
         void on_config_rollback(int64_t lsn) override {}


### PR DESCRIPTION
Design doc:
https://docs.google.com/document/d/18vtBbasnBH6cpxQ4NWwzSM3uWkRfqnEJpElBmmSJPt4/edit?tab=t.0#heading=h.ypyu7i2i9xj6

Changes:
Split replace_member into two phases: start_repalce_member and complete_replace_member.
For the sake of data durability and safety, we set the old member as learner first, only when the new member is fully replicated, we will perform the actual removal.
Add a reaper thread to check and complete replace member.

HO changes: https://github.com/eBay/HomeObject/pull/302/files