### PR TITLE
Fix: set freed pointers to nullptr in destructors

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.1.3"
+    version = "7.1.4"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/index/index_service.cpp
+++ b/src/lib/index/index_service.cpp
@@ -248,7 +248,10 @@ IndexBuffer::IndexBuffer(BlkId blkid, uint32_t buf_size, uint32_t align_size) :
 IndexBuffer::IndexBuffer(uint8_t* raw_bytes, BlkId blkid) : m_blkid(blkid), m_bytes{raw_bytes} {}
 
 IndexBuffer::~IndexBuffer() {
-    if (m_bytes) { hs_utils::iobuf_free(m_bytes, sisl::buftag::btree_node); }
+    if (m_bytes) {
+        hs_utils::iobuf_free(m_bytes, sisl::buftag::btree_node);
+        m_bytes = nullptr;
+    }
 }
 
 std::string IndexBuffer::to_string() const {

--- a/src/lib/replication/repl_dev/common.cpp
+++ b/src/lib/replication/repl_dev/common.cpp
@@ -59,7 +59,10 @@ ReplServiceError repl_req_ctx::init(repl_key rkey, journal_type_t op_code, bool 
 }
 
 repl_req_ctx::~repl_req_ctx() {
-    if (m_journal_entry) { m_journal_entry->~repl_journal_entry(); }
+    if (m_journal_entry) {
+        m_journal_entry->~repl_journal_entry();
+        m_journal_entry = nullptr;
+    }
 }
 
 void repl_req_ctx::create_journal_entry(bool is_raft_buf, int32_t server_id) {


### PR DESCRIPTION
Set m_bytes and m_journal_entry to nullptr after manual deallocation to prevent potential double-free and use-after-free issues. This is a defensive programming practice that makes the code more robust against future changes and easier to debug.