### PR TITLE
support manual trigger snapshot creation function

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.1.0"
+    version = "7.1.1"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/replication/repl_dev.h
+++ b/src/include/homestore/replication/repl_dev.h
@@ -621,6 +621,9 @@ public:
     // clear reqs that has allocated blks on the given chunk.
     virtual void clear_chunk_req(chunk_num_t chunk_id) = 0;
 
+    // create a snapshot manually and try to compact logs upto compact_lsn
+    virtual void trigger_snapshot_creation(repl_lsn_t compact_lsn, bool wait_for_commit) = 0;
+
 protected:
     shared< ReplDevListener > m_listener;
 

--- a/src/include/homestore/replication_service.hpp
+++ b/src/include/homestore/replication_service.hpp
@@ -110,6 +110,14 @@ public:
     /// @param group_id Group where the replace member happens
     virtual ReplServiceError destroy_repl_dev(group_id_t group_id, uint64_t trace_id = 0) = 0;
 
+    /// @brief Trigger a snapshot creation manually for a given group id
+    /// @param group_id Group id for which snapshot creation is requested
+    /// @param compact_lsn LSN upto which the snapshot expect to compact, -1 means no compaction upper needed
+    /// @param wait_for_commit default is true, means it will wait until the local committed lsn reach the compact_lsn,
+    /// if set to false, the snapshot and compaction will be triggered based on the latest committed lsn
+    virtual void trigger_snapshot_creation(group_id_t group_id, repl_lsn_t compact_lsn = -1,
+                                           bool wait_for_commit = true) = 0;
+
     /// @brief Get the repl dev for a given group id if it is already created or opened
     /// @param group_id Group id interested in
     /// @return ReplDev is opened or ReplServiceError::SERVER_NOT_FOUND if it doesn't exist

--- a/src/lib/replication/repl_dev/solo_repl_dev.h
+++ b/src/lib/replication/repl_dev/solo_repl_dev.h
@@ -121,6 +121,8 @@ public:
     // solo repl device truncation is triggerred by CP after flushing all the data in its cp_cleanup routine;
     void truncate();
 
+    void trigger_snapshot_creation(repl_lsn_t compact_lsn, bool wait_for_commit) override { return; }
+
 private:
     void write_journal(repl_req_ptr_t rreq);
     void on_log_found(logstore_seq_num_t lsn, log_buffer buf, void* ctx);

--- a/src/lib/replication/service/generic_repl_svc.cpp
+++ b/src/lib/replication/service/generic_repl_svc.cpp
@@ -233,6 +233,8 @@ ReplServiceError SoloReplService::destroy_repl_dev(group_id_t group_id, uint64_t
     return remove_repl_dev(group_id).get();
 }
 
+void SoloReplService::trigger_snapshot_creation(group_id_t group_id, repl_lsn_t compact_lsn, bool wait_for_commit) {}
+
 std::unique_ptr< CPContext > SoloReplServiceCPHandler::on_switchover_cp(CP* cur_cp, CP* new_cp) {
     return std::make_unique< CPContext >(new_cp);
 }

--- a/src/lib/replication/service/generic_repl_svc.h
+++ b/src/lib/replication/service/generic_repl_svc.h
@@ -112,6 +112,7 @@ public:
                                                   const std::vector< replica_member_info >& others,
                                                   uint64_t trace_id = 0) const override;
     ReplServiceError destroy_repl_dev(group_id_t group_id, uint64_t trace_id = 0) override;
+    void trigger_snapshot_creation(group_id_t group_id, repl_lsn_t compact_lsn, bool wait_for_commit) override;
 };
 
 class SoloReplServiceCPHandler : public CPCallbacks {

--- a/src/lib/replication/service/raft_repl_service.cpp
+++ b/src/lib/replication/service/raft_repl_service.cpp
@@ -610,6 +610,18 @@ ReplServiceError RaftReplService::destroy_repl_dev(group_id_t group_id, uint64_t
     return ReplServiceError::OK;
 }
 
+void RaftReplService::trigger_snapshot_creation(group_id_t group_id, repl_lsn_t compact_lsn, bool wait_for_commit) {
+    auto rdev_result = get_repl_dev(group_id);
+    if (!rdev_result) {
+        LOGWARNMOD(replication, "ReplDev group_id={} not found while scheduling snapshot creation",
+                   boost::uuids::to_string(group_id));
+        return;
+    }
+
+    std::dynamic_pointer_cast< RaftReplDev >(rdev_result.value())
+        ->trigger_snapshot_creation(compact_lsn, wait_for_commit);
+}
+
 ////////////////////// Reaper Thread related //////////////////////////////////
 void RaftReplService::start_repl_service_timers() {
     // we need to explictly cancel the timers before we stop the repl_devs, but we cannot cancel a thread timer

--- a/src/lib/replication/service/raft_repl_service.h
+++ b/src/lib/replication/service/raft_repl_service.h
@@ -106,6 +106,8 @@ protected:
                                                   uint64_t trace_id = 0) const override;
     ReplServiceError destroy_repl_dev(group_id_t group_id, uint64_t trace_id = 0) override;
 
+    void trigger_snapshot_creation(group_id_t group_id, repl_lsn_t compact_lsn, bool wait_for_commit) override;
+
 private:
     RaftReplDev* raft_group_config_found(sisl::byte_view const& buf, void* meta_cookie);
     void start_repl_service_timers();


### PR DESCRIPTION
Add manual snapshot creation API for log truncation control with 3 capabilities:
1. **Update truncation upper limit**: Allows truncating logs up to a specified threshold when the in-memory truncation_upper_limit is zero (e.g., after restart).
2. **Trigger snapshot via[ NuRaft API](https://github.com/eBay/NuRaft/blob/cc43cd488e5f887fc998809302dfbcfbfbeb7e4b/include/libnuraft/raft_server.hxx#L884-L896)**: Leverages NuRaft's snapshot creation AP: Triggers snapshot creation immediately based on current commit idx. NuRaft handles race conditions internally so we don't need to do more (e.g., rejecting concurrent snapshot requests and using distance checks and flags to prevent concurrency issues)
3. **support truncate logs upto compact_lsn**: if the compaction in raft didn't truncate logs as much as expected, it will trigger compact again to truncate logs. Please set wait_for_commit=true to make sure truncated logs have been committed.