### PR TITLE
Add nuraft_state field for complete Raft state persistence

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.0.7"
+    version = "7.0.8"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/tests/test_common/raft_repl_test_base.hpp
+++ b/src/tests/test_common/raft_repl_test_base.hpp
@@ -41,6 +41,7 @@
 #include "common/homestore_utils.hpp"
 
 #define private public
+#define protected public
 #include "test_common/hs_repl_test_common.hpp"
 #include "replication/service/raft_repl_service.h"
 #include "replication/repl_dev/raft_repl_dev.h"


### PR DESCRIPTION
This change use NuRaft's native binary serialization to persist srv_state instead of manual JSON field mapping. This ensures all state fields including receiving_snapshot_ are saved, preventing state inconsistency and unexpected raft behavior.

related issue: https://github.com/eBay/HomeStore/issues/835