### PR TITLE
SDSTOR-18915: Check if the devices are unique during boot

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.14"
+    version = "6.20.15"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/device/device.h
+++ b/src/lib/device/device.h
@@ -203,6 +203,7 @@ private:
                                 pdev_info_header& pinfo);
 
     const std::vector< PhysicalDev* >& pdevs_by_type_internal(HSDevType dtype) const;
+    bool verify_unique_devs() const;
 }; // class DeviceManager
 
 // Chunk pool is used to get chunks when there is no space


### PR DESCRIPTION
If the device list that we pass on to homestore has duplicates, we do not detect it and will have data corruption. Verify and add assert to cover this case. 