### PR TITLE
improve homestore timer

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.0.1"
+    version = "7.0.2"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -486,7 +486,7 @@ public:
     /// @param header - Blob representing the header (it is opaque and will be copied
     /// as-is to the journal entry)
     /// @param key - Blob representing the key (it is opaque and will be copied as-is to
-    /// the journal entry). We are tracking this seperately to support consistent read use
+    /// the journal entry). We are tracking this separately to support consistent read use
     /// cases
     /// @param value - vector of io buffers that contain value for the key. It is an optional field and if the value
     /// list size is 0, then only key is written to replicadev without data.

--- a/src/lib/blkalloc/varsize_blk_allocator.cpp
+++ b/src/lib/blkalloc/varsize_blk_allocator.cpp
@@ -450,7 +450,7 @@ out:
 
 BlkAllocStatus VarsizeBlkAllocator::alloc(blk_count_t nblks, blk_alloc_hints const& hints,
                                           std::vector< BlkId >& out_blkids) {
-    // Regular alloc blks will allocate in MultiBlkId, but there is an upper limit on how many it can accomodate in a
+    // Regular alloc blks will allocate in MultiBlkId, but there is an upper limit on how many it can accommodate in a
     // single MultiBlkId, if caller is ok to generate multiple MultiBlkids, this method is called.
     auto h = hints;
     h.partial_alloc_ok = true;

--- a/src/lib/checkpoint/cp_mgr.cpp
+++ b/src/lib/checkpoint/cp_mgr.cpp
@@ -423,9 +423,9 @@ CP* CPGuard::get() {
 CPWatchdog::CPWatchdog(CPManager* cp_mgr) :
         m_cp{nullptr}, m_cp_mgr{cp_mgr}, m_timer_sec{HS_DYNAMIC_CONFIG(generic.cp_watchdog_timer_sec)} {
     LOGINFO("CP watchdog timer setting to : {} seconds", m_timer_sec);
-    m_timer_hdl =
-        iomanager.schedule_global_timer(m_timer_sec * 1000 * 1000 * 1000, true, nullptr, iomgr::reactor_regex::all_user,
-                                        [this](void* cookie) { cp_watchdog_timer(); });
+    m_timer_hdl = iomanager.schedule_global_timer(m_timer_sec * 1000 * 1000 * 1000, true, nullptr,
+                                                  iomgr::reactor_regex::random_worker,
+                                                  [this](void* cookie) { cp_watchdog_timer(); });
 }
 
 void CPWatchdog::reset_cp() {

--- a/src/lib/common/resource_mgr.cpp
+++ b/src/lib/common/resource_mgr.cpp
@@ -90,7 +90,7 @@ void ResourceMgr::start_timer() {
     }
 
     m_res_audit_timer_hdl = iomanager.schedule_global_timer(
-        res_mgr_timer_ms * 1000 * 1000, true /* recurring */, nullptr /* cookie */, iomgr::reactor_regex::all_worker,
+        res_mgr_timer_ms * 1000 * 1000, true /* recurring */, nullptr /* cookie */, iomgr::reactor_regex::random_worker,
         [this](void*) {
             // all resource timely audit routine should arrive here;
             this->trigger_truncate();
@@ -193,8 +193,9 @@ bool ResourceMgr::check_journal_vdev_size(const uint64_t used_size, const uint64
         const uint32_t used_pct = (100 * used_size / total_size);
         if (used_pct >= get_journal_vdev_size_limit()) {
             m_journal_vdev_exceed_cb(used_size, used_pct >= get_journal_vdev_size_critical_limit() /* is_critical */);
-            HS_LOG_EVERY_N(WARN, base, unmove(50), "high watermark hit, used percentage: {}, high watermark percentage: {}",
-                           used_pct, get_journal_vdev_size_limit());
+            HS_LOG_EVERY_N(WARN, base, unmove(50),
+                           "high watermark hit, used percentage: {}, high watermark percentage: {}", used_pct,
+                           get_journal_vdev_size_limit());
             return true;
         }
     }

--- a/src/lib/device/virtual_dev.cpp
+++ b/src/lib/device/virtual_dev.cpp
@@ -269,7 +269,7 @@ BlkAllocStatus VirtualDev::alloc_blks(blk_count_t nblks, blk_alloc_hints const& 
 
 BlkAllocStatus VirtualDev::alloc_blks(blk_count_t nblks, blk_alloc_hints const& hints,
                                       std::vector< BlkId >& out_blkids) {
-    // Regular alloc blks will allocate in MultiBlkId, but there is an upper limit on how many it can accomodate in a
+    // Regular alloc blks will allocate in MultiBlkId, but there is an upper limit on how many it can accommodate in a
     // single MultiBlkId, if caller is ok to generate multiple MultiBlkids, this method is called.
     auto h = hints;
     h.partial_alloc_ok = true;

--- a/src/lib/index/wb_cache.cpp
+++ b/src/lib/index/wb_cache.cpp
@@ -618,23 +618,23 @@ void IndexWBCache::recover(sisl::byte_view sb) {
                 // (Up) buffer is not committed, node need to be kept and (potentially) repaired later
                 if (buf->m_created_cp_id != icp_ctx->id()) {
                     LOGTRACEMOD(wbcache,
-                                "NOT FREE committing buffer {} node deleted is false reason: node commited?= {} "
+                                "NOT FREE committing buffer {} node deleted is false reason: node committed?= {} "
                                 "up committed? {}",
                                 buf->to_string(), was_node_committed(buf), was_node_committed(buf->m_up_buffer));
                     buf->m_node_freed = false;
                     r_cast< persistent_hdr_t* >(buf->m_bytes)->node_deleted = false;
                     m_vdev->commit_blk(buf->m_blkid);
                     // it can happen when children moved to one of right parent sibling and then the previous node is
-                    // deleted but not commited during crash (upbuffer is not committed). but its children already
+                    // deleted but not committed during crash (upbuffer is not committed). but its children already
                     // committed. and freed (or changed)
                     if (buf->m_node_level) { potential_parent_recovered_bufs.insert(buf); }
                 } else {
                     LOGINFO("deleting and creating new buf {}", buf->to_string());
                     deleted_bufs.push_back(buf);
                 }
-                //  1- upbuffer was dirtied by the same cp, so it is not commited, so we don't need to repair it.
+                //  1- upbuffer was dirtied by the same cp, so it is not committed, so we don't need to repair it.
                 //  remove it from down_waiting list (probably recursively going up) 2- upbuffer was created and
-                //  freed at the same cp, so it is not commited, so we don't need to repair it.
+                //  freed at the same cp, so it is not committed, so we don't need to repair it.
                 if (buf->m_up_buffer) {
                     LOGTRACEMOD(wbcache, "remove_down_buffer {} from up buffer {}", buf->to_string(),
                                 buf->m_up_buffer->to_string());
@@ -647,7 +647,7 @@ void IndexWBCache::recover(sisl::byte_view sb) {
             LOGTRACEMOD(wbcache, "recovering new buf {}", buf->to_string());
             // New node
             if (was_node_committed(buf) && was_node_committed(buf->m_up_buffer)) {
-                // Both current and up buffer is commited, we can safely commit the current block
+                // Both current and up buffer is committed, we can safely commit the current block
                 LOGTRACEMOD(wbcache, "New buffer {} and the up buffer {} are committed", buf->to_string(),
                             buf->m_up_buffer->to_string());
                 m_vdev->commit_blk(buf->m_blkid);

--- a/src/lib/logstore/log_dev.hpp
+++ b/src/lib/logstore/log_dev.hpp
@@ -253,7 +253,7 @@ public:
     void reset(const uint32_t max_records);
     void create_overflow_buf(const uint32_t min_needed);
     bool add_record(log_record& record, const int64_t log_idx);
-    bool can_accomodate(const log_record& record) const { return (m_nrecords <= m_max_records); }
+    bool can_accommodate(const log_record& record) const { return (m_nrecords <= m_max_records); }
 
     const iovec_array& finish(logdev_id_t logdev_id, const crc32_t prev_crc);
     crc32_t compute_crc();


### PR DESCRIPTION
when we create global timer using iomanager, `all_user` means all the user reactor will run a timer, `all_worker` means all the worker reactor will run a timer.

actually, what we want is only one timer, not all the reactors run a separate timer.  this PR improve this behavior.

this PR also fixed some typos