### PR TITLE
init nuraft message port by the current repl svc port

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.23"
+    version = "6.20.24"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -114,6 +114,9 @@ public:
 
     // Get the current application/server repl uuid
     virtual replica_id_t get_my_repl_id() const = 0;
+
+    // Get the current replication service port
+    virtual uint32_t get_my_repl_svc_port() const = 0;
 };
 
 } // namespace homestore

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -87,7 +87,7 @@ void RaftReplService::start() {
     std::string ssl_ca_file = HS_DYNAMIC_CONFIG(consensus.ssl_ca_file);
     auto params = nuraft_mesg::Manager::Params{
         .server_uuid_ = m_my_uuid,
-        .mesg_port_ = m_repl_app->lookup_peer(m_my_uuid).second,
+        .mesg_port_ = static_cast< uint16_t >(m_repl_app->get_my_repl_svc_port()),
         .default_group_type_ = "homestore_replication",
         .ssl_key_ = ioenvironment.get_ssl_key(),
         .ssl_cert_ = ioenvironment.get_ssl_cert(),

--- a/src/tests/test_common/hs_repl_test_common.hpp
+++ b/src/tests/test_common/hs_repl_test_common.hpp
@@ -135,6 +135,9 @@ public:
         }
 
         homestore::replica_id_t get_my_repl_id() const override { return helper_.my_replica_id_; }
+        uint32_t get_my_repl_svc_port() const override {
+            return SISL_OPTIONS["base_port"].as< uint16_t >() + helper_.replica_num_;
+        }
     };
 
 public:

--- a/src/tests/test_solo_repl_dev.cpp
+++ b/src/tests/test_solo_repl_dev.cpp
@@ -160,6 +160,7 @@ public:
         void on_repl_devs_init_completed() { LOGINFO("Repl dev init completed CB called"); }
         std::pair< std::string, uint16_t > lookup_peer(uuid_t uuid) const override { return std::make_pair("", 0u); }
         replica_id_t get_my_repl_id() const override { return hs_utils::gen_random_uuid(); }
+        uint32_t get_my_repl_svc_port() const override { return 0; }
     };
 
 protected:


### PR DESCRIPTION
So we don't need to rely on cm to get the port