### PR TITLE
Blk alloc race

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.28"
+    version = "6.20.29"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/blkalloc/varsize_blk_allocator.cpp
+++ b/src/lib/blkalloc/varsize_blk_allocator.cpp
@@ -658,11 +658,11 @@ BlkAllocStatus VarsizeBlkAllocator::reserve_on_cache(BlkId const& bid) {
 }
 
 void VarsizeBlkAllocator::free(BlkId const& bid) {
+    if (is_persistent()) { free_on_disk(bid); }
     blk_count_t n_freed = (m_cfg.m_use_slabs && (bid.blk_count() <= m_cfg.highest_slab_blks_count()))
         ? free_blks_slab(r_cast< MultiBlkId const& >(bid))
         : free_blks_direct(r_cast< MultiBlkId const& >(bid));
 
-    if (is_persistent()) { free_on_disk(bid); }
     decr_alloced_blk_count(n_freed);
     BLKALLOC_LOG(TRACE, "Freed blk_num={}", bid.to_string());
 }

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -240,7 +240,7 @@ void SoloReplDev::cp_flush(CP*) {
     m_rd_sb->last_checkpoint_lsn_2 = m_rd_sb->last_checkpoint_lsn_1;
     m_rd_sb->last_checkpoint_lsn_1 = m_rd_sb->checkpoint_lsn;
     m_rd_sb->checkpoint_lsn = lsn;
-    HS_LOG(TRACE, solorepl, "dev={} cp flush cp_lsn={} cp_lsn_1={} cp_lsn_2={}", boost::uuids::to_string(group_id()),
+    HS_LOG(INFO, solorepl, "dev={} cp flush cp_lsn={} cp_lsn_1={} cp_lsn_2={}", boost::uuids::to_string(group_id()),
            lsn, m_rd_sb->last_checkpoint_lsn_1, m_rd_sb->last_checkpoint_lsn_2);
     m_rd_sb.write();
 }
@@ -252,7 +252,7 @@ void SoloReplDev::truncate() {
 
     // Truncate is safe anything below last_checkpoint_lsn - 2 as all the free blks
     // before that will be flushed in the last_checkpoint.
-    HS_LOG(TRACE, solorepl, "dev={} truncating at lsn={}", boost::uuids::to_string(group_id()),
+    HS_LOG(INFO, solorepl, "dev={} truncating at lsn={}", boost::uuids::to_string(group_id()),
            m_rd_sb->last_checkpoint_lsn_2);
     m_data_journal->truncate(m_rd_sb->last_checkpoint_lsn_2);
 }

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -117,6 +117,8 @@ public:
     void cp_cleanup(CP* cp);
 
     void destroy();
+
+    // solo repl device truncation is triggerred by CP after flushing all the data in its cp_cleanup routine;
     void truncate();
 
 private:


### PR DESCRIPTION
This issue is found during long hour running for NuBlox 2.0

This is change in varsize block allocator will not impact NuObject 2.0 as it doesn't use varsize blk allocator in write IO.

This issue was in HomeStore 4.x only and not impacting 1.3 NuBlox as it handles free blk differently. 

Root Cause
=========
In HomeStore 4.x, when there is an overwrite on an existing LBA, the previously associated physical block pointed by this LBA will be unlinked and we need to free this old written block. Freeing a block requires HomeBlocks to put free block into a list and this free block list will only be persisted to disk bitmap during next CP (checkpoint). 

When next CP arrives, the CP manager calls virtual device to flush every dirtied chunk bitmap. And when this particular chunk is trying to flush the free block to its disk bitmap, there is small race window that we:
1. Firstly unset the bit from cache bitmap, then
2. Acquire the block allocator’s portion lock and unset the bit from diskbitmap. 

What happened in this long running I/O load is:
1. The allocation thread comes after step-1 finishes, the cache bitmap opens the same block available for allocation.
2. The allocation thread does pick the same block successfully and in the same thread it does `alloc_sanity_check` and acquired the portion lock before the CP routine (previously step-2), and check the disk bitmap still showing in-use state. 
3.  What's worse is in production which is release build, alloc_sanity_check will not be called and the CP routine will go ahead freeing the block that has just been allocated successfully in the IO path which will cause data corruption.

Testing:
========
Without the fix, the issue can be reproduced consistently with 32 volumes running random IO.
With the fix, same test can run for more than 72 hours.
