### PR TITLE
Fix monitor_replace_member_replication_status

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.0"
+    version = "6.20.1"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"


### PR DESCRIPTION
Since HS_CTRL_START_REPLACE is before adding new member, so it's possible that the task is persisted but fail to add member. 
