### PR TITLE
Issue 779: Enable fault containment for ReplDev/LogStore/LogDev layers

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.17"
+    version = "6.20.19"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/logstore_service.hpp
+++ b/src/include/homestore/logstore_service.hpp
@@ -26,7 +26,7 @@
 #include <iomgr/iomgr.hpp>
 #include <sisl/metrics/metrics.hpp>
 #include <nlohmann/json.hpp>
-
+#include <boost/uuid/nil_generator.hpp>
 #include <homestore/homestore_decl.hpp>
 #include <homestore/logstore/log_store.hpp>
 #include <homestore/superblk_handler.hpp>
@@ -94,7 +94,7 @@ public:
      * chunks. Logdev can start with zero chunks and dynamically add chunks based on write request.
      * @return Newly created log dev id.
      */
-    logdev_id_t create_new_logdev(flush_mode_t flush_mode);
+    logdev_id_t create_new_logdev(flush_mode_t flush_mode, uuid_t pid = boost::uuids::nil_uuid());
 
     /**
      * @brief Open a log dev.
@@ -102,7 +102,7 @@ public:
      * @param logdev_id: Logdev ID
      * @return Newly created log dev id.
      */
-    void open_logdev(logdev_id_t logdev_id, flush_mode_t flush_mode);
+    void open_logdev(logdev_id_t logdev_id, flush_mode_t flush_mode, uuid_t pid = boost::uuids::nil_uuid());
 
     /**
      * @brief Destroy a log dev.
@@ -178,7 +178,8 @@ public:
     void delete_unopened_logdevs();
 
 private:
-    std::shared_ptr< LogDev > create_new_logdev_internal(logdev_id_t logdev_id, flush_mode_t flush_mode);
+    std::shared_ptr< LogDev > create_new_logdev_internal(logdev_id_t logdev_id, flush_mode_t flush_mode,
+                                                         uuid_t pid = boost::uuids::nil_uuid());
     void on_meta_blk_found(const sisl::byte_view& buf, void* meta_cookie);
     logdev_id_t get_next_logdev_id();
     void logdev_super_blk_found(const sisl::byte_view& buf, void* meta_cookie);

--- a/src/lib/logstore/log_dev.cpp
+++ b/src/lib/logstore/log_dev.cpp
@@ -23,6 +23,7 @@
 
 #include <homestore/logstore_service.hpp>
 #include <homestore/meta_service.hpp>
+#include <homestore/fault_cmt_service.hpp>
 #include <homestore/homestore.hpp>
 
 #include "log_dev.hpp"
@@ -43,7 +44,8 @@ SISL_LOGGING_DECL(logstore)
 static bool has_data_service() { return HomeStore::instance()->has_data_service(); }
 // static BlkDataService& data_service() { return HomeStore::instance()->data_service(); }
 
-LogDev::LogDev(logdev_id_t id, flush_mode_t flush_mode) : m_logdev_id{id}, m_flush_mode{flush_mode} {
+LogDev::LogDev(logdev_id_t id, flush_mode_t flush_mode, uuid_t pid) :
+        m_logdev_id{id}, m_flush_mode{flush_mode}, m_parent_id{pid} {
     m_flush_size_multiple = HS_DYNAMIC_CONFIG(logstore->flush_size_multiple_logdev);
 }
 
@@ -64,7 +66,7 @@ void LogDev::start(bool format, std::shared_ptr< JournalVirtualDev > vdev) {
     // First read the info block
     if (format) {
         HS_LOG_ASSERT(m_logdev_meta.is_empty(), "Expected meta to be not present");
-        m_logdev_meta.create(m_logdev_id, m_flush_mode);
+        m_logdev_meta.create(m_logdev_id, m_flush_mode, m_parent_id);
         m_vdev_jd->update_data_start_offset(0);
     } else {
         HS_LOG_ASSERT(!m_logdev_meta.is_empty(),
@@ -488,11 +490,25 @@ bool LogDev::flush() {
             return false;
         }
         auto sz = m_pending_flush_size.fetch_sub(lg->actual_data_size(), std::memory_order_relaxed);
-        HS_REL_ASSERT_GE((sz - lg->actual_data_size()), 0, "size {} lg size {}", sz, lg->actual_data_size());
+        if (sisl_unlikely(sz < lg->actual_data_size()) && hs()->has_fc_service()) {
+            auto const reason = fmt::format("parent_uuid: {}, size {} lg size {}",
+                                            boost::uuids::to_string(get_parent_id()), sz, lg->actual_data_size());
+            hs()->fc_service().trigger_fc(FaultContainmentEvent::ENTER, static_cast< void* >(&m_parent_id), reason);
+            return false;
+        } else {
+            HS_REL_ASSERT_GE((sz - lg->actual_data_size()), 0, "size {} lg size {}", sz, lg->actual_data_size());
+        }
         off_t offset = m_vdev_jd->alloc_next_append_blk(lg->header()->total_size());
         lg->m_log_dev_offset = offset;
 
-        HS_REL_ASSERT_NE(lg->m_log_dev_offset, INVALID_OFFSET, "log dev is full");
+        if (sisl_unlikely(lg->m_log_dev_offset == INVALID_OFFSET) && hs()->has_fc_service()) {
+            auto const reason =
+                fmt::format("parent_uuid: {}, log dev is full", boost::uuids::to_string(get_parent_id()));
+            hs()->fc_service().trigger_fc(FaultContainmentEvent::ENTER, static_cast< void* >(&m_parent_id), reason);
+            return false;
+        } else {
+            HS_REL_ASSERT_NE(lg->m_log_dev_offset, INVALID_OFFSET, "log dev is full");
+        }
         THIS_LOGDEV_LOG(TRACE, "Flushing log group data size={} at offset={} log_group={}", lg->actual_data_size(),
                         offset, *lg);
 
@@ -832,7 +848,7 @@ nlohmann::json LogDev::get_status(int verbosity) const {
 /////////////////////////////// LogDevMetadata Section ///////////////////////////////////////
 LogDevMetadata::LogDevMetadata() : m_sb{logdev_sb_meta_name}, m_rollback_sb{logdev_rollback_sb_meta_name} {}
 
-logdev_superblk* LogDevMetadata::create(logdev_id_t id, flush_mode_t flush_mode) {
+logdev_superblk* LogDevMetadata::create(logdev_id_t id, flush_mode_t flush_mode, uuid_t pid) {
     logdev_superblk* sb = m_sb.create(logdev_sb_size_needed(0));
     rollback_superblk* rsb = m_rollback_sb.create(rollback_superblk::size_needed(1));
 
@@ -842,6 +858,7 @@ logdev_superblk* LogDevMetadata::create(logdev_id_t id, flush_mode_t flush_mode)
     m_id_reserver = std::make_unique< sisl::IDReserver >();
     m_sb->logdev_id = id;
     m_sb->flush_mode = flush_mode;
+    m_sb->pid = pid;
     m_sb.write();
 
     m_rollback_sb->logdev_id = id;

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -15,9 +15,10 @@ SISL_LOGGING_DECL(solorepl)
 namespace homestore {
 SoloReplDev::SoloReplDev(superblk< solo_repl_dev_superblk >&& rd_sb, bool load_existing) :
         m_rd_sb{std::move(rd_sb)}, m_group_id{m_rd_sb->group_id} {
+    auto const gid = m_rd_sb->group_id;
     if (load_existing) {
         m_logdev_id = m_rd_sb->logdev_id;
-        logstore_service().open_logdev(m_rd_sb->logdev_id, flush_mode_t::TIMER);
+        logstore_service().open_logdev(m_rd_sb->logdev_id, flush_mode_t::TIMER, gid);
         logstore_service()
             .open_log_store(m_rd_sb->logdev_id, m_rd_sb->logstore_id, true /* append_mode */)
             .thenValue([this](auto log_store) {
@@ -28,7 +29,7 @@ SoloReplDev::SoloReplDev(superblk< solo_repl_dev_superblk >&& rd_sb, bool load_e
             });
         m_commit_upto = m_rd_sb->durable_commit_lsn;
     } else {
-        m_logdev_id = logstore_service().create_new_logdev(flush_mode_t::TIMER);
+        m_logdev_id = logstore_service().create_new_logdev(flush_mode_t::TIMER, gid);
         m_data_journal = logstore_service().create_new_log_store(m_logdev_id, true /* append_mode */);
         m_rd_sb->logstore_id = m_data_journal->get_store_id();
         m_rd_sb->logdev_id = m_logdev_id;


### PR DESCRIPTION
When FC is enabled by HomeStore consumer (currently only NuBlox, no impact to NuObject use case),
enable ReplDev(Solo)/LogStore/LogDev layers to exersise fault containment feature, e.g. not to crash the whole pod, but let individual Volume to taken action (go into offline mode), so that other volumes which is still in healthy can still function.

HomeStore doesn't have concept of volume, it is through FC to callback to HS consumer to take actions.