### PR TITLE
Added custom ci timeout

### DIFF
--- a/.github/workflows/merge_build.yml
+++ b/.github/workflows/merge_build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Build:
-    timeout: 268 # minutes, equal to max + 3*std of the last 2500 successful runs
+    timeout-minutes: 268 # equal to max + 3*std of the last 2500 successful runs
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/merge_build.yml
+++ b/.github/workflows/merge_build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   Build:
+    timeout: 268 # minutes, equal to max + 3*std of the last 2500 successful runs
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Change Summary
Added custom timeout for `Build` job of the `Homestore PR Build` workflow based on historical data.

### More details
Over the last 2569 successful runs, the `Build` job has a maximum runtime of 232 minutes (mean=34, std=12) accross all matrix combinations.

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/eBay/HomeStore/actions/runs/15449582553/job/43488094944) job run, that failed after 6 hours. More stuck jobs have been observed over the last six months, the first one on 27-Jan-2025 and the last one one on 04-Jun-2025, while more recent occurences are also possible because our dataset has a cutoff date around late May. With the proposed changes, a total of **91 hours would have been saved** over the last six months retrospectively, clearing the queue for other workflows and **speeding up the CI** of the project, while also **saving resources** in general 🌱.

The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail with a timeout at 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 268 minutes` where `max` and `std` (standard deviation) are derived from the history of 2569 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.
Note that the timeout applies to all the matrix jobs, and not to their sum, overriding the default 6-hour timeout of github.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this.

Feel free to let us know (here or in the email below) if you have any questions, and thanks for putting in the time to read this.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch