### PR TITLE
Change task_id to string

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.17.5"
+    version = "6.18.0"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -371,11 +371,11 @@ public:
     virtual void on_destroy(const group_id_t& group_id) = 0;
 
     /// @brief Called when start replace member.
-    virtual void on_start_replace_member(const uuid_t& task_id, const replica_member_info& member_out,
+    virtual void on_start_replace_member(const std::string& task_id, const replica_member_info& member_out,
                                          const replica_member_info& member_in, trace_id_t tid) = 0;
 
     /// @brief Called when complete replace member.
-    virtual void on_complete_replace_member(const uuid_t& task_id, const replica_member_info& member_out,
+    virtual void on_complete_replace_member(const std::string& task_id, const replica_member_info& member_out,
                                             const replica_member_info& member_in, trace_id_t tid) = 0;
 
     /// @brief Called when the snapshot is being created by nuraft

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -48,7 +48,7 @@ public:
     /// @param member_in The member which is going to be added in place of member_out
     /// @param commit_quorum Commit quorum to be used for this operation. If 0, it will use the default commit quorum.
     /// @return A Future on replace the member accepted or Future ReplServiceError upon error
-    virtual AsyncReplResult<> replace_member(group_id_t group_id, uuid_t task_id, const replica_member_info& member_out,
+    virtual AsyncReplResult<> replace_member(group_id_t group_id, std::string& task_id, const replica_member_info& member_out,
                                                    const replica_member_info& member_in, uint32_t commit_quorum = 0,
                                                    uint64_t trace_id = 0) const = 0;
 
@@ -62,7 +62,7 @@ public:
     /// @param member_in The member which is going to be added in place of member_out
     /// @param others Other members excluding member_out, member_in
     /// @return ReplaceMemberStatus
-    virtual ReplaceMemberStatus get_replace_member_status(group_id_t group_id, uuid_t task_id,
+    virtual ReplaceMemberStatus get_replace_member_status(group_id_t group_id, std::string& task_id,
                                                           const replica_member_info& member_out,
                                                           const replica_member_info& member_in,
                                                           const std::vector< replica_member_info >& others,

--- a/src/lib/replication/service/generic_repl_svc.cpp
+++ b/src/lib/replication/service/generic_repl_svc.cpp
@@ -193,7 +193,7 @@ void SoloReplService::load_repl_dev(sisl::byte_view const& buf, void* meta_cooki
     }
 }
 
-AsyncReplResult<> SoloReplService::replace_member(group_id_t group_id, uuid_t task_id,
+AsyncReplResult<> SoloReplService::replace_member(group_id_t group_id, std::string& task_id,
                                                   const replica_member_info& member_out,
                                                   const replica_member_info& member_in, uint32_t commit_quorum,
                                                   uint64_t trace_id) const {
@@ -206,7 +206,7 @@ AsyncReplResult<> SoloReplService::flip_learner_flag(group_id_t group_id, const 
     return make_async_error<>(ReplServiceError::NOT_IMPLEMENTED);
 }
 
-ReplaceMemberStatus SoloReplService::get_replace_member_status(group_id_t group_id, uuid_t task_id,
+ReplaceMemberStatus SoloReplService::get_replace_member_status(group_id_t group_id, std::string& task_id,
                                                                const replica_member_info& member_out,
                                                                const replica_member_info& member_in,
                                                                const std::vector< replica_member_info >& others,

--- a/src/lib/replication/service/generic_repl_svc.h
+++ b/src/lib/replication/service/generic_repl_svc.h
@@ -91,13 +91,13 @@ public:
                                                          std::set< replica_id_t > const& members) override;
     folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) override;
     void load_repl_dev(sisl::byte_view const& buf, void* meta_cookie) override;
-    AsyncReplResult<> replace_member(group_id_t group_id, uuid_t task_id, const replica_member_info& member_out,
+    AsyncReplResult<> replace_member(group_id_t group_id, std::string& task_id, const replica_member_info& member_out,
                                      const replica_member_info& member_in, uint32_t commit_quorum = 0,
                                      uint64_t trace_id = 0) const override;
     AsyncReplResult<> flip_learner_flag(group_id_t group_id, const replica_member_info& member, bool target,
                                         uint32_t commit_quorum, bool wait_and_verify = true,
                                         uint64_t trace_id = 0) const override;
-    ReplaceMemberStatus get_replace_member_status(group_id_t group_id, uuid_t task_id,
+    ReplaceMemberStatus get_replace_member_status(group_id_t group_id, std::string& task_id,
                                                   const replica_member_info& member_out,
                                                   const replica_member_info& member_in,
                                                   const std::vector< replica_member_info >& others,

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -489,7 +489,7 @@ void RaftReplService::load_repl_dev(sisl::byte_view const& buf, void* meta_cooki
 // In this function, it only invokes replDev start_replace_member. There is
 // a background reaper thread helps periodically check the member_in replication status, after in_member has caught up,
 // will trigger replDev complete_replace_member.
-AsyncReplResult<> RaftReplService::replace_member(group_id_t group_id, uuid_t task_id, const replica_member_info& member_out,
+AsyncReplResult<> RaftReplService::replace_member(group_id_t group_id, std::string& task_id, const replica_member_info& member_out,
                                                   const replica_member_info& member_in, uint32_t commit_quorum,
                                                   uint64_t trace_id) const {
     if (is_stopping()) return make_async_error<>(ReplServiceError::STOPPING);
@@ -536,7 +536,7 @@ AsyncReplResult<> RaftReplService::flip_learner_flag(group_id_t group_id, const 
 }
 
 // This query should always be called on leader to avoid misleading results due to lagging status on some followers.
-ReplaceMemberStatus RaftReplService::get_replace_member_status(group_id_t group_id, uuid_t task_id,
+ReplaceMemberStatus RaftReplService::get_replace_member_status(group_id_t group_id, std::string& task_id,
                                                                const replica_member_info& member_out,
                                                                const replica_member_info& member_in,
                                                                const std::vector< replica_member_info >& others,

--- a/src/lib/replication/service/raft_repl_service.h
+++ b/src/lib/replication/service/raft_repl_service.h
@@ -79,7 +79,7 @@ protected:
                                                          std::set< replica_id_t > const& members) override;
     folly::SemiFuture< ReplServiceError > remove_repl_dev(group_id_t group_id) override;
     void load_repl_dev(sisl::byte_view const& buf, void* meta_cookie) override;
-    AsyncReplResult<> replace_member(group_id_t group_id, uuid_t task_id, const replica_member_info& member_out,
+    AsyncReplResult<> replace_member(group_id_t group_id, std::string& task_id, const replica_member_info& member_out,
                                            const replica_member_info& member_in, uint32_t commit_quorum = 0,
                                            uint64_t trace_id = 0) const override;
 
@@ -87,7 +87,7 @@ protected:
                                         uint32_t commit_quorum, bool wait_and_verify = true,
                                         uint64_t trace_id = 0) const override;
 
-    ReplaceMemberStatus get_replace_member_status(group_id_t group_id, uuid_t task_id,
+    ReplaceMemberStatus get_replace_member_status(group_id_t group_id, std::string& task_id,
                                                   const replica_member_info& member_out,
                                                   const replica_member_info& member_in,
                                                   const std::vector< replica_member_info >& others,

--- a/src/tests/test_common/raft_repl_test_base.hpp
+++ b/src/tests/test_common/raft_repl_test_base.hpp
@@ -343,13 +343,13 @@ public:
         return hints;
     }
 
-    void on_start_replace_member(const uuid_t& task_id, const replica_member_info& member_out,
+    void on_start_replace_member(const std::string& task_id, const replica_member_info& member_out,
                                  const replica_member_info& member_in, trace_id_t tid) override {
         LOGINFO("[Replica={}] start replace member out {} in {}", g_helper->replica_num(),
                 boost::uuids::to_string(member_out.id), boost::uuids::to_string(member_in.id));
     }
 
-    void on_complete_replace_member(const uuid_t& task_id, const replica_member_info& member_out,
+    void on_complete_replace_member(const std::string& task_id, const replica_member_info& member_out,
                                     const replica_member_info& member_in, trace_id_t tid) override {
         LOGINFO("[Replica={}] complete replace member out {} in {}", g_helper->replica_num(),
                 boost::uuids::to_string(member_out.id), boost::uuids::to_string(member_in.id));
@@ -743,11 +743,11 @@ public:
     void create_snapshot() { dbs_[0]->create_snapshot(); }
     void truncate(int num_reserved_entries) { dbs_[0]->truncate(num_reserved_entries); }
 
-    void replace_member(std::shared_ptr< TestReplicatedDB > db, uuid_t task_id, replica_id_t member_out,
+    void replace_member(std::shared_ptr< TestReplicatedDB > db, std::string& task_id, replica_id_t member_out,
                         replica_id_t member_in, uint32_t commit_quorum = 0,
                         ReplServiceError error = ReplServiceError::OK) {
-        this->run_on_leader(db, [this, error, db, task_id, member_out, member_in, commit_quorum]() {
-            LOGINFO("Start replace member task_id={}, out={}, in={}", boost::uuids::to_string(task_id),
+        this->run_on_leader(db, [this, error, db, &task_id, member_out, member_in, commit_quorum]() {
+            LOGINFO("Start replace member task_id={}, out={}, in={}", task_id,
                     boost::uuids::to_string(member_out), boost::uuids::to_string(member_in));
 
             replica_member_info out{member_out, ""};
@@ -763,9 +763,9 @@ public:
         });
     }
 
-    ReplaceMemberStatus check_replace_member_status(std::shared_ptr< TestReplicatedDB > db, uuid_t task_id,
+    ReplaceMemberStatus check_replace_member_status(std::shared_ptr< TestReplicatedDB > db, std::string& task_id,
                                                     replica_id_t member_out, replica_id_t member_in) {
-        LOGINFO("check replace member status, task_id={}, out={} in={}", boost::uuids::to_string(task_id),
+        LOGINFO("check replace member status, task_id={}, out={} in={}", task_id,
                 boost::uuids::to_string(member_out), boost::uuids::to_string(member_in));
 
         replica_member_info out{member_out, ""};

--- a/src/tests/test_solo_repl_dev.cpp
+++ b/src/tests/test_solo_repl_dev.cpp
@@ -133,9 +133,9 @@ public:
                       cintrusive< repl_req_ctx >& ctx) override {
             LOGINFO("Received error={} on repl_dev", enum_name(error));
         }
-        void on_start_replace_member(const uuid_t& task_id, const replica_member_info& member_out,
+        void on_start_replace_member(const std::string& task_id, const replica_member_info& member_out,
                                      const replica_member_info& member_in, trace_id_t tid) override {}
-        void on_complete_replace_member(const uuid_t& task_id, const replica_member_info& member_out,
+        void on_complete_replace_member(const std::string& task_id, const replica_member_info& member_out,
                                         const replica_member_info& member_in, trace_id_t tid) override {}
         void on_destroy(const group_id_t& group_id) override {}
         void notify_committed_lsn(int64_t lsn) override {}


### PR DESCRIPTION
Changing task_id to string allows users to use more meaningful information as id.
In NuObject2.0, CM will use "timestamp:pg_id" as task_id for easy time based range query in its kvstore.