### PR TITLE
Align chunk start offset to 4k and logstore inline flush

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "6.20.32"
+    version = "6.20.33"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/checkpoint/cp_mgr.cpp
+++ b/src/lib/checkpoint/cp_mgr.cpp
@@ -39,8 +39,10 @@ CPManager::CPManager() :
         [this](meta_blk* mblk, sisl::byte_view buf, size_t size) { on_meta_blk_found(std::move(buf), (void*)mblk); },
         nullptr);
 
-    resource_mgr().register_dirty_buf_exceed_cb(
-        [this]([[maybe_unused]] int64_t dirty_buf_count, bool critical) { this->trigger_cp_flush(false /* force */); });
+    resource_mgr().register_dirty_buf_exceed_cb([this]([[maybe_unused]] int64_t dirty_buf_count, bool critical) {
+        LOGINFO("Dirty buffer exceeded count {} critical {}", dirty_buf_count, critical);
+        this->trigger_cp_flush(false /* force */);
+    });
 
     start_timer_thread();
     start_cp_thread();

--- a/src/lib/common/homestore_config.fbs
+++ b/src/lib/common/homestore_config.fbs
@@ -107,7 +107,7 @@ table LogStore {
     try_flush_iteration: uint64 = 10240(hotswap);
 
     // Logdev flushes in multiples of this size, setting to 0 will make it use default device optimal size
-    flush_size_multiple_logdev: uint64 = 512;
+    flush_size_multiple_logdev: uint64 = 0;
 
     // Logdev will flush the logs only in a dedicated thread. Turn this on, if flush IO doesn't want to
     // intervene with data IO path.
@@ -165,7 +165,7 @@ table Generic {
 
 table ResourceLimits {
     /* it is going to use 2 times of this space because of two concurrent cps */
-    dirty_buf_percent: uint32 = 1 (hotswap);
+    dirty_buf_percent: uint32 = 10 (hotswap);
 
     /* it is going to use 2 times of this space because of two concurrent cps */
     free_blk_cnt: uint32 = 10000000 (hotswap);
@@ -190,7 +190,7 @@ table ResourceLimits {
     /* 0 means HomeStore doesn't reserve anything and let nuraft controlls the truncation */
     /* default reserve 1 million logs */
     raft_logstore_reserve_threshold: uint32 = 1000000 (hotswap);
-    
+
     /* resource audit timer in ms */
     resource_audit_timer_ms: uint32 = 120000;
 
@@ -262,10 +262,10 @@ table Consensus {
     // Minimum log gap a replica has to be from leader before joining the replica set.
     // 0 indicates the new member will join in cluster immediately.
     min_log_gap_to_join: int32 = 0;
-    
+
     // amount of time in millis to wait on data write before fetch data from remote;
     wait_data_write_timer_ms: uint64 = 1500 (hotswap);
-    
+
     // Leadership expiry (=0 indicates 20 times heartbeat period), set -1 to never expire
     leadership_expiry_ms: int32 = 0;
 

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -18,7 +18,7 @@ SoloReplDev::SoloReplDev(superblk< solo_repl_dev_superblk >&& rd_sb, bool load_e
     auto const gid = m_rd_sb->group_id;
     if (load_existing) {
         m_logdev_id = m_rd_sb->logdev_id;
-        logstore_service().open_logdev(m_rd_sb->logdev_id, flush_mode_t::TIMER, gid);
+        logstore_service().open_logdev(m_rd_sb->logdev_id, flush_mode_t::TIMER | flush_mode_t::INLINE, gid);
         logstore_service()
             .open_log_store(m_rd_sb->logdev_id, m_rd_sb->logstore_id, true /* append_mode */)
             .thenValue([this](auto log_store) {
@@ -29,7 +29,7 @@ SoloReplDev::SoloReplDev(superblk< solo_repl_dev_superblk >&& rd_sb, bool load_e
             });
         m_commit_upto = m_rd_sb->durable_commit_lsn;
     } else {
-        m_logdev_id = logstore_service().create_new_logdev(flush_mode_t::TIMER, gid);
+        m_logdev_id = logstore_service().create_new_logdev(flush_mode_t::TIMER | flush_mode_t::INLINE, gid);
         m_data_journal = logstore_service().create_new_log_store(m_logdev_id, true /* append_mode */);
         m_rd_sb->logstore_id = m_data_journal->get_store_id();
         m_rd_sb->logdev_id = m_logdev_id;


### PR DESCRIPTION
Align the chunk start offset to 4k to fix performance degradation of 4kb writes from 150us to 20us on p5gx. Because physical block size is 4kb on nvme on p5gx. Earlier the chunk start offset was aligned to 512. This alignment will only affect during first time boot. Existing nodes during upgrade wont have issues as they use old format. Add logstore inline flush mode for solo repl dev.
Run the completion callback in a different thread only for raft repl devi as there is 100us difference in latency. For nublocks callback can be run inline.