### PR TITLE
fix found issues

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.23"
+    version = "6.20.24"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -2528,8 +2528,8 @@ void RaftReplDev::become_leader_cb() {
     auto current_gate = m_traffic_ready_lsn.load();
     auto new_gate = raft_server()->get_last_log_idx();
 
-    HS_REL_ASSERT(new_gate >= current_gate, "new_gate={} should be equal or larger than current_gate={}!", new_gate,
-                  current_gate);
+    RD_REL_ASSERT(new_gate >= static_cast< uint64_t >(current_gate),
+                  "new_gate={} should be equal or larger than current_gate={}!", new_gate, current_gate);
 
     m_traffic_ready_lsn.store(new_gate);
     // in nuraft, a leader might become a new leader directly, which means it is unnecessary to become a follower before

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -2527,8 +2527,11 @@ ReplServiceError RaftReplDev::init_req_ctx(repl_req_ptr_t rreq, repl_key rkey, j
 void RaftReplDev::become_leader_cb() {
     auto current_gate = m_traffic_ready_lsn.load();
     auto new_gate = raft_server()->get_last_log_idx();
-    m_traffic_ready_lsn.store(new_gate);
 
+    HS_REL_ASSERT(new_gate >= current_gate, "new_gate={} should be equal or larger than current_gate={}!", new_gate,
+                  current_gate);
+
+    m_traffic_ready_lsn.store(new_gate);
     // in nuraft, a leader might become a new leader directly, which means it is unnecessary to become a follower before
     // becoming a leader.
 

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -357,11 +357,7 @@ public:
 
     void become_leader_cb();
 
-    void become_follower_cb() {
-        // m_traffic_ready_lsn should be zero on follower.
-        m_traffic_ready_lsn.store(0);
-        RD_LOGD(NO_TRACE_ID, "become_follower_cb setting  traffic_ready_lsn to 0");
-    }
+    void become_follower_cb() { RD_LOGD(NO_TRACE_ID, "become_follower_cb called!"); }
 
     /// @brief This method is called when the data journal is compacted
     ///

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -357,9 +357,9 @@ public:
 
     void become_leader_cb();
 
-    void become_follower_cb() {
+    void become_follower_cb() { 
         m_traffic_ready_lsn.store(0);
-        RD_LOGD(NO_TRACE_ID, "become_follower_cb called!");
+        RD_LOGD(NO_TRACE_ID, "become_follower_cb called!"); 
     }
 
     /// @brief This method is called when the data journal is compacted

--- a/src/lib/replication/repl_dev/raft_repl_dev.h
+++ b/src/lib/replication/repl_dev/raft_repl_dev.h
@@ -357,7 +357,10 @@ public:
 
     void become_leader_cb();
 
-    void become_follower_cb() { RD_LOGD(NO_TRACE_ID, "become_follower_cb called!"); }
+    void become_follower_cb() {
+        m_traffic_ready_lsn.store(0);
+        RD_LOGD(NO_TRACE_ID, "become_follower_cb called!");
+    }
 
     /// @brief This method is called when the data journal is compacted
     ///

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -207,6 +207,13 @@ void RaftReplService::start() {
 }
 
 void RaftReplService::stop() {
+    // we stop reaper thread here before destorying repl_dev to prevent data from being fetched after repl_dev is
+    // stopped.
+
+    // FIXME: there is still a case that before we stop_reaper_thread, some fetch_data requests have already been sent
+    // out. we need use a counter to make sure all the fetch_data request has completed.
+    stop_reaper_thread();
+
     start_stopping();
     while (true) {
         auto pending_request_num = get_pending_request_num();
@@ -236,8 +243,7 @@ void RaftReplService::stop() {
 }
 
 RaftReplService::~RaftReplService() {
-    stop_reaper_thread();
-
+    LOGINFO("raft_repl_service has been destructed!");
     // the base class destructor will clear the m_rd_map
 }
 


### PR DESCRIPTION
1 in nuraft, a leader might become a new leader directly, we need adapt to this case.
2 for the error happens in on_fetch_data_received( in originator), do not assert, just ignore this request and let follower retry.
3 when stopping raft_repl_service, we should stop the reaper thread first so that fetch data will not happen after the repl_dev is destroyed.