### PR TITLE
Improve ReplaceMemberRollback UT

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.1.2"
+    version = "7.1.3"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/tests/test_common/homestore_test_common.hpp
+++ b/src/tests/test_common/homestore_test_common.hpp
@@ -250,7 +250,7 @@ public:
         freq.set_count(count);
         freq.set_percent(percent);
         m_fc.inject_noreturn_flip(flip_name, {null_cond}, freq);
-        LOGDEBUG("Flip {} set", flip_name);
+        LOGINFO("Flip {} set", flip_name);
     }
 
     void set_delay_flip(const std::string flip_name, uint64_t delay_usec, uint32_t count = 1, uint32_t percent = 100) {


### PR DESCRIPTION
- Add flip to control complete_replace_member, it is enabled after we check replace member intermediate status.
- In ReplaceMemberRollback UT, wait for in member being caught up before rollback.