### PR TITLE
bump openssl version and enable WriteWithSLL UT for raft repl dev

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.0.0"
+    version = "7.0.1"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
@@ -61,7 +61,7 @@ class HomestoreConan(ConanFile):
             self.requires("isa-l/2.30.0", transitive_headers=True)
 
         # Tests require OpenSSL 3.x
-        self.requires("openssl/[^3.1]", override=True)
+        self.requires("openssl/[^3.6]", override=True)
 
     def imports(self):
         self.copy(root_package="sisl", pattern="*", dst="bin/scripts/python/flip/", src="bindings/flip/python/", keep_path=False)

--- a/src/tests/test_raft_repl_dev.cpp
+++ b/src/tests/test_raft_repl_dev.cpp
@@ -699,7 +699,6 @@ TEST_F(RaftReplDevTest, RaftLogTruncationTest) {
     LOGINFO("RaftLogTruncationTest done");
 }
 
-#if 0
 TEST_F(RaftReplDevTest, WriteWithSSL) {
     LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());
     g_helper->sync_for_test_start();
@@ -744,7 +743,6 @@ TEST_F(RaftReplDevTest, WriteWithSSL) {
         [prev_ssl_ca_file](auto& s) { s.consensus.ssl_ca_file = prev_ssl_ca_file; });
     HS_SETTINGS_FACTORY().save();
 }
-#endif
 
 TEST_F(RaftReplDevTest, ReconcileLeader) {
     LOGINFO("Homestore replica={} setup completed", g_helper->replica_num());


### PR DESCRIPTION
since we have conan2 in github CI now, this PR try to bump ssl to the latest version and solve this issue
https://github.com/eBay/HomeStore/pull/756#issuecomment-3443275679