### PR TITLE
Optimize Bucket configs for Histogram.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.20"
+    version = "6.20.21"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
@@ -53,7 +53,7 @@ class HomestoreConan(ConanFile):
 
     def requirements(self):
         self.requires("iomgr/[^11.3]@oss/master", transitive_headers=True)
-        self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
+        self.requires("sisl/[^12.4.7]@oss/master", transitive_headers=True)
         self.requires("nuraft_mesg/[~3.8.7]@oss/main", transitive_headers=True)
 
         self.requires("farmhash/cci.20190513@", transitive_headers=True)

--- a/src/include/homestore/btree/detail/btree_internal.hpp
+++ b/src/include/homestore/btree/detail/btree_internal.hpp
@@ -315,9 +315,9 @@ public:
         REGISTER_COUNTER(btree_num_pc_gen_mismatch, "Number of gen mismatches to recover");
 
         REGISTER_HISTOGRAM(btree_int_node_occupancy, "Interior node occupancy", "btree_node_occupancy",
-                           {"node_type", "interior"}, HistogramBucketsType(LinearUpto128Buckets));
+                           {"node_type", "interior"}, HistogramBucketsType(PercentileBuckets));
         REGISTER_HISTOGRAM(btree_leaf_node_occupancy, "Leaf node occupancy", "btree_node_occupancy",
-                           {"node_type", "leaf"}, HistogramBucketsType(LinearUpto128Buckets));
+                           {"node_type", "leaf"}, HistogramBucketsType(PercentileBuckets));
         REGISTER_COUNTER(btree_retry_count, "number of retries");
         REGISTER_COUNTER(write_err_cnt, "number of errors in write");
         REGISTER_COUNTER(query_err_cnt, "number of errors in query");
@@ -326,13 +326,16 @@ public:
         REGISTER_COUNTER(btree_remove_ops_count, "number of btree operations");
         REGISTER_HISTOGRAM(btree_exclusive_time_in_int_node,
                            "Exclusive time spent (Write locked) on interior node (ns)", "btree_exclusive_time_in_node",
-                           {"node_type", "interior"});
+                           {"node_type", "interior"}, HistogramBucketsType(OpLatecyBuckets));
         REGISTER_HISTOGRAM(btree_exclusive_time_in_leaf_node, "Exclusive time spent (Write locked) on leaf node (ns)",
-                           "btree_exclusive_time_in_node", {"node_type", "leaf"});
+                           "btree_exclusive_time_in_node", {"node_type", "leaf"},
+                           HistogramBucketsType(OpLatecyBuckets));
         REGISTER_HISTOGRAM(btree_inclusive_time_in_int_node, "Inclusive time spent (Read locked) on interior node (ns)",
-                           "btree_inclusive_time_in_node", {"node_type", "interior"});
+                           "btree_inclusive_time_in_node", {"node_type", "interior"},
+                           HistogramBucketsType(OpLatecyBuckets));
         REGISTER_HISTOGRAM(btree_inclusive_time_in_leaf_node, "Inclusive time spent (Read locked) on leaf node (ns)",
-                           "btree_inclusive_time_in_node", {"node_type", "leaf"});
+                           "btree_inclusive_time_in_node", {"node_type", "leaf"},
+                           HistogramBucketsType(OpLatecyBuckets));
 
         register_me_to_farm();
     }

--- a/src/include/homestore/checkpoint/cp_mgr.hpp
+++ b/src/include/homestore/checkpoint/cp_mgr.hpp
@@ -35,7 +35,7 @@ public:
     explicit CPMgrMetrics() : sisl::MetricsGroup("CPMgr") {
         REGISTER_COUNTER(back_to_back_cps, "back to back cp");
         REGISTER_COUNTER(cp_cnt, "cp cnt");
-        REGISTER_HISTOGRAM(cp_latency, "cp latency (in us)");
+        REGISTER_HISTOGRAM(cp_latency, "cp latency (in us)", HistogramBucketsType(OpLatecyBuckets));
         register_me_to_farm();
     }
 

--- a/src/include/homestore/meta_service.hpp
+++ b/src/include/homestore/meta_service.hpp
@@ -62,7 +62,8 @@ public:
         REGISTER_COUNTER(compress_backoff_memory_cnt, "compression back-off cnt because of exceending memory limit")
         REGISTER_COUNTER(compress_backoff_ratio_cnt, "compression back-off cnt because of exceeding ratio limit");
 
-        REGISTER_HISTOGRAM(compress_ratio_percent, "compression ration percentage");
+        REGISTER_HISTOGRAM(compress_ratio_percent, "compression ration percentage",
+                           HistogramBucketsType(PercentileBuckets));
         register_me_to_farm();
     }
 

--- a/src/lib/blkalloc/varsize_blk_allocator.h
+++ b/src/lib/blkalloc/varsize_blk_allocator.h
@@ -180,7 +180,7 @@ public:
         REGISTER_COUNTER(num_blks_alloc_direct, "Number of blks alloc attempt directly because of empty cache");
 
         REGISTER_HISTOGRAM(frag_pct_distribution, "Distribution of fragmentation percentage",
-                           HistogramBucketsType(LinearUpto64Buckets));
+                           HistogramBucketsType(PercentileBuckets));
 
         register_me_to_farm();
     }

--- a/src/lib/device/physical_dev.hpp
+++ b/src/lib/device/physical_dev.hpp
@@ -48,8 +48,10 @@ public:
         REGISTER_COUNTER(drive_spurios_events, "Total number of spurious events per drive");
         REGISTER_COUNTER(drive_skipped_chunk_bm_writes, "Total number of skipped writes for chunk bitmap");
 
-        REGISTER_HISTOGRAM(drive_write_latency, "BlkStore drive write latency in us");
-        REGISTER_HISTOGRAM(drive_read_latency, "BlkStore drive read latency in us");
+        REGISTER_HISTOGRAM(drive_write_latency, "BlkStore drive write latency in us",
+                           HistogramBucketsType(OpLatecyBuckets));
+        REGISTER_HISTOGRAM(drive_read_latency, "BlkStore drive read latency in us",
+                           HistogramBucketsType(OpLatecyBuckets));
 
         REGISTER_HISTOGRAM(write_io_sizes, "Write IO Sizes", "io_sizes", {"io_direction", "write"},
                            HistogramBucketsType(ExponentialOfTwoBuckets));

--- a/src/lib/device/virtual_dev.hpp
+++ b/src/lib/device/virtual_dev.hpp
@@ -54,7 +54,8 @@ public:
         REGISTER_COUNTER(default_chunk_allocation_cnt, "default chunk allocation count");
         REGISTER_COUNTER(random_chunk_allocation_cnt,
                          "random chunk allocation count"); // ideally it should be zero for hdd
-        REGISTER_HISTOGRAM(blk_alloc_latency, "Blk allocation latency", "blk_alloc_latency");
+        REGISTER_HISTOGRAM(blk_alloc_latency, "Blk allocation latency", "blk_alloc_latency", {},
+                           HistogramBucketsType(OpLatecyBuckets));
         register_me_to_farm();
     }
 

--- a/src/lib/logstore/log_store_service.cpp
+++ b/src/lib/logstore/log_store_service.cpp
@@ -404,23 +404,25 @@ LogStoreServiceMetrics::LogStoreServiceMetrics() : sisl::MetricsGroup("LogStores
                      {"op", "write"});
     REGISTER_COUNTER(logstore_read_count, "Total number of read requests to log stores", "logstore_op_count",
                      {"op", "read"});
-    REGISTER_HISTOGRAM(logstore_append_latency, "Logstore append latency", "logstore_op_latency", {"op", "write"});
+    REGISTER_HISTOGRAM(logstore_append_latency, "Logstore append latency", "logstore_op_latency", {"op", "write"},
+                       HistogramBucketsType(OpLatecyBuckets));
 #ifdef _PRERELEASE
     REGISTER_HISTOGRAM(logstore_stream_tracker_lock_latency, "Logstore stream tracker lock latency",
                        "logstore_stream_tracker_lock_latency");
 #endif
-    REGISTER_HISTOGRAM(logstore_read_latency, "Logstore read latency", "logstore_op_latency", {"op", "read"});
+    REGISTER_HISTOGRAM(logstore_read_latency, "Logstore read latency", "logstore_op_latency", {"op", "read"},
+                       HistogramBucketsType(OpLatecyBuckets));
     REGISTER_HISTOGRAM(logdev_flush_size_distribution, "Distribution of flush data size",
                        HistogramBucketsType(ExponentialOfTwoBuckets));
     REGISTER_HISTOGRAM(logdev_flush_records_distribution, "Distribution of num records to flush",
                        HistogramBucketsType(LinearUpto128Buckets));
     REGISTER_HISTOGRAM(logstore_record_size, "Distribution of log record size",
                        HistogramBucketsType(ExponentialOfTwoBuckets));
-    REGISTER_HISTOGRAM(logdev_flush_done_msg_time_ns, "Logdev flush completion msg time in ns");
     REGISTER_HISTOGRAM(logdev_post_flush_processing_latency,
-                       "Logdev post flush processing (including callbacks) latency");
-    REGISTER_HISTOGRAM(logdev_flush_time_us, "time elapsed since last flush time in us");
-    REGISTER_HISTOGRAM(logdev_fsync_time_us, "Logdev fsync completion time in us");
+                       "Logdev post flush processing (including callbacks) latency",
+                       HistogramBucketsType(OpLatecyBuckets));
+    REGISTER_HISTOGRAM(logdev_flush_time_us, "time elapsed since last flush time in us",
+                       HistogramBucketsType(OpLatecyBuckets));
 
     register_me_to_farm();
 }

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -90,42 +90,35 @@ public:
         // leader: data write latency;
         // follower: from rreq push data received to data write completion;
         REGISTER_HISTOGRAM(rreq_data_write_latency_us, "rreq data write latency in us", "rreq_data_op_latency",
-                           {"op", "write"});
-        REGISTER_HISTOGRAM(rreq_data_read_latency_us, "rreq data read latency in us", "rreq_data_op_latency",
-                           {"op", "read"}); // placeholder
+                           {"op", "write"}, HistogramBucketsType(OpLatecyBuckets));
         REGISTER_HISTOGRAM(rreq_push_data_latency_us, "rreq data write latency in us", "rreq_data_op_latency",
-                           {"op", "push"});
-        // latency from req received to sending response
-        REGISTER_HISTOGRAM(rreq_data_write_respond_latency_us, "rreq data write and respond latency in us",
-                           "rreq_data_op_latency", {"op", "respond"});
-        // latency from req received to rpc complete
-        REGISTER_HISTOGRAM(rreq_data_write_complete_latency_us, "rreq data rpc complete latency in us",
-                           "rreq_data_op_latency", {"op", "complete"});
+                           {"op", "push"}, HistogramBucketsType(OpLatecyBuckets));
         // latency from follower->originator->follower, not including actual data write on follower;
         REGISTER_HISTOGRAM(rreq_data_fetch_latency_us, "rreq data fetch latency in us", "rreq_data_op_latency",
-                           {"op", "fetch"});
+                           {"op", "fetch"}, HistogramBucketsType(OpLatecyBuckets));
 
         /* from rreq creation to data ops completion */
-        REGISTER_HISTOGRAM(rreq_total_data_read_latency_us, "rreq data read latency in us", "rdev_data_op_latency",
-                           {"op", "read"}); // placeholder
         REGISTER_HISTOGRAM(rreq_total_data_write_latency_us, "rreq data write latency in us", "rdev_data_op_latency",
-                           {"op", "write"});
+                           {"op", "write"}, HistogramBucketsType(OpLatecyBuckets));
 
         REGISTER_HISTOGRAM(rreq_pieces_per_write, "Number of individual pieces per write",
-                           HistogramBucketsType(LinearUpto64Buckets));
+                           HistogramBucketsType(SteppedUpto32Buckets));
 
         // In the identical layout chunk, the blk num of the follower and leader is expected to be the same.
         // However, due to the concurrency between the data channel and the raft channel, there might be some
         // allocation differences on the same lsn. When a leader switch occurs, these differences could become garbage.
         // This metric can partially reflect the potential amount of garbage.
         REGISTER_HISTOGRAM(blk_diff_with_proposer,
-                           "allocated blk num diff on the same lsn with proposer when chunk usage >= 0.9");
+                           "allocated blk num diff on the same lsn with proposer when chunk usage >= 0.9",
+                           HistogramBucketsType(ExponentialOfTwoBuckets));
 
         // Raft channel metrics
         REGISTER_HISTOGRAM(raft_end_of_append_batch_latency_us, "Raft end_of_append_batch latency in us",
-                           "raft_logstore_append_latency", {"op", "end_of_append_batch"});
+                           "raft_logstore_append_latency", {"op", "end_of_append_batch"},
+                           HistogramBucketsType(OpLatecyBuckets));
         REGISTER_HISTOGRAM(data_channel_wait_latency_us, "Data channel wait latency in us",
-                           "raft_logstore_append_latency", {"op", "wait_for_data"});
+                           "raft_logstore_append_latency", {"op", "wait_for_data"},
+                           HistogramBucketsType(OpLatecyBuckets));
 
         register_me_to_farm();
     }


### PR DESCRIPTION
Mostly,
1. for latency related metrics, change to use OpLatencyBucket
2. for percentile, use PercentileBuckets.
3. Remove some unused (no observation) metrics.