### PR TITLE
add latch lsn

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.0.6"
+    version = "7.0.7"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -99,13 +99,13 @@ protected:
 };
 
 struct snapshot_obj {
-    void *&user_ctx;
+    void*& user_ctx;
     uint64_t offset{0};
     sisl::io_blob_safe blob;
     bool is_first_obj{false};
     bool is_last_obj{false};
 
-    snapshot_obj(void *&ctx) : user_ctx(ctx) {}
+    snapshot_obj(void*& ctx) : user_ctx(ctx) {}
 };
 
 // HomeStore has some meta information to be transmitted during the baseline resync,
@@ -404,7 +404,7 @@ public:
     /// times on the leader till all the data is transferred to the follower. is_last_obj in
     /// snapshot_obj will be true once all the data has been trasnferred. After this the raft on
     /// the follower side can do the incremental resync.
-    virtual int read_snapshot_obj(shared<snapshot_context> context, shared<snapshot_obj> snp_obj) = 0;
+    virtual int read_snapshot_obj(shared< snapshot_context > context, shared< snapshot_obj > snp_obj) = 0;
 
     /// @brief Called on the follower when the leader sends the data during the baseline resyc.
     /// is_last_obj in in snapshot_obj will be true once all the data has been transfered.
@@ -591,6 +591,8 @@ public:
             m_listener.reset();
         }
     }
+
+    virtual void reset_latch_lsn() { return; }
 
     virtual shared< ReplDevListener > get_listener() { return m_listener; }
 

--- a/src/lib/logstore/log_dev.cpp
+++ b/src/lib/logstore/log_dev.cpp
@@ -139,6 +139,7 @@ void LogDev::stop() {
         if (!get_pending_request_num()) break;
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
+
     {
         std::unique_lock lg = flush_guard();
         // waiting under lock to make sure no new flush is started
@@ -582,26 +583,20 @@ void LogDev::on_flush_completion(LogGroup* lg) {
 
     // since we support out-of-order lsn write, so no need to guarantee the order of logstore write completion
     for (auto const& [idx, req] : req_map) {
-        m_pending_callback++;
         auto callback_lambda = [this, dev_offset, idx, req]() {
             auto ld_key = logdev_key{idx, dev_offset};
             auto comp_cb = req->log_store->get_comp_cb();
             (req->cb) ? req->cb(req, ld_key) : comp_cb(req, ld_key);
-            m_pending_callback--;
         };
 
-        // Only server side replication which uses raft runs the callback on a random worker.
-        bool server_side_replication = true;
+        // if we do not have repl_service, we run the callback in a random worker for the case of log store UT, where
+        // the callback will schedule a new write and try to acquire the flush lock again causing a deadlock
         if (hs()->has_repl_data_service()) {
-            auto& repl_svc = dynamic_cast< GenericReplService& >(hs()->repl_service());
-            server_side_replication = repl_svc.get_impl_type() == repl_impl_type::server_side;
-        }
-
-        if (server_side_replication) {
+            // if we have replication service, we do sync callback
+            callback_lambda();
+        } else {
             iomanager.run_on_forget(iomgr::reactor_regex::random_worker, /* iomgr::fiber_regex::syncio_only, */
                                     [this, callback_lambda]() { callback_lambda(); });
-        } else {
-            callback_lambda();
         }
     }
 }

--- a/src/lib/logstore/log_dev.hpp
+++ b/src/lib/logstore/log_dev.hpp
@@ -810,8 +810,11 @@ private:
     // callback of the append_async we schedule another flush.), so we need the lock to be locked for multitimes in the
     // same thread.
     iomgr::FiberManagerLib::mutex m_flush_mtx;
-    std::atomic_uint64_t m_pending_callback{0};
     folly::SharedMutexWritePriority m_stream_tracker_mtx;
+
+    // Note that, this is used for tracking pending callbacks to avoid stopping logdev before all callbacks are done
+    // if any one want to use async cbs, please make sure to incr/decr this counter properly
+    std::atomic_uint64_t m_pending_callback{0};
 
     // This is used to ensure that the logdev meta is created/loaded
     // to avoid other threads accessing it before it is ready (e.g., resource_mgr's device truncate thread)

--- a/src/tests/test_common/raft_repl_test_base.hpp
+++ b/src/tests/test_common/raft_repl_test_base.hpp
@@ -199,7 +199,10 @@ public:
         LOGINFOMOD(replication, "[Replica={}] Received config rollback at lsn={}", g_helper->replica_num(), lsn);
     }
     void on_no_space_left(repl_lsn_t lsn, sisl::blob const& header) override {
-        LOGINFOMOD(replication, "[Replica={}] Received no_space_left at lsn={}", g_helper->replica_num(), lsn);
+        LOGINFOMOD(replication,
+                   "[Replica={}] Received no_space_left at lsn={}, reset latch lsn since we don`t really handle it.",
+                   g_helper->replica_num(), lsn);
+        repl_dev()->reset_latch_lsn();
     }
 
     AsyncReplResult<> create_snapshot(shared< snapshot_context > context) override {


### PR DESCRIPTION
there is a very corner case like following:

        T1: L1 is leader, push data to follower F1, F1 generate rreq1 and allocate blk for this data. let`s say the
        lsn of this data is lsn-100

        T2: leader switchs to L2, L2 send log to F1, F1 generate rreq2 and try to allocate blk but got
        no_space_left. then it will set the quiesce flag and waiting for the commit of lsn-99 (100 - 1).

        T3: leader switchs back to L1, L1 send log (lsn-100) to F1, when F1 tries to create rreq for lsn-100,  rreq1
        (which is created at T1) will be found since the rkey{server,term,dsn} is same as rreq1. so F1 will skip
        creating a new rreq. since the data for lsn-100 is already in written at T1, F1 start appending log entries
        to its log store, which will call logstore::append_log_entries and thus call localize_journal_entry_finish.

        T4: lsn-99 is committed at F1 and clear_chunk_req is called, so all the rreqs in F1 including rreq1 are
        cleared.

        T5: F1 call localize_journal_entry_finish, rreq1 is not found since it is cleared at T4, so F1 will try to
        create a new rreq for lsn-100. but now, F1 is in quiesce state, all the rreq creation will be rejected, so a
        nullptr will be returned. and cause RELEASE_ASSERT(rreq != nullptr) failure.


 when we got no_space_left in log channel at follower, we set this latch_lsn, so if any lsn in this batch that is >= latch_lsn, the whole batch will be rejected. after we successfully handle no_space_left and call resume_accepting_reqs, latch_lsn will be reset to max value.    