### PR TITLE
Add isblk alloced and free_blk_now api in dataservice.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.3.1"
+    version = "7.3.2"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/blkdata_service.hpp
+++ b/src/include/homestore/blkdata_service.hpp
@@ -202,6 +202,22 @@ public:
     folly::Future< std::error_code > async_free_blk(MultiBlkId const& bid);
 
     /**
+     * @brief Frees the specified block IDs immediately. Used during log replay on commit only.
+     *
+     * @param bid The block ID to free.
+     * @return An error code indicating the result of the operation.
+     */
+    std::error_code free_blk_now(MultiBlkId const& bid);
+
+    /**
+     * @brief Check if the blk id is free or not.
+     *
+     * @param bid The block ID to check.
+     * @return Return whether blkid is alloced or not.
+     */
+    bool is_blk_alloced(BlkId const& blkid) const;
+
+    /**
      * @brief : get the blk size of this data service;
      *
      * @return : blk size

--- a/src/lib/blkalloc/bitmap_blk_allocator.cpp
+++ b/src/lib/blkalloc/bitmap_blk_allocator.cpp
@@ -157,7 +157,9 @@ sisl::byte_array BitmapBlkAllocator::acquire_underlying_buffer() {
     synchronize_rcu();
 
     BLKALLOC_REL_ASSERT(old_alloc_list_ptr == nullptr, "Multiple acquires concurrently?");
-    return (m_disk_bm->serialize(m_align_size));
+    // Copy the serialized buffer as cp flush can interefere with incoming I/O's.
+    // Cp flush happens not only during restart but also during normal I/O's.
+    return (m_disk_bm->serialize(m_align_size, true /* force_copy */));
 }
 
 void BitmapBlkAllocator::release_underlying_buffer() {

--- a/src/lib/blkalloc/varsize_blk_allocator.cpp
+++ b/src/lib/blkalloc/varsize_blk_allocator.cpp
@@ -698,6 +698,8 @@ blk_count_t VarsizeBlkAllocator::free_blks_direct(MultiBlkId const& bid) {
     auto const do_free = [this](BlkId const& b) {
         BlkAllocPortion& portion = blknum_to_portion(b.blk_num());
         {
+            BLKALLOC_LOG(TRACE, "Freeing directly to portion={} blkid={} set_bits_count={}",
+                         blknum_to_portion_num(b.blk_num()), b.to_string(), get_alloced_blk_count());
             auto const start_blk_id = portion.get_portion_num() * get_blks_per_portion();
             auto const end_blk_id = start_blk_id + get_blks_per_portion() - 1;
             auto lock{portion.portion_auto_lock()};
@@ -707,8 +709,6 @@ blk_count_t VarsizeBlkAllocator::free_blks_direct(MultiBlkId const& bid) {
             BLKALLOC_REL_ASSERT(m_cache_bm->is_bits_set(b.blk_num(), b.blk_count()), "Expected bits to be set");
             m_cache_bm->reset_bits(b.blk_num(), b.blk_count());
         }
-        BLKALLOC_LOG(TRACE, "Freeing directly to portion={} blkid={} set_bits_count={}",
-                     blknum_to_portion_num(b.blk_num()), b.to_string(), get_alloced_blk_count());
         return b.blk_count();
     };
 

--- a/src/lib/device/virtual_dev.hpp
+++ b/src/lib/device/virtual_dev.hpp
@@ -172,7 +172,7 @@ public:
     /// @return Allocation Status
     virtual BlkAllocStatus commit_blk(BlkId const& blkid);
 
-    virtual void free_blk(BlkId const& b, VDevCPContext* vctx = nullptr);
+    virtual void free_blk(BlkId const& b, VDevCPContext* vctx = nullptr, bool free_now = false);
 
     /////////////////////// Write API related methods /////////////////////////////
     /// @brief Asynchornously write the buffer to the device on a given blkid


### PR DESCRIPTION
During replay nublocks needs to check if blks are alloced and call free_blk_now to directly free the blks from bitmap cache and not depend on cp flush.

This PR is needed for https://github.com/eBay/HomeBlocks/pull/144. Details are there in that PR. We cant write UT to repro but its reproduced with long running.
test_volume_io --gtest_filter="VolumeIOTest.LongRunningRandomIO" --num_restarts=4 --num_vols=32 --write_num_io=300 --read_num_io=300 --dev_size_mb=1024000 --log_mods blkalloc:debug --run_time=300