### PR TITLE
support disable push_data by rreq

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.14"
+    version = "6.20.15"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -220,6 +220,8 @@ public:
     void release_data();
     flatbuffers::FlatBufferBuilder& create_fb_builder() { return m_fb_builder; }
     void release_fb_builder() { m_fb_builder.Release(); }
+    void disable_push_data() { m_enable_push_data = false; }
+    bool is_push_data_enabled() const { return m_enable_push_data; }
 
 public:
     // IMPORTANT: Avoid declaring variables public, since this structure carries various entries and try to work in
@@ -260,6 +262,7 @@ private:
     sisl::io_blob_safe m_buf_for_unaligned_data;
     intrusive< sisl::GenericRpcData > m_pushed_data;
     sisl::GenericClientResponse m_fetched_data;
+    bool m_enable_push_data{true};
 };
 
 //

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -796,14 +796,17 @@ void RaftReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& 
             return;
         }
 
+        // Push the data to all followers if push data is enabled
+        if (rreq->is_push_data_enabled()) {
 #ifdef _PRERELEASE
-        if (iomgr_flip::instance()->test_flip("disable_leader_push_data")) {
-            RD_LOGD(tid, "Simulating push data failure, so that all the follower will have to fetch data");
-        } else
-            push_data_to_all_followers(rreq, data);
+            if (iomgr_flip::instance()->test_flip("disable_leader_push_data")) {
+                RD_LOGD(tid, "Simulating push data failure, so that all the follower will have to fetch data");
+            } else
+                push_data_to_all_followers(rreq, data);
 #else
-        push_data_to_all_followers(rreq, data);
+            push_data_to_all_followers(rreq, data);
 #endif
+        }
 
         COUNTER_INCREMENT(m_metrics, total_write_cnt, 1);
         COUNTER_INCREMENT(m_metrics, outstanding_data_write_cnt, 1);


### PR DESCRIPTION
extend rreq to support disable push_data if rreq has linked data. this is useful in some scenario of homeobject, and maybe also useful for other cases in the future