### PR TITLE
add rreq check before appending logs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.25"
+    version = "6.20.26"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -2090,26 +2090,6 @@ nuraft::cb_func::ReturnCode RaftReplDev::raft_event(nuraft::cb_func::Type type, 
         become_leader_cb();
         return nuraft::cb_func::ReturnCode::Ok;
     }
-        // this is called on leader before appending the log entries.
-        // leader will assign the current term to each log entry, we check if the corrsponding rreq exists. if not ,
-        // refuse the request batch.
-    case nuraft::cb_func::Type::ProcessReq: {
-        auto req = r_cast< nuraft::req_msg* >(param->ctx);
-        for (const auto& entry : req->log_entries()) {
-            // add_srv and remove_srv will hit here, ignore them
-            if (entry->get_val_type() != nuraft::log_val_type::app_log) continue;
-
-            repl_journal_entry* jentry = r_cast< repl_journal_entry* >(entry->get_buf().data_begin());
-            repl_key rkey{.server_id = jentry->server_id,
-                          .term = raft_server()->get_term(),
-                          .dsn = jentry->dsn,
-                          .traceID = jentry->traceID};
-            if (m_repl_key_req_map.find(rkey) == m_repl_key_req_map.cend()) {
-                return nuraft::cb_func::ReturnCode::ReturnNull;
-            }
-        }
-        return nuraft::cb_func::ReturnCode::Ok;
-    }
 
     // RemovedFromCluster will be handled in nuraft_mesg::generic_raft_event_handler where leave() is called
 

--- a/src/lib/replication/repl_dev/raft_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/raft_repl_dev.cpp
@@ -249,11 +249,21 @@ AsyncReplResult<> RaftReplDev::start_replace_member(std::string& task_id, const 
     auto ctx = replace_member_ctx(task_id, member_out, member_in);
 
     sisl::blob header(r_cast< uint8_t* >(&ctx), sizeof(replace_member_ctx));
-    rreq->init(repl_key{.server_id = server_id(),
-                        .term = raft_server()->get_term(),
-                        .dsn = m_next_dsn.fetch_add(1),
-                        .traceID = trace_id},
-               journal_type_t::HS_CTRL_START_REPLACE, true, header, sisl::blob{}, 0, m_listener);
+
+    auto status = init_req_ctx(rreq,
+                               repl_key{.server_id = server_id(),
+                                        .term = raft_server()->get_term(),
+                                        .dsn = m_next_dsn.fetch_add(1),
+                                        .traceID = trace_id},
+                               journal_type_t::HS_CTRL_START_REPLACE, true /* is_proposer */, header, sisl::blob{}, 0,
+                               m_listener);
+
+    if (status != ReplServiceError::OK) {
+        RD_LOGE(trace_id, "Initializing rreq failed, rreq=[{}], error={}", rreq->to_string(), status);
+    }
+
+    auto const [_, happened] = m_repl_key_req_map.emplace(rreq->rkey(), rreq);
+    RD_DBG_ASSERT(happened, "Duplicate repl_key={} found in the map", rreq->rkey().to_string());
 
     auto err = m_state_machine->propose_to_raft(std::move(rreq));
     if (err != ReplServiceError::OK) {
@@ -361,11 +371,21 @@ AsyncReplResult<> RaftReplDev::complete_replace_member(std::string& task_id, con
     auto ctx = replace_member_ctx(task_id, member_out, member_in);
 
     sisl::blob header(r_cast< uint8_t* >(&ctx), sizeof(replace_member_ctx));
-    rreq->init(repl_key{.server_id = server_id(),
-                        .term = raft_server()->get_term(),
-                        .dsn = m_next_dsn.fetch_add(1),
-                        .traceID = trace_id},
-               journal_type_t::HS_CTRL_COMPLETE_REPLACE, true, header, sisl::blob{}, 0, m_listener);
+
+    auto status = init_req_ctx(rreq,
+                               repl_key{.server_id = server_id(),
+                                        .term = raft_server()->get_term(),
+                                        .dsn = m_next_dsn.fetch_add(1),
+                                        .traceID = trace_id},
+                               journal_type_t::HS_CTRL_COMPLETE_REPLACE, true /* is_proposer */, header, sisl::blob{},
+                               0, m_listener);
+
+    if (status != ReplServiceError::OK) {
+        RD_LOGE(trace_id, "Initializing rreq failed, rreq=[{}], error={}", rreq->to_string(), status);
+    }
+
+    auto const [_, happened] = m_repl_key_req_map.emplace(rreq->rkey(), rreq);
+    RD_DBG_ASSERT(happened, "Duplicate repl_key={} found in the map", rreq->rkey().to_string());
 
     auto err = m_state_machine->propose_to_raft(std::move(rreq));
     if (err != ReplServiceError::OK) {
@@ -681,6 +701,9 @@ folly::SemiFuture< ReplServiceError > RaftReplDev::destroy_group() {
         return folly::makeSemiFuture< ReplServiceError >(std::move(err));
     }
 
+    auto const [_, happened] = m_repl_key_req_map.emplace(rreq->rkey(), rreq);
+    RD_DBG_ASSERT(happened, "Duplicate repl_key={} found in the map", rreq->rkey().to_string());
+
     err = m_state_machine->propose_to_raft(std::move(rreq));
     if (err != ReplServiceError::OK) {
         m_stage.update([](auto* stage) { *stage = repl_dev_stage_t::ACTIVE; });
@@ -729,11 +752,22 @@ void RaftReplDev::propose_truncate_boundary() {
         auto ctx = truncate_ctx(truncation_upper_limit);
 
         sisl::blob header(r_cast< uint8_t* >(&ctx), sizeof(truncate_ctx));
-        rreq->init(repl_key{.server_id = server_id(),
-                            .term = raft_server()->get_term(),
-                            .dsn = m_next_dsn.fetch_add(1),
-                            .traceID = std::numeric_limits< uint64_t >::max()},
-                   journal_type_t::HS_CTRL_UPDATE_TRUNCATION_BOUNDARY, true, header, sisl::blob{}, 0, m_listener);
+
+        auto status = init_req_ctx(rreq,
+                                   repl_key{.server_id = server_id(),
+                                            .term = raft_server()->get_term(),
+                                            .dsn = m_next_dsn.fetch_add(1),
+                                            .traceID = std::numeric_limits< uint64_t >::max()},
+                                   journal_type_t::HS_CTRL_UPDATE_TRUNCATION_BOUNDARY, true /* is_proposer */, header,
+                                   sisl::blob{}, 0, m_listener);
+
+        if (status != ReplServiceError::OK) {
+            RD_LOGE(std::numeric_limits< uint64_t >::max(), "Initializing rreq failed, rreq=[{}], error={}",
+                    rreq->to_string(), status);
+        }
+
+        auto const [_, happened] = m_repl_key_req_map.emplace(rreq->rkey(), rreq);
+        RD_DBG_ASSERT(happened, "Duplicate repl_key={} found in the map", rreq->rkey().to_string());
 
         auto err = m_state_machine->propose_to_raft(std::move(rreq));
         if (err != ReplServiceError::OK) {
@@ -785,7 +819,7 @@ void RaftReplDev::async_alloc_write(sisl::blob const& header, sisl::blob const& 
             header.size(), key.size(), data.size);
 
     // Add the request to the repl_dev_rreq map, it will be accessed throughout the life cycle of this request
-    auto const [it, happened] = m_repl_key_req_map.emplace(rreq->rkey(), rreq);
+    auto const [_, happened] = m_repl_key_req_map.emplace(rreq->rkey(), rreq);
     RD_DBG_ASSERT(happened, "Duplicate repl_key={} found in the map", rreq->rkey().to_string());
 
     // If it is header only entry, directly propose to the raft
@@ -2054,6 +2088,26 @@ nuraft::cb_func::ReturnCode RaftReplDev::raft_event(nuraft::cb_func::Type type, 
     case nuraft::cb_func::Type::BecomeLeader: {
         RD_LOGD(NO_TRACE_ID, "Raft channel: Received BecomeLeader");
         become_leader_cb();
+        return nuraft::cb_func::ReturnCode::Ok;
+    }
+        // this is called on leader before appending the log entries.
+        // leader will assign the current term to each log entry, we check if the corrsponding rreq exists. if not ,
+        // refuse the request batch.
+    case nuraft::cb_func::Type::ProcessReq: {
+        auto req = r_cast< nuraft::req_msg* >(param->ctx);
+        for (const auto& entry : req->log_entries()) {
+            // add_srv and remove_srv will hit here, ignore them
+            if (entry->get_val_type() != nuraft::log_val_type::app_log) continue;
+
+            repl_journal_entry* jentry = r_cast< repl_journal_entry* >(entry->get_buf().data_begin());
+            repl_key rkey{.server_id = jentry->server_id,
+                          .term = raft_server()->get_term(),
+                          .dsn = jentry->dsn,
+                          .traceID = jentry->traceID};
+            if (m_repl_key_req_map.find(rkey) == m_repl_key_req_map.cend()) {
+                return nuraft::cb_func::ReturnCode::ReturnNull;
+            }
+        }
         return nuraft::cb_func::ReturnCode::Ok;
     }
 

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -39,7 +39,10 @@ ReplServiceError RaftStateMachine::propose_to_raft(repl_req_ptr_t rreq) {
     auto* vec = sisl::VectorPool< raft_buf_ptr_t >::alloc();
     vec->push_back(rreq->raft_journal_buf());
 
-    auto append_status = m_rd.raft_server()->append_entries(*vec);
+    nuraft::raft_server::req_ext_params ex_params;
+    ex_params.expected_term_ = rreq->term();
+
+    auto append_status = m_rd.raft_server()->append_entries_ext(*vec, ex_params);
     sisl::VectorPool< raft_buf_ptr_t >::free(vec);
 
     if (append_status && !append_status->get_accepted()) {

--- a/src/lib/replication/repl_dev/raft_state_machine.h
+++ b/src/lib/replication/repl_dev/raft_state_machine.h
@@ -122,8 +122,10 @@ public:
 
     ////////// APIs outside of nuraft::state_machine requirements ////////////////////
     ReplServiceError propose_to_raft(repl_req_ptr_t rreq);
+
     repl_req_ptr_t localize_journal_entry_prepare(nuraft::log_entry& lentry, int64_t lsn = -1);
     repl_req_ptr_t localize_journal_entry_finish(nuraft::log_entry& lentry);
+
     void link_lsn_to_req(repl_req_ptr_t rreq, int64_t lsn);
     void unlink_lsn_to_req(int64_t lsn, repl_req_ptr_t rreq);
     repl_req_ptr_t lsn_to_req(int64_t lsn);


### PR DESCRIPTION
this PR tried to fix issue #810 .
before append log, we check if the corresponding rreq exist . if not , we drop this request. so , when term changes between init_req_ctx and propose_to_raft, the request will be rejected