### PR TITLE
fix append allocator free

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.16.1"
+    version = "6.16.2"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/blkalloc/append_blk_allocator.cpp
+++ b/src/lib/blkalloc/append_blk_allocator.cpp
@@ -138,8 +138,16 @@ void AppendBlkAllocator::cp_flush(CP* cp) {
 
 // free operation books keeping "total freeable" space
 void AppendBlkAllocator::free(const BlkId& bid) {
-    m_freeable_nblks.fetch_add(bid.blk_count());
-    m_is_dirty.store(true);
+    if (is_blk_alloced(bid)) {
+        m_freeable_nblks.fetch_add(bid.blk_count());
+        m_is_dirty.store(true);
+        return;
+    }
+    // we have no lock in append_blk_allocator, so there is a corner case that
+    //  is_blk_alloced(bid) is true, so we lost the update of m_freeable_nblks.
+    //  should we involve a lock here?
+    LOGWARN("Trying to free an unallocated block: {} , m_last_append_offset is {}", bid,
+            m_last_append_offset.load(std::memory_order_relaxed));
 }
 
 bool AppendBlkAllocator::is_blk_alloced(const BlkId& in_bid, bool) const {


### PR DESCRIPTION
we need to check if the blk to be freed is an alloced blk. if yes , free it. if no, do not increase the counter.
in homeobject gc, some times a blk free will hit the chunk which is already reset and reused since we always async_free