### PR TITLE
fetch data from leader

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.31"
+    version = "6.20.32"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -413,8 +413,10 @@ public:
     // @param blkid - original blkid of the log entry
     // @param sgs - sgs to be filled with data
     // @param lsn - lsn of the log entry
+    // @param is_originator - I am the originator or not
     virtual folly::Future< std::error_code > on_fetch_data(const int64_t lsn, const sisl::blob& header,
-                                                           const MultiBlkId& blkid, sisl::sg_list& sgs) {
+                                                           const MultiBlkId& blkid, sisl::sg_list& sgs,
+                                                           bool is_originator) {
         // default implementation is reading by blkid directly
         return data_service().async_read(blkid, sgs, sgs.size);
     }

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -234,6 +234,10 @@ private:
     std::atomic_uint64_t m_pending_init_req_num;
     std::atomic< bool > m_in_quience;
 
+    // TODO::remove this after we change raft_repl_dev UT to support fetching data from non-originitor
+    inline static bool m_fetch_data_only_from_originator =
+        false; // If true, fetch data only from originator, not from other peers
+
 public:
     friend class RaftStateMachine;
 
@@ -433,6 +437,10 @@ public:
 
     // clear reqs that has allocated blks on the given chunk.
     void clear_chunk_req(chunk_num_t chunk_id);
+
+    static void enable_fetch_data_only_from_originator(bool enable) { m_fetch_data_only_from_originator = enable; }
+
+    static bool is_fetch_data_only_from_originator() { return m_fetch_data_only_from_originator; }
 
 protected:
     //////////////// All nuraft::state_mgr overrides ///////////////////////

--- a/src/tests/test_raft_repl_dev.cpp
+++ b/src/tests/test_raft_repl_dev.cpp
@@ -824,6 +824,8 @@ int main(int argc, char* argv[]) {
         args.emplace_back(argv[i]);
     }
 
+    RaftReplDev::enable_fetch_data_only_from_originator(true);
+
     ::testing::InitGoogleTest(&parsed_argc, argv);
 
     SISL_OPTIONS_LOAD(parsed_argc, argv, logging, config, test_raft_repl_dev, iomgr, test_common_setup,

--- a/src/tests/test_raft_repl_dev_dynamic.cpp
+++ b/src/tests/test_raft_repl_dev_dynamic.cpp
@@ -474,6 +474,8 @@ int main(int argc, char* argv[]) {
         args.emplace_back(argv[i]);
     }
 
+    RaftReplDev::enable_fetch_data_only_from_originator(true);
+
     ::testing::InitGoogleTest(&parsed_argc, argv);
 
     SISL_OPTIONS_LOAD(parsed_argc, argv, logging, config, test_raft_repl_dev, iomgr, test_common_setup,


### PR DESCRIPTION
1 fetch data from leader , not leader, to avoid the case that originator is the out_member when replace member happens

2 if error happens when handling fetch_data request, return empty mesage and let follower retry. don`t crash