### PR TITLE
Issue xxxx: default solo repl dev replay to false

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.0.3"
+    version = "7.0.4"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -174,7 +174,9 @@ void SoloReplDev::async_write_journal(const std::vector< MultiBlkId >& blkids, s
 void SoloReplDev::on_log_found(logstore_seq_num_t lsn, log_buffer buf, void* ctx) {
     auto cur_lsn = m_commit_upto.load();
 
-    auto force_replay = SISL_OPTIONS["solo_force_replay"].as< bool >();
+    bool force_replay = false;
+    if (SISL_OPTIONS.count("solo_force_replay")) { force_replay = SISL_OPTIONS["solo_force_replay"].as< bool >(); }
+
     if (cur_lsn >= lsn and !force_replay) {
         // Already committed
         LOGINFO("SoloReplDev skipping already committed log_entry lsn={}, m_commit_upto at lsn={}", lsn, cur_lsn);


### PR DESCRIPTION
Changes:
========
So that HomeStore Consumer HomeBlocks doesn't need to specify --solo_force_replay=false;
This change has no impact to HomeStore other consumer like HomeObj or internal services.


Testing:
======
Cross tested with HomeBlocks and passed the integration test.