### PR TITLE
return error blk if no_space_left happens

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.16.4"
+    version = "6.16.5"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/device/virtual_dev.cpp
+++ b/src/lib/device/virtual_dev.cpp
@@ -178,8 +178,8 @@ BlkAllocStatus VirtualDev::commit_blk(BlkId const& blkid) {
 
 BlkAllocStatus VirtualDev::alloc_contiguous_blks(blk_count_t nblks, blk_alloc_hints const& hints, BlkId& out_blkid) {
     BlkAllocStatus ret;
+    MultiBlkId mbid;
     try {
-        MultiBlkId mbid;
         if (!hints.is_contiguous) {
             HS_DBG_ASSERT(false, "Expected alloc_contiguous_blk call to be with hints.is_contiguous=true");
             blk_alloc_hints adjusted_hints = hints;
@@ -191,14 +191,13 @@ BlkAllocStatus VirtualDev::alloc_contiguous_blks(blk_count_t nblks, blk_alloc_hi
 
         if (ret == BlkAllocStatus::SUCCESS || (ret == BlkAllocStatus::PARTIAL && hints.partial_alloc_ok)) {
             HS_REL_ASSERT_EQ(mbid.num_pieces(), 1, "out blkid more than 1 entries will lead to blk leak!");
-            out_blkid = mbid.to_single_blkid();
         }
-
-        // for failure case, fall through and return the status to caller;
     } catch (const std::exception& e) {
         ret = BlkAllocStatus::FAILED;
         HS_DBG_ASSERT(0, "{}", e.what());
     }
+
+    out_blkid = mbid.to_single_blkid();
     return ret;
 }
 
@@ -262,9 +261,8 @@ BlkAllocStatus VirtualDev::alloc_blks(blk_count_t nblks, blk_alloc_hints const& 
         nblks_remain = (nblks_remain < nblks_this_iter) ? 0 : (nblks_remain - nblks_this_iter);
 
         if (status != BlkAllocStatus::SUCCESS && status != BlkAllocStatus::PARTIAL) {
-            out_blkids.pop_back();
-            // all chunks has been tried, but still failed to allocate;
-            // break out and return status to caller;
+            //  all chunks has been tried, but still failed to allocate;
+            //  break out and return status to caller;
             break;
         }
     } while (nblks_remain);

--- a/src/lib/replication/repl_dev/common.cpp
+++ b/src/lib/replication/repl_dev/common.cpp
@@ -152,16 +152,17 @@ ReplServiceError repl_req_ctx::alloc_local_blks(cshared< ReplDevListener >& list
     std::vector< BlkId > blkids;
     auto status = data_service().alloc_blks(sisl::round_up(uint32_cast(data_size), data_service().get_blk_size()),
                                             hints_result.value(), blkids);
-    if (status != BlkAllocStatus::SUCCESS) {
-        LOGWARNMOD(replication, "[traceID={}] block allocation failure, repl_key=[{}], status=[{}]", rkey().traceID,
-                   rkey(), status);
-        DEBUG_ASSERT_EQ(status, BlkAllocStatus::SUCCESS, "Unable to allocate blks");
-        return ReplServiceError::NO_SPACE_LEFT;
-    }
-
     for (auto& blkid : blkids) {
         m_local_blkids.emplace_back(blkid);
     }
+
+    if (status != BlkAllocStatus::SUCCESS) {
+        LOGWARNMOD(replication, "[traceID={}] block allocation failure, repl_key=[{}], status=[{}]", rkey().traceID,
+                   rkey(), status);
+        // we need directly return the error to upper layer, not assert here
+        return ReplServiceError::NO_SPACE_LEFT;
+    }
+
     add_state(repl_req_state_t::BLK_ALLOCATED);
     return ReplServiceError::OK;
 }
@@ -266,7 +267,8 @@ std::string repl_req_ctx::to_string() const {
 }
 
 std::string repl_req_ctx::to_compact_string() const {
-    if (m_op_code == journal_type_t::HS_CTRL_DESTROY || m_op_code == journal_type_t::HS_CTRL_START_REPLACE || m_op_code == journal_type_t::HS_CTRL_COMPLETE_REPLACE) {
+    if (m_op_code == journal_type_t::HS_CTRL_DESTROY || m_op_code == journal_type_t::HS_CTRL_START_REPLACE ||
+        m_op_code == journal_type_t::HS_CTRL_COMPLETE_REPLACE) {
         return fmt::format("term={} lsn={} op={}", m_rkey.term, m_lsn, enum_name(m_op_code));
     }
 

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -206,7 +206,9 @@ AsyncReplResult<> RaftReplDev::start_replace_member(const replica_member_info& m
     // replace_member(S3, S4) if S2 is down or laggy. Needs to recover S2 first or retry with commit_quorum=1.
     auto quorum = get_quorum_for_commit();
     if (active_num < quorum && commit_quorum == 0) {
-        RD_LOGE(trace_id, "Step1. Replace member, quorum safety check failed, active_peers={}, active_peers_exclude_out/in_member={}, required_quorum={}, commit_quorum={}",
+        RD_LOGE(trace_id,
+                "Step1. Replace member, quorum safety check failed, active_peers={}, "
+                "active_peers_exclude_out/in_member={}, required_quorum={}, commit_quorum={}",
                 active_peers.size(), active_num, quorum, commit_quorum);
         reset_quorum_size(0, trace_id);
         decr_pending_request_num();
@@ -268,7 +270,8 @@ AsyncReplResult<> RaftReplDev::start_replace_member(const replica_member_info& m
         decr_pending_request_num();
         return make_async_error<>(std::move(ret));
     }
-    RD_LOGI(trace_id, "Step4. Replace member, proposed to raft to add member, member={}", boost::uuids::to_string(member_in.id));
+    RD_LOGI(trace_id, "Step4. Replace member, proposed to raft to add member, member={}",
+            boost::uuids::to_string(member_in.id));
     reset_quorum_size(0, trace_id);
     decr_pending_request_num();
     return make_async_success<>();
@@ -519,7 +522,7 @@ ReplServiceError RaftReplDev::do_flip_learner(const replica_member_info& member,
 }
 
 nuraft::cmd_result_code RaftReplDev::retry_when_config_changing(const std::function< nuraft::cmd_result_code() >& func,
-                                                              uint64_t trace_id) {
+                                                                uint64_t trace_id) {
     auto ret = nuraft::cmd_result_code::OK;
     int32_t retries = HS_DYNAMIC_CONFIG(consensus.config_changing_error_retries);
     for (auto i = 0; i < retries; i++) {
@@ -882,7 +885,8 @@ repl_req_ptr_t RaftReplDev::applier_create_req(repl_key const& rkey, journal_typ
     }
 
     // rreq->init will allocate the block if it has linked data.
-    auto status = init_req_ctx(rreq, rkey, code, m_raft_server_id == rkey.server_id, user_header, key, data_size, m_listener);
+    auto status =
+        init_req_ctx(rreq, rkey, code, m_raft_server_id == rkey.server_id, user_header, key, data_size, m_listener);
 
     if (status != ReplServiceError::OK) {
         RD_LOGD(rkey.traceID, "For Repl_key=[{}] alloc hints returned error={}, failing this req", rkey.to_string(),
@@ -1521,7 +1525,7 @@ std::set< replica_id_t > RaftReplDev::get_active_peers() const {
     auto repl_status = get_replication_status();
     std::set< replica_id_t > res;
     auto my_committed_idx = m_commit_upto_lsn.load();
-    auto laggy=HS_DYNAMIC_CONFIG(consensus.laggy_threshold);
+    auto laggy = HS_DYNAMIC_CONFIG(consensus.laggy_threshold);
     uint64_t least_active_repl_idx = my_committed_idx > HS_DYNAMIC_CONFIG(consensus.laggy_threshold)
         ? my_committed_idx - HS_DYNAMIC_CONFIG(consensus.laggy_threshold)
         : 0;
@@ -1890,8 +1894,8 @@ void RaftReplDev::check_replace_member_status() {
         RD_LOGE(trace_id, "Failed to complete replace member, next time will retry it, error={}", ret.error());
         return;
     }
-    RD_LOGI(trace_id, "Complete replace member, replica_in={}, replica_out={}",
-            boost::uuids::to_string(replica_in), boost::uuids::to_string(replica_out))
+    RD_LOGI(trace_id, "Complete replace member, replica_in={}, replica_out={}", boost::uuids::to_string(replica_in),
+            boost::uuids::to_string(replica_out))
 }
 
 ///////////////////////////////////  Private metohds ////////////////////////////////////
@@ -1999,7 +2003,8 @@ void RaftReplDev::gc_repl_reqs() {
             auto blkid = removing_rreq->local_blkid();
             data_service().async_free_blk(blkid).thenValue([this, blkid, removing_rreq](auto&& err) {
                 if (!err) {
-                    RD_LOGD(removing_rreq->traceID(), "GC rreq: Releasing blkid={} freed successfully", blkid.to_string());
+                    RD_LOGD(removing_rreq->traceID(), "GC rreq: Releasing blkid={} freed successfully",
+                            blkid.to_string());
                 } else if (err == std::make_error_code(std::errc::operation_canceled)) {
                     // The gc reaper thread stops after the data service has been stopped,
                     // leading to a scenario where it attempts to free the blkid while the data service is inactive.


### PR DESCRIPTION
when we got no_space_left error when allocating blk in a specifc chunk, we need let the upper layer know this through the out_blk_id, this is crucial for handling no space left case. so that:

1 upper layer can check the returned status of alloc_blks to be aware of whether the blk is allocated successfully.
2 if the return status is no success, from the out_blk_id, the upper layer can know which chunk fails to allocate blk.

this bug is found in emergent gc test.