### PR TITLE
[DNM] add uint64 checksum log for blk data

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.23"
+    version = "6.20.24"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <openssl/evp.h>
 
 #include <libnuraft/ptr.hxx>
 #include <nuraft_mesg/nuraft_mesg.hpp>
@@ -461,6 +462,7 @@ private:
     void fetch_data_from_remote(std::vector< repl_req_ptr_t > rreqs);
     void handle_fetch_data_response(sisl::GenericClientResponse response, std::vector< repl_req_ptr_t > rreqs);
     bool is_resync_mode();
+    uint64_t sha256ToUint64(const void* data, size_t length);
 
     /**
      * \brief This method handles errors that occur during append entries or data receiving.


### PR DESCRIPTION
this PR add uint64_t checksum for push_data/on_push_data_received and on_fetch_data_received/handle_fetch_data_response, so that we can directly check whether data is corrupted during network transmission from the log.

next step, we need to drop the received data if it is found corrupted.