### PR TITLE
determine proposer based on server_id

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.16.2"
+    version = "6.16.3"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -882,7 +882,7 @@ repl_req_ptr_t RaftReplDev::applier_create_req(repl_key const& rkey, journal_typ
     }
 
     // rreq->init will allocate the block if it has linked data.
-    auto status = init_req_ctx(rreq, rkey, code, false /* is_proposer */, user_header, key, data_size, m_listener);
+    auto status = init_req_ctx(rreq, rkey, code, m_raft_server_id == rkey.server_id, user_header, key, data_size, m_listener);
 
     if (status != ReplServiceError::OK) {
         RD_LOGD(rkey.traceID, "For Repl_key=[{}] alloc hints returned error={}, failing this req", rkey.to_string(),


### PR DESCRIPTION
Fix leader crash issue:
Leader is re-elected as leader between 1 and 3, and during append log step, it cannot find rreq due to the change of term, so try to fetch data (act as follower). Then crash at fetch failed because it cannot find the client to itself.

1. Push data to all followers Data push completed for `dsn=12796 term=6`
2. Alloc local blk and write data
3. Propose to raft  with `server_id=642347589, term=7  `