### PR TITLE
fix init rreq

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.27"
+    version = "6.20.28"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -72,7 +72,8 @@ struct repl_key {
 
     bool operator==(repl_key const& other) const = default;
     std::string to_string() const {
-        return fmt::format("server={}, term={}, dsn={}, hash={}", server_id, term, dsn, Hasher()(*this));
+        return fmt::format("server={}, term={}, dsn={}, hash={}, trace_id={}", server_id, term, dsn, Hasher()(*this),
+                           traceID);
     }
 };
 

--- a/src/lib/replication/log_store/repl_log_store.cpp
+++ b/src/lib/replication/log_store/repl_log_store.cpp
@@ -15,7 +15,7 @@ uint64_t ReplLogStore::append(nuraft::ptr< nuraft::log_entry >& entry) {
         return lsn;
     }
 
-    repl_req_ptr_t rreq = m_sm.localize_journal_entry_finish(*entry, true /* is_append_log */);
+    repl_req_ptr_t rreq = m_sm.localize_journal_entry_finish(*entry);
     RELEASE_ASSERT_NE(nullptr != rreq, "Failed to localize journal entry before appending log");
 
     ulong lsn = HomeRaftLogStore::append(entry);

--- a/src/lib/replication/repl_dev/raft_state_machine.cpp
+++ b/src/lib/replication/repl_dev/raft_state_machine.cpp
@@ -133,7 +133,7 @@ out:
     return rreq;
 }
 
-repl_req_ptr_t RaftStateMachine::localize_journal_entry_finish(nuraft::log_entry& lentry, bool is_append_log) {
+repl_req_ptr_t RaftStateMachine::localize_journal_entry_finish(nuraft::log_entry& lentry) {
     // Try to locate the rreq based on the log_entry.
     // If we are able to locate that req in the map for this entry, it could be one of
     //  a) This is an inline data and don't need any localization
@@ -164,11 +164,6 @@ repl_req_ptr_t RaftStateMachine::localize_journal_entry_finish(nuraft::log_entry
         .server_id = jentry->server_id, .term = lentry.get_term(), .dsn = jentry->dsn, .traceID = jentry->traceID};
 
     auto rreq = m_rd.repl_key_to_req(rkey);
-
-    if (is_append_log) {
-        // make sure the rreq exists before appending the log, both leader and follower
-        RELEASE_ASSERT(rreq, "Failed to find in-memory rreq for repl_key={} before appending log", rkey.to_string());
-    }
 
     if ((rreq == nullptr) || (rreq->is_localize_pending())) {
         rreq = localize_journal_entry_prepare(lentry,

--- a/src/lib/replication/repl_dev/raft_state_machine.h
+++ b/src/lib/replication/repl_dev/raft_state_machine.h
@@ -124,7 +124,7 @@ public:
     ReplServiceError propose_to_raft(repl_req_ptr_t rreq);
 
     repl_req_ptr_t localize_journal_entry_prepare(nuraft::log_entry& lentry, int64_t lsn = -1);
-    repl_req_ptr_t localize_journal_entry_finish(nuraft::log_entry& lentry, bool is_append_log = false);
+    repl_req_ptr_t localize_journal_entry_finish(nuraft::log_entry& lentry);
 
     void link_lsn_to_req(repl_req_ptr_t rreq, int64_t lsn);
     void unlink_lsn_to_req(int64_t lsn, repl_req_ptr_t rreq);


### PR DESCRIPTION
we should do a deep copy for the user header , otherwise if the input user_header is freed after the call is returned, then m_header will become a dangling blob(the pointer in it is a dangling pointer).

> why homestore start_replace_member/complete_replace_member(header involved) works well with this error

previously, we do not create and add rreq in to m_repl_key_req_map before propose_to_raft. the rreq is created and inserted into rreq when applier_create_req, where we created the rreq from the raft log entry, and the the in-memory log entry is available when the rreq#header is used, so the shallow copy works.

but now we create and add rreq in to m_repl_key_req_map before propose_to_raft.

so for follower , it works well since it is still created in applier_create_req

but for leader, the rreq , where the [header blob](https://github.com/eBay/HomeStore/blob/2f0e74d8147f1dbacbb981d4c71cff837167f573/src/lib/replication/repl_dev/raft_repl_dev.cpp#L250) is destroyed after we propose_to_raft. so the header of the rreq in m_repl_key_req_map will become a dangling blob.  

