### PR TITLE
Add a get_replace_member_status API for upper layer to query status

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -54,7 +54,7 @@ class HomestoreConan(ConanFile):
     def requirements(self):
         self.requires("iomgr/[^11.3]@oss/master", transitive_headers=True)
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
-        self.requires("nuraft_mesg/[~3.8.0]@oss/main", transitive_headers=True)
+        self.requires("nuraft_mesg/[~3.8.4]@oss/main", transitive_headers=True)
 
         self.requires("farmhash/cci.20190513@", transitive_headers=True)
         if self.settings.arch in ['x86', 'x86_64']:

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.16.4"
+    version = "6.17.0"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_decls.h
+++ b/src/include/homestore/replication/repl_decls.h
@@ -38,7 +38,16 @@ VENUM(ReplServiceError, int32_t,
       DATA_DUPLICATED = -20002,
       QUIENCE_STATE = -20003,
       QUORUM_NOT_MET = -20004,
+      REPLACE_MEMBER_TASK_MISMATCH = -20005,
       FAILED = -32768);
+
+VENUM(ReplaceMemberStatus, int32_t,
+      COMPLETED = 0,
+      IN_PROGRESS = 1,
+      NOT_LEADER = 2,
+      TASK_ID_MISMATCH = 3,
+      TASK_NOT_FOUND = 4,
+      UNKNOWN = 5);
 // clang-format on
 
 template < typename V, typename E >

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -369,11 +369,11 @@ public:
     virtual void on_destroy(const group_id_t& group_id) = 0;
 
     /// @brief Called when start replace member.
-    virtual void on_start_replace_member(const replica_member_info& member_out, const replica_member_info& member_in,
+    virtual void on_start_replace_member(const uuid_t& task_id, const replica_member_info& member_out, const replica_member_info& member_in,
                                          trace_id_t tid) = 0;
 
     /// @brief Called when complete replace member.
-    virtual void on_complete_replace_member(const replica_member_info& member_out, const replica_member_info& member_in,
+    virtual void on_complete_replace_member(const uuid_t& task_id, const replica_member_info& member_out, const replica_member_info& member_in,
                                             trace_id_t tid) = 0;
 
     /// @brief Called when the snapshot is being created by nuraft

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -43,16 +43,31 @@ public:
 
     /// @brief Replace one of the members with a new one.
     /// @param group_id Group where the replace member happens
+    /// @param task_id Id of the task which is going to be used for this operation. This is used to track the replace member.
     /// @param member_out The member which is going to be replaced
     /// @param member_in The member which is going to be added in place of member_out
     /// @param commit_quorum Commit quorum to be used for this operation. If 0, it will use the default commit quorum.
     /// @return A Future on replace the member accepted or Future ReplServiceError upon error
-    virtual AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
+    virtual AsyncReplResult<> replace_member(group_id_t group_id, uuid_t task_id, const replica_member_info& member_out,
                                                    const replica_member_info& member_in, uint32_t commit_quorum = 0,
                                                    uint64_t trace_id = 0) const = 0;
 
     virtual AsyncReplResult<> flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target, uint32_t commit_quorum,
                                         bool wait_and_verify = true, uint64_t trace_id = 0) const = 0;
+
+    /// @brief Get status of member replacement.
+    /// @param group_id Group where the replace member happens
+    /// @param task_id Id of the replace member task. This is used to track the replace
+    /// @param member_out The member which is going to be replaced
+    /// @param member_in The member which is going to be added in place of member_out
+    /// @param others Other members excluding member_out, member_in
+    /// @return ReplaceMemberStatus
+    virtual ReplaceMemberStatus get_replace_member_status(group_id_t group_id, uuid_t task_id,
+                                                          const replica_member_info& member_out,
+                                                          const replica_member_info& member_in,
+                                                          const std::vector< replica_member_info >& others,
+                                                          uint64_t trace_id = 0) const = 0;
+
     /// @brief Get the repl dev for a given group id if it is already created or opened
     /// @param group_id Group id interested in
     /// @return ReplDev is opened or ReplServiceError::SERVER_NOT_FOUND if it doesn't exist

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -1530,10 +1530,11 @@ void RaftReplDev::handle_error(repl_req_ptr_t const& rreq, ReplServiceError err)
 void RaftReplDev::start_replace_member(repl_req_ptr_t rreq) {
     auto ctx = r_cast< const replace_member_ctx* >(rreq->header().cbytes());
 
-    RD_LOGI(rreq->traceID(), "Raft repl start_replace_member commit member_out={} member_in={}",
-            boost::uuids::to_string(ctx->replica_out.id), boost::uuids::to_string(ctx->replica_in.id));
+    RD_LOGI(rreq->traceID(), "Raft repl start_replace_member commit, task_id={} member_out={} member_in={}",
+            boost::uuids::to_string(ctx->task_id), boost::uuids::to_string(ctx->replica_out.id),
+            boost::uuids::to_string(ctx->replica_in.id));
 
-    m_listener->on_start_replace_member(ctx->replica_out, ctx->replica_in, rreq->traceID());
+    m_listener->on_start_replace_member(ctx->task_id, ctx->replica_out, ctx->replica_in, rreq->traceID());
     // record the replace_member intent
     std::unique_lock lg{m_sb_mtx};
     m_rd_sb->replace_member_task.task_id = ctx->task_id;
@@ -1545,10 +1546,11 @@ void RaftReplDev::start_replace_member(repl_req_ptr_t rreq) {
 void RaftReplDev::complete_replace_member(repl_req_ptr_t rreq) {
     auto ctx = r_cast< const replace_member_ctx* >(rreq->header().cbytes());
 
-    RD_LOGI(rreq->traceID(), "Raft repl complete_replace_member commit member_out={} member_in={}",
-            boost::uuids::to_string(ctx->replica_out.id), boost::uuids::to_string(ctx->replica_in.id));
+    RD_LOGI(rreq->traceID(), "Raft repl complete_replace_member commit, task_id={} member_out={} member_in={}",
+            boost::uuids::to_string(ctx->task_id), boost::uuids::to_string(ctx->replica_out.id),
+            boost::uuids::to_string(ctx->replica_in.id));
 
-    m_listener->on_complete_replace_member(ctx->replica_out, ctx->replica_in, rreq->traceID());
+    m_listener->on_complete_replace_member(ctx->task_id, ctx->replica_out, ctx->replica_in, rreq->traceID());
 
     // clear the replace_member intent
     std::unique_lock lg{m_sb_mtx};

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -138,7 +138,7 @@ bool RaftReplDev::join_group() {
 }
 
 // All the steps in the implementation should be idempotent and retryable.
-AsyncReplResult<> RaftReplDev::start_replace_member(const replica_member_info& member_out,
+AsyncReplResult<> RaftReplDev::start_replace_member(uuid_t task_id, const replica_member_info& member_out,
                                                     const replica_member_info& member_in, uint32_t commit_quorum,
                                                     uint64_t trace_id) {
     if (is_stopping()) {
@@ -147,34 +147,37 @@ AsyncReplResult<> RaftReplDev::start_replace_member(const replica_member_info& m
     }
     incr_pending_request_num();
 
-    RD_LOGI(trace_id, "Start replace member, member_out={} member_in={}", boost::uuids::to_string(member_out.id),
-            boost::uuids::to_string(member_in.id));
-
-    if (commit_quorum >= 1) {
-        // Two members are down and leader cant form the quorum. Reduce the quorum size.
-        reset_quorum_size(commit_quorum, trace_id);
-    }
+    RD_LOGI(trace_id, "Start replace member, task_id={}, member_out={} member_in={}", boost::uuids::to_string(task_id),
+            boost::uuids::to_string(member_out.id), boost::uuids::to_string(member_in.id));
 
     // Step1, validate request
+    // TODO support rollback, this could happen when the first task failed, and we want to launch a new task to
+    // remediate it. Need to rollback the first task. And for the same task, it's reentrant and idempotent.
+    if (!m_rd_sb->replace_member_task.task_id.is_nil() && m_rd_sb->replace_member_task.task_id != task_id) {
+        RD_LOGE(trace_id, "Step1. Replace member, task_id={} is not the same as existing task_id={}",
+                boost::uuids::to_string(task_id), boost::uuids::to_string(m_rd_sb->replace_member_task.task_id));
+        decr_pending_request_num();
+        return make_async_error<>(ReplServiceError::REPLACE_MEMBER_TASK_MISMATCH);
+    }
+
     auto out_srv_cfg = raft_server()->get_config()->get_server(nuraft_mesg::to_server_id(member_out.id));
     if (!out_srv_cfg) {
         auto in_srv_cfg = raft_server()->get_config()->get_server(nuraft_mesg::to_server_id(member_in.id));
         if (in_srv_cfg) {
-            RD_LOGI(
-                trace_id,
-                "Step1. Replace member, the intent has already been fulfilled, ignore it, member_out={} member_in={}",
-                boost::uuids::to_string(member_out.id), boost::uuids::to_string(member_in.id));
-            reset_quorum_size(0, trace_id);
+            RD_LOGI(trace_id,
+                    "Step1. Replace member, the intent has already been fulfilled, ignore it, task_id={}, "
+                    "member_out={} member_in={}",
+                    boost::uuids::to_string(task_id), boost::uuids::to_string(member_out.id),
+                    boost::uuids::to_string(member_in.id));
             decr_pending_request_num();
             return make_async_success<>();
         }
-        RD_LOGE(trace_id, "Step1. Replace member invalid parameter, out member is not found");
-        reset_quorum_size(0, trace_id);
+        RD_LOGE(trace_id, "Step1. Replace member invalid parameter, out member is not found, task_id={}",
+                boost::uuids::to_string(task_id));
         decr_pending_request_num();
         return make_async_error<>(ReplServiceError::SERVER_NOT_FOUND);
     }
     if (m_my_repl_id != get_leader_id()) {
-        reset_quorum_size(0, trace_id);
         decr_pending_request_num();
         return make_async_error<>(ReplServiceError::NOT_LEADER);
     }
@@ -184,8 +187,8 @@ AsyncReplResult<> RaftReplDev::start_replace_member(const replica_member_info& m
         // until the successor finishes the catch-up of the latest log, and then resign. Return NOT_LEADER and let
         // client retry.
         raft_server()->yield_leadership(false /* immediate */, -1 /* successor */);
-        RD_LOGI(trace_id, "Step1. Replace member, leader is the member_out so yield leadership");
-        reset_quorum_size(0, trace_id);
+        RD_LOGI(trace_id, "Step1. Replace member, leader is the member_out so yield leadership, task_id={}",
+                boost::uuids::to_string(task_id));
         decr_pending_request_num();
         return make_async_error<>(ReplServiceError::NOT_LEADER);
     }
@@ -199,18 +202,24 @@ AsyncReplResult<> RaftReplDev::start_replace_member(const replica_member_info& m
     }
     RD_LOGD(trace_id,
             "Step1. Replace member, quorum safety check, active_peers={}, active_peers_exclude_out/in_member={}, "
-            "commit_quorum={}",
-            active_peers.size(), active_num, commit_quorum);
+            "commit_quorum={}, task_id={}",
+            active_peers.size(), active_num, commit_quorum, boost::uuids::to_string(task_id));
     // commit_quorum=0 means actual commit quorum is the majority. In this case, active normal member count should be
     // >= majority. To be more specific, if we have S1(leader), S2, S3(out), S4(in), we don't allow
     // replace_member(S3, S4) if S2 is down or laggy. Needs to recover S2 first or retry with commit_quorum=1.
     auto quorum = get_quorum_for_commit();
     if (active_num < quorum && commit_quorum == 0) {
-        RD_LOGE(trace_id, "Step1. Replace member, quorum safety check failed, active_peers={}, active_peers_exclude_out/in_member={}, required_quorum={}, commit_quorum={}",
-                active_peers.size(), active_num, quorum, commit_quorum);
-        reset_quorum_size(0, trace_id);
+        RD_LOGE(trace_id,
+                "Step1. Replace member, quorum safety check failed, active_peers={}, "
+                "active_peers_exclude_out/in_member={}, required_quorum={}, commit_quorum={}, task_id={}",
+                active_peers.size(), active_num, quorum, commit_quorum, boost::uuids::to_string(task_id));
         decr_pending_request_num();
         return make_async_error<>(ReplServiceError::QUORUM_NOT_MET);
+    }
+
+    if (commit_quorum >= 1) {
+        // Two members are down and leader cant form the quorum. Reduce the quorum size.
+        reset_quorum_size(commit_quorum, trace_id);
     }
 
     // Step 2: Handle out member.
@@ -220,25 +229,29 @@ AsyncReplResult<> RaftReplDev::start_replace_member(const replica_member_info& m
         return make_async_error(ReplServiceError::FAILED);
     }
 #endif
-    RD_LOGI(trace_id, "Step2. Replace member, flip out member to learner");
+    RD_LOGI(trace_id, "Step2. Replace member, flip out member to learner, task_id={}",
+            boost::uuids::to_string(task_id));
     auto learner_ret = do_flip_learner(member_out, true, true, trace_id);
     if (learner_ret != ReplServiceError::OK) {
-        RD_LOGE(trace_id, "Step2. Replace member, failed to flip out member to learner {}", learner_ret);
+        RD_LOGE(trace_id, "Step2. Replace member, failed to flip out member to learner {}, task_id={}", learner_ret,
+                boost::uuids::to_string(task_id));
         reset_quorum_size(0, trace_id);
         decr_pending_request_num();
         return make_async_error(std::move(learner_ret));
     }
-    RD_LOGI(trace_id, "Step2. Replace member, flip out member to learner and set priority to 0");
+    RD_LOGI(trace_id, "Step2. Replace member, flip out member to learner and set priority to 0, task_id={}",
+            boost::uuids::to_string(task_id));
 
     // Step 3. Append log entry to mark the old member is out and new member is added.
-    RD_LOGI(trace_id, "Step3. Replace member, propose to raft for HS_CTRL_START_REPLACE req, group_id={}",
-            group_id_str());
+    RD_LOGI(trace_id, "Step3. Replace member, propose to raft for HS_CTRL_START_REPLACE req, group_id={}, task_id={}",
+            boost::uuids::to_string(task_id), group_id_str());
     auto rreq = repl_req_ptr_t(new repl_req_ctx{});
-    replace_member_ctx members;
-    members.replica_out = member_out;
-    members.replica_in = member_in;
+    replace_member_ctx ctx;
+    ctx.task_id = task_id;
+    ctx.replica_out = member_out;
+    ctx.replica_in = member_in;
 
-    sisl::blob header(r_cast< uint8_t* >(&members), sizeof(replace_member_ctx));
+    sisl::blob header(r_cast< uint8_t* >(&ctx), sizeof(replace_member_ctx));
     rreq->init(repl_key{.server_id = server_id(),
                         .term = raft_server()->get_term(),
                         .dsn = m_next_dsn.fetch_add(1),
@@ -247,7 +260,9 @@ AsyncReplResult<> RaftReplDev::start_replace_member(const replica_member_info& m
 
     auto err = m_state_machine->propose_to_raft(std::move(rreq));
     if (err != ReplServiceError::OK) {
-        RD_LOGE(trace_id, "Step3. Replace member, propose to raft for HS_CTRL_START_REPLACE req failed {}", err);
+        RD_LOGE(trace_id,
+                "Step3. Replace member, propose to raft for HS_CTRL_START_REPLACE req failed, task_id={}, err={}",
+                boost::uuids::to_string(task_id), err);
         reset_quorum_size(0, trace_id);
         decr_pending_request_num();
         return make_async_error<>(std::move(err));
@@ -260,21 +275,24 @@ AsyncReplResult<> RaftReplDev::start_replace_member(const replica_member_info& m
         return make_async_error(ReplServiceError::FAILED);
     }
 #endif
-    RD_LOGI(trace_id, "Step4. Replace member, propose to raft to add new member, group_id={}", group_id_str());
+    RD_LOGI(trace_id, "Step4. Replace member, propose to raft to add new member, group_id={}, task_id={}",
+            group_id_str(), boost::uuids::to_string(task_id));
     auto ret = do_add_member(member_in, trace_id);
     if (ret != ReplServiceError::OK) {
-        RD_LOGE(trace_id, "Step4. Replace member, add member failed {}", ret);
+        RD_LOGE(trace_id, "Step4. Replace member, add member failed, err={}, task_id={}", ret,
+                boost::uuids::to_string(task_id));
         reset_quorum_size(0, trace_id);
         decr_pending_request_num();
         return make_async_error<>(std::move(ret));
     }
-    RD_LOGI(trace_id, "Step4. Replace member, proposed to raft to add member, member={}", boost::uuids::to_string(member_in.id));
+    RD_LOGI(trace_id, "Step4. Replace member, proposed to raft to add member, task_id={}, member={}",
+            boost::uuids::to_string(task_id), boost::uuids::to_string(member_in.id));
     reset_quorum_size(0, trace_id);
     decr_pending_request_num();
     return make_async_success<>();
 }
 
-AsyncReplResult<> RaftReplDev::complete_replace_member(const replica_member_info& member_out,
+AsyncReplResult<> RaftReplDev::complete_replace_member(uuid_t task_id, const replica_member_info& member_out,
                                                        const replica_member_info& member_in, uint32_t commit_quorum,
                                                        uint64_t trace_id) {
     if (is_stopping()) {
@@ -283,8 +301,9 @@ AsyncReplResult<> RaftReplDev::complete_replace_member(const replica_member_info
     }
     incr_pending_request_num();
 
-    RD_LOGI(trace_id, "Complete replace member, member={}", boost::uuids::to_string(member_out.id),
-            boost::uuids::to_string(member_out.id));
+    RD_LOGI(trace_id, "Complete replace member, task_id={}, member_out={}, member_in={}",
+            boost::uuids::to_string(task_id), boost::uuids::to_string(member_out.id),
+            boost::uuids::to_string(member_in.id));
 
     if (commit_quorum >= 1) {
         // Two members are down and leader cant form the quorum. Reduce the quorum size.
@@ -292,7 +311,8 @@ AsyncReplResult<> RaftReplDev::complete_replace_member(const replica_member_info
     }
 
     // Step 5: Remove member
-    RD_LOGI(trace_id, "Step5. Replace member, remove old member, member={}", boost::uuids::to_string(member_out.id));
+    RD_LOGI(trace_id, "Step5. Replace member, remove old member, task_id={}, member={}",
+            boost::uuids::to_string(task_id), boost::uuids::to_string(member_out.id));
 #ifdef _PRERELEASE
     if (iomgr_flip::instance()->test_flip("replace_member_remove_member_failure")) {
         RD_LOGE(trace_id, "Simulating remove member failure");
@@ -301,14 +321,14 @@ AsyncReplResult<> RaftReplDev::complete_replace_member(const replica_member_info
 #endif
     auto ret = do_remove_member(member_out, trace_id);
     if (ret != ReplServiceError::OK) {
-        RD_LOGE(trace_id, "Step5. Replace member, failed to remove member, member={}, err={}",
-                boost::uuids::to_string(member_out.id), ret);
+        RD_LOGE(trace_id, "Step5. Replace member, failed to remove member, task_id={}, member={}, err={}",
+                boost::uuids::to_string(task_id), boost::uuids::to_string(member_out.id), ret);
         reset_quorum_size(0, trace_id);
         decr_pending_request_num();
         return make_async_error<>(std::move(ret));
     }
-    RD_LOGI(trace_id, "Step5. Replace member, proposed to raft to remove member, member={}",
-            boost::uuids::to_string(member_out.id));
+    RD_LOGI(trace_id, "Step5. Replace member, proposed to raft to remove member, task_id={}, member={}",
+            boost::uuids::to_string(task_id), boost::uuids::to_string(member_out.id));
     auto timeout = HS_DYNAMIC_CONFIG(consensus.wait_for_config_change_ms);
     // TODO Move wait logic to nuraft_mesg
     if (!wait_and_check(
@@ -327,20 +347,22 @@ AsyncReplResult<> RaftReplDev::complete_replace_member(const replica_member_info
                 timeout);
         // If the member_out is down, leader will force remove it after
         // leave_timeout=leave_limit_(default=5)*heart_beat_interval_, it's better for client to retry it.
-        return make_async_error<>(ReplServiceError::CANCELLED);
+        return make_async_error<>(ReplServiceError::RETRY_REQUEST);
     }
-    RD_LOGD(trace_id, "Step5.  Replace member, old member is removed, member={}",
-            boost::uuids::to_string(member_out.id));
+    RD_LOGD(trace_id, "Step5.  Replace member, old member is removed, task_id={}, member={}",
+            boost::uuids::to_string(task_id), boost::uuids::to_string(member_out.id));
 
     // Step 2. Append log entry to complete replace member
-    RD_LOGI(trace_id, "Step6. Replace member, propose to raft for HS_CTRL_COMPLETE_REPLACE req, group_id={}",
-            group_id_str());
+    RD_LOGI(trace_id,
+            "Step6. Replace member, propose to raft for HS_CTRL_COMPLETE_REPLACE req, group_id={}, task_id={}",
+            boost::uuids::to_string(task_id), group_id_str());
     auto rreq = repl_req_ptr_t(new repl_req_ctx{});
-    replace_member_ctx members;
-    members.replica_out = member_out;
-    members.replica_in = member_in;
+    replace_member_ctx ctx;
+    ctx.task_id = task_id;
+    ctx.replica_out = member_out;
+    ctx.replica_in = member_in;
 
-    sisl::blob header(r_cast< uint8_t* >(&members), sizeof(replace_member_ctx));
+    sisl::blob header(r_cast< uint8_t* >(&ctx), sizeof(replace_member_ctx));
     rreq->init(repl_key{.server_id = server_id(),
                         .term = raft_server()->get_term(),
                         .dsn = m_next_dsn.fetch_add(1),
@@ -349,8 +371,9 @@ AsyncReplResult<> RaftReplDev::complete_replace_member(const replica_member_info
 
     auto err = m_state_machine->propose_to_raft(std::move(rreq));
     if (err != ReplServiceError::OK) {
-        RD_LOGE(trace_id, "Step6. Replace member, propose to raft for HS_CTRL_COMPLETE_REPLACE req failed , err={}",
-                err);
+        RD_LOGE(trace_id,
+                "Step6. Replace member, propose to raft for HS_CTRL_COMPLETE_REPLACE req failed , task_id={}, err={}",
+                boost::uuids::to_string(task_id), err);
         reset_quorum_size(0, trace_id);
         decr_pending_request_num();
         return make_async_error<>(std::move(err));
@@ -358,9 +381,90 @@ AsyncReplResult<> RaftReplDev::complete_replace_member(const replica_member_info
 
     reset_quorum_size(0, trace_id);
     decr_pending_request_num();
-    RD_LOGI(trace_id, "Complete replace member done, group_id={}, member_out={} member_in={}", group_id_str(),
-            boost::uuids::to_string(member_out.id), boost::uuids::to_string(member_in.id));
+    RD_LOGI(trace_id, "Complete replace member done, group_id={}, task_id={}, member_out={} member_in={}",
+            group_id_str(), boost::uuids::to_string(task_id), boost::uuids::to_string(member_out.id),
+            boost::uuids::to_string(member_in.id));
     return make_async_success<>();
+}
+
+ReplaceMemberStatus RaftReplDev::get_replace_member_status(uuid_t task_id, const replica_member_info& member_out,
+                                                           const replica_member_info& member_in,
+                                                           const std::vector< replica_member_info >& others,
+                                                           uint64_t trace_id) {
+    if (is_stopping()) {
+        RD_LOGI(trace_id, "repl dev is being shutdown!");
+        return ReplaceMemberStatus::UNKNOWN;
+    }
+    incr_pending_request_num();
+
+    if (!m_repl_svc_ctx || !is_leader()) {
+        decr_pending_request_num();
+        return ReplaceMemberStatus::NOT_LEADER;
+    }
+
+    auto peers = get_replication_status();
+    peer_info out_peer_info;
+    bool found_out = false;
+    bool found_in = false;
+    for (auto p : peers) {
+        if (p.id_ == member_out.id) {
+            out_peer_info = p;
+            found_out = true;
+        } else if (p.id_ == member_in.id) {
+            found_in = true;
+        }
+    }
+
+    bool intent_completed = !found_out && found_in;
+    if (m_rd_sb->replace_member_task.task_id.is_nil()) {
+        if (intent_completed) {
+            // If caller doesn't give others, won't check it.
+            bool others_match = others.size() == 0 || others.size() + 1 == peers.size();
+            auto detail = std::string{};
+            for (const auto& other : others) {
+                if (!raft_server()->get_srv_config(nuraft_mesg::to_server_id(other.id))) {
+                    others_match = false;
+                    detail = fmt::format("member {} is not found in raft group", boost::uuids::to_string(other.id));
+                    break;
+                }
+            }
+            if (!others_match) {
+                RD_LOGE(trace_id,
+                        "get_replace_member_status failed, other membership mismatch, task_id={}, detail={}, "
+                        "others.size={}, "
+                        "all_peers.size={}",
+                        boost::uuids::to_string(task_id), detail, others.size(), peers.size());
+                decr_pending_request_num();
+                return ReplaceMemberStatus::UNKNOWN;
+            }
+            decr_pending_request_num();
+            return ReplaceMemberStatus::COMPLETED;
+        }
+        decr_pending_request_num();
+        return ReplaceMemberStatus::TASK_NOT_FOUND;
+    }
+    if (m_rd_sb->replace_member_task.task_id != task_id) {
+        RD_LOGE(trace_id, "get_replace_member_status failed, task_id mismatch, persisted={}, received={}",
+                boost::uuids::to_string(m_rd_sb->replace_member_task.task_id), boost::uuids::to_string(task_id));
+        decr_pending_request_num();
+        return ReplaceMemberStatus::TASK_ID_MISMATCH;
+    }
+    // If the first attempt to remove out_member fails because out_member is down or leader crashes between Step5(remove
+    // member) and Step6(HS_CTRL_COMPLETE_REPLACE mesg). Replace member intent might be already fulfilled but
+    // replace_member_task sb still exists. In this case, we honor task sb, return IN_PROGRESS, and wait for reaper
+    // thread to trigger complete_replace_member again to cleanup the sb.
+    if (intent_completed) {
+        RD_LOGI(trace_id,
+                "Member replacement fulfilled, but task still exists, wait for reaper thread to retry "
+                "complete_replace_member. task_id={}, out_member={}, in_member={}",
+                boost::uuids::to_string(m_rd_sb->replace_member_task.task_id), boost::uuids::to_string(member_out.id),
+                boost::uuids::to_string(member_in.id));
+    }
+    RD_LOGD(trace_id, "Member replacement is in progress. task_id={}, out_member={}, in_member={}",
+            boost::uuids::to_string(task_id), boost::uuids::to_string(member_out.id),
+            boost::uuids::to_string(member_in.id));
+    decr_pending_request_num();
+    return ReplaceMemberStatus::IN_PROGRESS;
 }
 
 ReplServiceError RaftReplDev::do_add_member(const replica_member_info& member, uint64_t trace_id) {
@@ -381,9 +485,14 @@ ReplServiceError RaftReplDev::do_add_member(const replica_member_info& member, u
     if (ret == nuraft::cmd_result_code::SERVER_ALREADY_EXISTS) {
         RD_LOGW(trace_id, "Ignoring error returned from nuraft add_member, member={}, err={}",
                 boost::uuids::to_string(member.id), ret);
+    } else if (ret == nuraft::cmd_result_code::CANCELLED) {
+        // nuraft mesg will return cancelled if the change is not commited after waiting for
+        // raft_leader_change_timeout_ms(default 3200).
+        RD_LOGE(trace_id, "Add member failed, member={}, err={}", boost::uuids::to_string(member.id), ret);
+        return ReplServiceError::CANCELLED;
     } else if (ret != nuraft::cmd_result_code::OK) {
-        // Its ok to retry this request as the request
-        // of replace member is idempotent.
+        // It's ok to retry this request as the request
+        //  replace member is idempotent.
         RD_LOGE(trace_id, "Add member failed, member={}, err={}", boost::uuids::to_string(member.id), ret);
         return ReplServiceError::RETRY_REQUEST;
     }
@@ -509,9 +618,9 @@ ReplServiceError RaftReplDev::do_flip_learner(const replica_member_info& member,
                     return srv_conf->is_learner() && srv_conf->get_priority() == 0;
                 },
                 timeout)) {
-            RD_LOGD(trace_id, "Wait for learner and priority config change timed out, cancel the request, timeout: {}",
+            RD_LOGD(trace_id, "Wait for learner and priority config change timed out, please retry, timeout: {}",
                     timeout);
-            return ReplServiceError::CANCELLED;
+            return ReplServiceError::RETRY_REQUEST;
         }
     }
 
@@ -519,7 +628,7 @@ ReplServiceError RaftReplDev::do_flip_learner(const replica_member_info& member,
 }
 
 nuraft::cmd_result_code RaftReplDev::retry_when_config_changing(const std::function< nuraft::cmd_result_code() >& func,
-                                                              uint64_t trace_id) {
+                                                                uint64_t trace_id) {
     auto ret = nuraft::cmd_result_code::OK;
     int32_t retries = HS_DYNAMIC_CONFIG(consensus.config_changing_error_retries);
     for (auto i = 0; i < retries; i++) {
@@ -882,7 +991,8 @@ repl_req_ptr_t RaftReplDev::applier_create_req(repl_key const& rkey, journal_typ
     }
 
     // rreq->init will allocate the block if it has linked data.
-    auto status = init_req_ctx(rreq, rkey, code, m_raft_server_id == rkey.server_id, user_header, key, data_size, m_listener);
+    auto status =
+        init_req_ctx(rreq, rkey, code, m_raft_server_id == rkey.server_id, user_header, key, data_size, m_listener);
 
     if (status != ReplServiceError::OK) {
         RD_LOGD(rkey.traceID, "For Repl_key=[{}] alloc hints returned error={}, failing this req", rkey.to_string(),
@@ -1418,32 +1528,38 @@ void RaftReplDev::handle_error(repl_req_ptr_t const& rreq, ReplServiceError err)
 }
 
 void RaftReplDev::start_replace_member(repl_req_ptr_t rreq) {
-    auto members = r_cast< const replace_member_ctx* >(rreq->header().cbytes());
+    auto ctx = r_cast< const replace_member_ctx* >(rreq->header().cbytes());
 
     RD_LOGI(rreq->traceID(), "Raft repl start_replace_member commit member_out={} member_in={}",
-            boost::uuids::to_string(members->replica_out.id), boost::uuids::to_string(members->replica_in.id));
+            boost::uuids::to_string(ctx->replica_out.id), boost::uuids::to_string(ctx->replica_in.id));
 
-    m_listener->on_start_replace_member(members->replica_out, members->replica_in, rreq->traceID());
+    m_listener->on_start_replace_member(ctx->replica_out, ctx->replica_in, rreq->traceID());
     // record the replace_member intent
     std::unique_lock lg{m_sb_mtx};
-    m_rd_sb->replace_member_ctx.replica_in = members->replica_in.id;
-    m_rd_sb->replace_member_ctx.replica_out = members->replica_out.id;
+    m_rd_sb->replace_member_task.task_id = ctx->task_id;
+    m_rd_sb->replace_member_task.replica_in = ctx->replica_in.id;
+    m_rd_sb->replace_member_task.replica_out = ctx->replica_out.id;
     m_rd_sb.write();
 }
 
 void RaftReplDev::complete_replace_member(repl_req_ptr_t rreq) {
-    auto members = r_cast< const replace_member_ctx* >(rreq->header().cbytes());
+    auto ctx = r_cast< const replace_member_ctx* >(rreq->header().cbytes());
 
     RD_LOGI(rreq->traceID(), "Raft repl complete_replace_member commit member_out={} member_in={}",
-            boost::uuids::to_string(members->replica_out.id), boost::uuids::to_string(members->replica_in.id));
+            boost::uuids::to_string(ctx->replica_out.id), boost::uuids::to_string(ctx->replica_in.id));
 
-    m_listener->on_complete_replace_member(members->replica_out, members->replica_in, rreq->traceID());
+    m_listener->on_complete_replace_member(ctx->replica_out, ctx->replica_in, rreq->traceID());
 
     // clear the replace_member intent
     std::unique_lock lg{m_sb_mtx};
-    m_rd_sb->replace_member_ctx = replace_member_ctx_superblk{};
-    m_rd_sb.write();
-    RD_LOGI(rreq->traceID(), "Raft repl replace_member_ctx has been cleared.");
+    if (!m_rd_sb->replace_member_task.task_id.is_nil()) {
+        RD_DBG_ASSERT(m_rd_sb->replace_member_task.task_id == ctx->task_id,
+                      "Invalid task_id in complete_replace_member message, received {}, expected {}", ctx->task_id,
+                      m_rd_sb->replace_member_task.task_id);
+        m_rd_sb->replace_member_task = replace_member_task_superblk{};
+        m_rd_sb.write();
+    }
+    RD_LOGI(rreq->traceID(), "Raft repl replace_member_task has been cleared.");
 }
 
 static bool blob_equals(sisl::blob const& a, sisl::blob const& b) {
@@ -1521,7 +1637,7 @@ std::set< replica_id_t > RaftReplDev::get_active_peers() const {
     auto repl_status = get_replication_status();
     std::set< replica_id_t > res;
     auto my_committed_idx = m_commit_upto_lsn.load();
-    auto laggy=HS_DYNAMIC_CONFIG(consensus.laggy_threshold);
+    auto laggy = HS_DYNAMIC_CONFIG(consensus.laggy_threshold);
     uint64_t least_active_repl_idx = my_committed_idx > HS_DYNAMIC_CONFIG(consensus.laggy_threshold)
         ? my_committed_idx - HS_DYNAMIC_CONFIG(consensus.laggy_threshold)
         : 0;
@@ -1836,21 +1952,22 @@ void RaftReplDev::flush_durable_commit_lsn() {
     m_rd_sb.write();
 }
 
-void RaftReplDev::check_replace_member_status() {
+void RaftReplDev::monitor_replace_member_replication_status() {
     if (is_destroyed()) {
         RD_LOGI(NO_TRACE_ID, "Raft repl dev is destroyed, ignore check replace member status");
         return;
     }
     if (!m_repl_svc_ctx || !is_leader()) { return; }
-    if (m_rd_sb->replace_member_ctx.replica_in == boost::uuids::nil_uuid() ||
-        m_rd_sb->replace_member_ctx.replica_out == boost::uuids::nil_uuid()) {
+    if (m_rd_sb->replace_member_task.replica_in == boost::uuids::nil_uuid() ||
+        m_rd_sb->replace_member_task.replica_out == boost::uuids::nil_uuid()) {
         RD_LOGT(NO_TRACE_ID, "No replace member in progress, return");
         return;
     }
 
     auto peers = get_replication_status();
-    auto replica_in = m_rd_sb->replace_member_ctx.replica_in;
-    auto replica_out = m_rd_sb->replace_member_ctx.replica_out;
+    auto task_id = m_rd_sb->replace_member_task.task_id;
+    auto replica_in = m_rd_sb->replace_member_task.replica_in;
+    auto replica_out = m_rd_sb->replace_member_task.replica_out;
     repl_lsn_t in_lsn = 0;
     repl_lsn_t out_lsn = 0;
     repl_lsn_t laggy = HS_DYNAMIC_CONFIG(consensus.laggy_threshold);
@@ -1868,30 +1985,36 @@ void RaftReplDev::check_replace_member_status() {
     bool catch_up = in_lsn + laggy >= out_lsn;
 
     if (!catch_up) {
-        RD_LOGD(NO_TRACE_ID, "Checking replace member status, replica_in={} with lsn={}, replica_out={} with lsn={}",
-                boost::uuids::to_string(replica_in), in_lsn, boost::uuids::to_string(replica_out), out_lsn);
+        RD_LOGD(NO_TRACE_ID,
+                "Checking replace member status, task_id={},replica_in={} with lsn={}, replica_out={} with lsn={}",
+                boost::uuids::to_string(replica_in), boost::uuids::to_string(replica_in), in_lsn,
+                boost::uuids::to_string(replica_out), out_lsn);
         return;
     }
 
     RD_LOGD(NO_TRACE_ID,
-            "Checking replace member status, new member has caught up, replica_in={} with lsn={}, replica_out={} with "
+            "Checking replace member status, new member has caught up, task_id={}, replica_in={} with lsn={}, "
+            "replica_out={} with "
             "lsn={}",
-            boost::uuids::to_string(replica_in), in_lsn, boost::uuids::to_string(replica_out), out_lsn);
+            boost::uuids::to_string(task_id), boost::uuids::to_string(replica_in), in_lsn,
+            boost::uuids::to_string(replica_out), out_lsn);
 
     trace_id_t trace_id = generateRandomTraceId();
 
-    RD_LOGD(trace_id, "Trigger complete_replace_member, replica_in={}, replica_out={}",
-            boost::uuids::to_string(replica_in), boost::uuids::to_string(replica_out));
+    RD_LOGD(trace_id, "Trigger complete_replace_member, task_id={}, replica_in={}, replica_out={}",
+            boost::uuids::to_string(replica_in), boost::uuids::to_string(replica_in),
+            boost::uuids::to_string(replica_out));
 
     replica_member_info out{replica_out, ""};
     replica_member_info in{replica_in, ""};
-    auto ret = complete_replace_member(out, in, 0, trace_id).get();
+    auto ret = complete_replace_member(m_rd_sb->replace_member_task.task_id, out, in, 0, trace_id).get();
     if (ret.hasError()) {
-        RD_LOGE(trace_id, "Failed to complete replace member, next time will retry it, error={}", ret.error());
+        RD_LOGE(trace_id, "Failed to complete replace member, next time will retry it, task_id={}, error={}",
+                boost::uuids::to_string(task_id), ret.error());
         return;
     }
-    RD_LOGI(trace_id, "Complete replace member, replica_in={}, replica_out={}",
-            boost::uuids::to_string(replica_in), boost::uuids::to_string(replica_out))
+    RD_LOGI(trace_id, "Complete replace member, task_id={}, replica_in={}, replica_out={}",
+            boost::uuids::to_string(task_id), boost::uuids::to_string(replica_in), boost::uuids::to_string(replica_out))
 }
 
 ///////////////////////////////////  Private metohds ////////////////////////////////////
@@ -1999,7 +2122,8 @@ void RaftReplDev::gc_repl_reqs() {
             auto blkid = removing_rreq->local_blkid();
             data_service().async_free_blk(blkid).thenValue([this, blkid, removing_rreq](auto&& err) {
                 if (!err) {
-                    RD_LOGD(removing_rreq->traceID(), "GC rreq: Releasing blkid={} freed successfully", blkid.to_string());
+                    RD_LOGD(removing_rreq->traceID(), "GC rreq: Releasing blkid={} freed successfully",
+                            blkid.to_string());
                 } else if (err == std::make_error_code(std::errc::operation_canceled)) {
                     // The gc reaper thread stops after the data service has been stopped,
                     // leading to a scenario where it attempts to free the blkid while the data service is inactive.

--- a/src/lib/replication/service/generic_repl_svc.cpp
+++ b/src/lib/replication/service/generic_repl_svc.cpp
@@ -193,7 +193,7 @@ void SoloReplService::load_repl_dev(sisl::byte_view const& buf, void* meta_cooki
     }
 }
 
-AsyncReplResult<> SoloReplService::replace_member(group_id_t group_id, const replica_member_info& member_out,
+AsyncReplResult<> SoloReplService::replace_member(group_id_t group_id, uuid_t task_id, const replica_member_info& member_out,
                                                         const replica_member_info& member_in, uint32_t commit_quorum,
                                                         uint64_t trace_id) const {
     return make_async_error<>(ReplServiceError::NOT_IMPLEMENTED);
@@ -202,6 +202,14 @@ AsyncReplResult<> SoloReplService::replace_member(group_id_t group_id, const rep
 AsyncReplResult<> SoloReplService::flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target,
                                     uint32_t commit_quorum, bool wait_and_verify, uint64_t trace_id) const {
     return make_async_error<>(ReplServiceError::NOT_IMPLEMENTED);
+}
+
+ReplaceMemberStatus SoloReplService::get_replace_member_status(group_id_t group_id, uuid_t task_id,
+                                                               const replica_member_info& member_out,
+                                                               const replica_member_info& member_in,
+                                                               const std::vector< replica_member_info >& others,
+                                                               uint64_t trace_id) const {
+    return ReplaceMemberStatus::UNKNOWN;
 }
 
 std::unique_ptr< CPContext > SoloReplServiceCPHandler::on_switchover_cp(CP* cur_cp, CP* new_cp) {

--- a/src/lib/replication/service/generic_repl_svc.h
+++ b/src/lib/replication/service/generic_repl_svc.h
@@ -89,12 +89,17 @@ public:
                                                          std::set< replica_id_t > const& members) override;
     folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) override;
     void load_repl_dev(sisl::byte_view const& buf, void* meta_cookie) override;
-    AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
+    AsyncReplResult<> replace_member(group_id_t group_id, uuid_t task_id, const replica_member_info& member_out,
                                            const replica_member_info& member_in, uint32_t commit_quorum = 0,
                                            uint64_t trace_id = 0) const override;
     AsyncReplResult<> flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target,
                                         uint32_t commit_quorum, bool wait_and_verify = true,
                                         uint64_t trace_id = 0) const override;
+    ReplaceMemberStatus get_replace_member_status(group_id_t group_id, uuid_t task_id,
+                                                  const replica_member_info& member_out,
+                                                  const replica_member_info& member_in,
+                                                  const std::vector< replica_member_info >& others,
+                                                  uint64_t trace_id = 0) const override;
 };
 
 class SoloReplServiceCPHandler : public CPCallbacks {

--- a/src/lib/replication/service/raft_repl_service.h
+++ b/src/lib/replication/service/raft_repl_service.h
@@ -79,13 +79,19 @@ protected:
                                                          std::set< replica_id_t > const& members) override;
     folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) override;
     void load_repl_dev(sisl::byte_view const& buf, void* meta_cookie) override;
-    AsyncReplResult<> replace_member(group_id_t group_id, const replica_member_info& member_out,
+    AsyncReplResult<> replace_member(group_id_t group_id, uuid_t task_id, const replica_member_info& member_out,
                                            const replica_member_info& member_in, uint32_t commit_quorum = 0,
                                            uint64_t trace_id = 0) const override;
 
     AsyncReplResult<> flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target,
                                         uint32_t commit_quorum, bool wait_and_verify = true,
                                         uint64_t trace_id = 0) const override;
+
+    ReplaceMemberStatus get_replace_member_status(group_id_t group_id, uuid_t task_id,
+                                                  const replica_member_info& member_out,
+                                                  const replica_member_info& member_in,
+                                                  const std::vector< replica_member_info >& others,
+                                                  uint64_t trace_id = 0) const override;
 
 private:
     RaftReplDev* raft_group_config_found(sisl::byte_view const& buf, void* meta_cookie);
@@ -95,7 +101,7 @@ private:
     void gc_repl_devs();
     void gc_repl_reqs();
     void flush_durable_commit_lsn();
-    void check_replace_member_status();
+    void monitor_replace_member_replication_status();
     void monitor_cert_changes();
     void restart_raft_svc(const std::string filepath, const bool deleted);
     bool wait_for_cert(const std::string& filepath);

--- a/src/tests/test_common/raft_repl_test_base.hpp
+++ b/src/tests/test_common/raft_repl_test_base.hpp
@@ -344,13 +344,13 @@ public:
         }
         return blk_alloc_hints{};
     }
-    void on_start_replace_member(const replica_member_info& member_out, const replica_member_info& member_in,
+    void on_start_replace_member(const uuid_t& task_id, const replica_member_info& member_out, const replica_member_info& member_in,
                                  trace_id_t tid) override {
         LOGINFO("[Replica={}] start replace member out {} in {}", g_helper->replica_num(),
                 boost::uuids::to_string(member_out.id), boost::uuids::to_string(member_in.id));
     }
 
-    void on_complete_replace_member(const replica_member_info& member_out, const replica_member_info& member_in,
+    void on_complete_replace_member(const uuid_t& task_id, const replica_member_info& member_out, const replica_member_info& member_in,
                                     trace_id_t tid) override {
         LOGINFO("[Replica={}] complete replace member out {} in {}", g_helper->replica_num(),
                 boost::uuids::to_string(member_out.id), boost::uuids::to_string(member_in.id));

--- a/src/tests/test_raft_repl_dev_dynamic.cpp
+++ b/src/tests/test_raft_repl_dev_dynamic.cpp
@@ -39,12 +39,17 @@ TEST_F(ReplDevDynamicTest, ReplaceMember) {
     uint32_t member_in = num_replicas;
 
     g_helper->sync_for_test_start(num_members);
+    auto task_id = boost::uuids::random_generator()();
+    this->run_on_leader(db, [this, db, task_id, member_out, member_in] {
+        ASSERT_EQ(
+            check_replace_member_status(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in)),
+            ReplaceMemberStatus::TASK_NOT_FOUND);
+    });
     if (g_helper->replica_num() < num_replicas) {
         // With existing raft repl dev group, write IO's, validate and call replace_member on leader.
         LOGINFO("Writing on leader num_io={} replica={}", num_io_entries, g_helper->replica_num());
         this->write_on_leader(num_io_entries, true /* wait_for_commit */);
-
-        replace_member(db, g_helper->replica_id(member_out), g_helper->replica_id(member_in));
+        replace_member(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in));
         std::this_thread::sleep_for(std::chrono::seconds(3));
     } else if (g_helper->replica_num() == member_in) {
         LOGINFO("Wait for commits replica={}", g_helper->replica_num());
@@ -53,6 +58,14 @@ TEST_F(ReplDevDynamicTest, ReplaceMember) {
 
     g_helper->sync_for_verify_start(num_members);
     LOGINFO("sync_for_verify_state replica={} ", g_helper->replica_num());
+    this->run_on_leader(db, [this, db, task_id, member_out, member_in] {
+        ASSERT_EQ(
+            check_replace_member_status(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in)),
+            ReplaceMemberStatus::IN_PROGRESS);
+        auto new_task_id = boost::uuids::random_generator()();
+        replace_member(db, new_task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in), 0,
+                       ReplServiceError::REPLACE_MEMBER_TASK_MISMATCH);
+    });
     if (is_replica_num_in({0, 1, member_in})) {
         // Skip the member which is going to be replaced. Validate data on all other replica's.
         LOGINFO("Validate all data written so far by reading them replica={}", g_helper->replica_num());
@@ -61,7 +74,7 @@ TEST_F(ReplDevDynamicTest, ReplaceMember) {
     g_helper->sync_for_verify_start(num_members);
     LOGINFO("data synced, sync_for_verify_state replica={} ", g_helper->replica_num());
 
-    //wait for background reaper thread to trigger complete_replace_member
+    // wait for background reaper thread to trigger complete_replace_member
     if (g_helper->replica_num() == member_out) {
         // The out member will have the repl dev destroyed.
         auto repl_dev = std::dynamic_pointer_cast< RaftReplDev >(db->repl_dev());
@@ -75,6 +88,11 @@ TEST_F(ReplDevDynamicTest, ReplaceMember) {
     }
 
     g_helper->sync_for_cleanup_start(num_members);
+    this->run_on_leader(db, [this, db, task_id, member_out, member_in] {
+        ASSERT_EQ(
+            check_replace_member_status(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in)),
+            ReplaceMemberStatus::COMPLETED);
+    });
     LOGINFO("ReplaceMember test done replica={}", g_helper->replica_num());
 }
 
@@ -109,11 +127,13 @@ TEST_F(ReplDevDynamicTest, TwoMemberDown) {
         LOGINFO("Shutdown replica 2");
     }
 
+    auto task_id = boost::uuids::random_generator()();
     if (g_helper->replica_num() == 0) {
         // Replace down replica 2 with spare replica 3 with commit quorum 1
         // so that leader can go ahead with replacing member.
-        LOGINFO("Replace member started");
-        replace_member(db, g_helper->replica_id(member_out), g_helper->replica_id(member_in), 1 /* commit quorum*/);
+        LOGINFO("Replace member started, task_id={}", boost::uuids::to_string(task_id));
+        replace_member(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in),
+                       1 /* commit quorum*/);
         this->write_on_leader(num_io_entries, true /* wait_for_commit */);
         LOGINFO("Leader completed num_io={}", num_io_entries);
     }
@@ -128,6 +148,12 @@ TEST_F(ReplDevDynamicTest, TwoMemberDown) {
         LOGINFO("Validate all data written so far by reading them replica={}", g_helper->replica_num());
         this->validate_data();
     }
+    g_helper->sync_for_verify_start(num_members);
+    this->run_on_leader(db, [this, db, task_id, member_out, member_in] {
+        ASSERT_EQ(
+            check_replace_member_status(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in)),
+            ReplaceMemberStatus::IN_PROGRESS);
+    });
 
     if (g_helper->replica_num() == 1) {
         LOGINFO("Start replica 1");
@@ -167,12 +193,13 @@ TEST_F(ReplDevDynamicTest, OutMemberDown) {
         LOGINFO("Writing on leader num_io={} replica={}", num_io_entries, g_helper->replica_num());
         this->write_on_leader(num_io_entries, true /* wait_for_commit */);
     }
-    //shut down before replace member
+    // shut down before replace member
     this->shutdown_replica(2);
     LOGINFO("Shutdown replica 2");
 
+    auto task_id = boost::uuids::random_generator()();
     if (g_helper->replica_num() == 0) {
-        replace_member(db, g_helper->replica_id(member_out), g_helper->replica_id(member_in));
+        replace_member(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in));
         std::this_thread::sleep_for(std::chrono::seconds(3));
     } else if (g_helper->replica_num() == member_in) {
         LOGINFO("Wait for commits replica={}", g_helper->replica_num());
@@ -195,6 +222,11 @@ TEST_F(ReplDevDynamicTest, OutMemberDown) {
     // data synced, waiting for removing learner
     LOGINFO("data synced, sync for completing replace member, replica={}", g_helper->replica_num());
     g_helper->sync_for_verify_start(num_members);
+    this->run_on_leader(db, [this, db, task_id, member_out, member_in] {
+        ASSERT_EQ(
+            check_replace_member_status(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in)),
+            ReplaceMemberStatus::IN_PROGRESS);
+    });
     // Since the out_member stopped, it cannot response to remove_srv req, as a result the first time will get CANCELLED
     // error, so waiting time is longer than other tests.
     if (g_helper->replica_num() == 2) {
@@ -211,9 +243,26 @@ TEST_F(ReplDevDynamicTest, OutMemberDown) {
         LOGINFO("Repl dev destroyed on out member replica={}", g_helper->replica_num());
         db->set_zombie();
     }
-
+    g_helper->sync_for_test_start(num_members);
+    if (g_helper->replica_num() != 2) {
+        this->run_on_leader(db, [this, db, task_id, member_out, member_in] {
+            auto status = check_replace_member_status(db, task_id, g_helper->replica_id(member_out),
+                                                      g_helper->replica_id(member_in));
+            // out_member is down, so it can not response to remove req. Based on nuraft logic, leader will wait for
+            // timeout and remove it automatically. Simulate next complete_replace_member retry.
+            if (status == ReplaceMemberStatus::IN_PROGRESS) {
+                auto& raft_repl_svc = dynamic_cast< RaftReplService& >(hs()->repl_service());
+                raft_repl_svc.monitor_replace_member_replication_status();
+                LOGINFO("Simulate reaper thread to complete_replace_member");
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
+            ASSERT_EQ(check_replace_member_status(db, task_id, g_helper->replica_id(member_out),
+                                                  g_helper->replica_id(member_in)),
+                      ReplaceMemberStatus::COMPLETED);
+        });
+    }
     g_helper->sync_for_cleanup_start(num_members);
-    LOGINFO("OneMemberDown test done replica={}", g_helper->replica_num());
+    LOGINFO("OutMemberDown test done replica={}", g_helper->replica_num());
 }
 
 TEST_F(ReplDevDynamicTest, LeaderReplace) {
@@ -233,7 +282,7 @@ TEST_F(ReplDevDynamicTest, LeaderReplace) {
     uint32_t member_in = num_replicas;
 
     g_helper->sync_for_test_start(num_members);
-
+    auto task_id = boost::uuids::random_generator()();
     if (g_helper->replica_num() == member_out) {
         LOGINFO("Writing on leader num_io={} replica={}", num_io_entries, g_helper->replica_num());
         // With existing raft repl dev group, write IO's, validate and call replace_member on leader.
@@ -242,13 +291,13 @@ TEST_F(ReplDevDynamicTest, LeaderReplace) {
         // Leader will return error NOT_LEADER and yield leadership, sleep and connect again
         // to the new leader.
         LOGINFO("Replace old leader");
-        replace_member(db, g_helper->replica_id(member_out), g_helper->replica_id(member_in), 0,
+        replace_member(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in), 0,
                        ReplServiceError::NOT_LEADER);
         LOGINFO("Replace member leader yield done");
     }
     std::this_thread::sleep_for(std::chrono::seconds(3));
     if (g_helper->replica_num() != member_in) {
-        replace_member(db, g_helper->replica_id(member_out), g_helper->replica_id(member_in));
+        replace_member(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in));
         LOGINFO("Replace member old leader done");
     }
 
@@ -264,8 +313,12 @@ TEST_F(ReplDevDynamicTest, LeaderReplace) {
         this->validate_data();
     }
 
-    g_helper->sync_for_verify_start(num_members);
     LOGINFO("data synced, sync_for_verify_state replica={} ", g_helper->replica_num());
+    this->run_on_leader(db, [this, db, task_id, member_out, member_in] {
+        ASSERT_EQ(
+            check_replace_member_status(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in)),
+            ReplaceMemberStatus::IN_PROGRESS);
+    });
     if (g_helper->replica_num() == member_out) {
         // The out member will have the repl dev destroyed.
         auto repl_dev = std::dynamic_pointer_cast< RaftReplDev >(db->repl_dev());
@@ -280,6 +333,11 @@ TEST_F(ReplDevDynamicTest, LeaderReplace) {
     }
 
     g_helper->sync_for_cleanup_start(num_members);
+    this->run_on_leader(db, [this, db, task_id, member_out, member_in] {
+        ASSERT_EQ(
+            check_replace_member_status(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in)),
+            ReplaceMemberStatus::COMPLETED);
+    });
     LOGINFO("LeaderReplace test done replica={}", g_helper->replica_num());
 }
 
@@ -303,13 +361,13 @@ TEST_F(ReplDevDynamicTest, OneMemberRestart) {
         LOGINFO("Restart replica 1, ");
         this->restart_replica(15);
     }
-
+    auto task_id = boost::uuids::random_generator()();
     if (g_helper->replica_num() == 0) {
         // With existing raft repl dev group, write IO's, validate and call replace_member on leader.
         LOGINFO("Writing on leader num_io={} replica={}", num_io_entries, g_helper->replica_num());
         this->write_on_leader(num_io_entries, true /* wait_for_commit */);
 
-        replace_member(db, g_helper->replica_id(member_out), g_helper->replica_id(member_in));
+        replace_member(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in));
         std::this_thread::sleep_for(std::chrono::seconds(3));
     } else if (g_helper->replica_num() == member_in) {
         LOGINFO("Wait for commits replica={}", g_helper->replica_num());
@@ -324,8 +382,12 @@ TEST_F(ReplDevDynamicTest, OneMemberRestart) {
         this->validate_data();
     }
 
-    g_helper->sync_for_verify_start(num_members);
     LOGINFO("data synced, sync_for_verify_state replica={} ", g_helper->replica_num());
+    this->run_on_leader(db, [this, db, task_id, member_out, member_in] {
+        ASSERT_EQ(
+            check_replace_member_status(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in)),
+            ReplaceMemberStatus::IN_PROGRESS);
+    });
     if (g_helper->replica_num() == member_out) {
         // The out member will have the repl dev destroyed.
         auto repl_dev = std::dynamic_pointer_cast< RaftReplDev >(db->repl_dev());
@@ -339,6 +401,11 @@ TEST_F(ReplDevDynamicTest, OneMemberRestart) {
     }
 
     g_helper->sync_for_cleanup_start(num_members);
+    this->run_on_leader(db, [this, db, task_id, member_out, member_in] {
+        ASSERT_EQ(
+            check_replace_member_status(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in)),
+            ReplaceMemberStatus::COMPLETED);
+    });
     LOGINFO("OneMemberRestart test done replica={}", g_helper->replica_num());
 }
 
@@ -362,11 +429,11 @@ TEST_F(ReplDevDynamicTest, ValidateRequest) {
 
     g_helper->sync_for_test_start(num_members);
 
-    //shut down before replace member
+    // shut down before replace member
     this->shutdown_replica(1);
     LOGINFO("Shutdown replica 1");
 
-    //wait for shutdown
+    // wait for shutdown
     std::this_thread::sleep_for(std::chrono::seconds(3));
     g_helper->sync_for_verify_start(num_members);
     if (g_helper->replica_num() == 0) {
@@ -374,17 +441,18 @@ TEST_F(ReplDevDynamicTest, ValidateRequest) {
         LOGINFO("Writing on leader num_io={} replica={}", num_io_entries, g_helper->replica_num());
         this->write_on_leader(num_io_entries, true /* wait_for_commit */);
     }
-    g_helper->sync_for_verify_start(num_members);
+
+    auto task_id = boost::uuids::random_generator()();
     if (g_helper->replica_num() == 0) {
         // generate uuid
         replica_id_t fake_member_out = boost::uuids::random_generator()();
         replica_id_t fake_member_in = boost::uuids::random_generator()();
         LOGINFO("test SERVER_NOT_FOUND");
-        replace_member(db, fake_member_out, fake_member_in, 0, ReplServiceError::SERVER_NOT_FOUND);
+        replace_member(db, task_id, fake_member_out, fake_member_in, 0, ReplServiceError::SERVER_NOT_FOUND);
         LOGINFO("test replace_member already complete");
-        replace_member(db, fake_member_out, g_helper->replica_id(0));
+        replace_member(db, task_id, fake_member_out, g_helper->replica_id(0));
         LOGINFO("test QUORUM_NOT_MET", num_io_entries, g_helper->replica_num());
-        replace_member(db, g_helper->replica_id(member_out), g_helper->replica_id(member_in), 0,
+        replace_member(db, task_id, g_helper->replica_id(member_out), g_helper->replica_id(member_in), 0,
                        ReplServiceError::QUORUM_NOT_MET);
     }
 

--- a/src/tests/test_solo_repl_dev.cpp
+++ b/src/tests/test_solo_repl_dev.cpp
@@ -133,9 +133,9 @@ public:
                       cintrusive< repl_req_ctx >& ctx) override {
             LOGINFO("Received error={} on repl_dev", enum_name(error));
         }
-        void on_start_replace_member(const replica_member_info& member_out, const replica_member_info& member_in,
+        void on_start_replace_member(const uuid_t& task_id, const replica_member_info& member_out, const replica_member_info& member_in,
                                      trace_id_t tid) override {}
-        void on_complete_replace_member(const replica_member_info& member_out, const replica_member_info& member_in,
+        void on_complete_replace_member(const uuid_t& task_id, const replica_member_info& member_out, const replica_member_info& member_in,
                                         trace_id_t tid) override {}
         void on_destroy(const group_id_t& group_id) override {}
         void notify_committed_lsn(int64_t lsn) override {}


### PR DESCRIPTION
- get_replace_member_status should always be called to leader.
- Add a task_id in replace member implementation to track the status.