### PR TITLE
add on_reject to repl_req_ctx

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.16.4"
+    version = "6.17.0"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -45,6 +45,7 @@ ReplServiceError RaftStateMachine::propose_to_raft(repl_req_ptr_t rreq) {
     if (append_status && !append_status->get_accepted()) {
         RD_LOGE(rreq->traceID(), "Raft Channel: Failed to propose rreq=[{}] result_code={}", rreq->to_compact_string(),
                 append_status->get_result_code());
+        rreq->on_reject();
         return RaftReplService::to_repl_error(append_status->get_result_code());
     }
     return ReplServiceError::OK;


### PR DESCRIPTION
if leader try to propose a new log to raft and before this log is appended to log store, this leader changes to follower, then raft_server#drop_all_pending_commit_elems will be called, in which this new log(request) will be dropped. this means this req will be rejected, and will not be committed , nor rolled back. in this case, we need notify upperlayer through this virtual function.

in homeobject, we can use this callback to notify the upper layer. otherwise, it will stuck there. for example, for put_blob, if this req is rejected, then the ThenValue of put blob will not be called and the request will never be completed, since we set value for the promise in the put_blob_rreq only in on_commit or on_rollback