### PR TITLE
complete the ctx future if no dirty to unblock cp flush

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.4.4"
+    version = "7.4.5"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/index/wb_cache.cpp
+++ b/src/lib/index/wb_cache.cpp
@@ -863,6 +863,15 @@ folly::Future< bool > IndexWBCache::async_cp_flush(IndexCPContext* cp_ctx) {
             IndexBufferPtrList buf_list;
             get_next_bufs(cp_ctx, resource_mgr().get_dirty_buf_qd(), buf_list);
 
+            if (buf_list.empty()) {
+                LOGTRACEMOD(wbcache, "No more buffers to flush for cp {}, exiting flush iteration", cp_ctx->id());
+                // if no dirty buffer, we should complete the cp_ctx here, otherwise it will be waiting for ever and
+                // block the next CP from flushing
+                m_vdev->cp_flush(cp_ctx);
+                cp_ctx->complete(true);
+                return;
+            }
+
             for (auto& buf : buf_list) {
                 do_flush_one_buf(cp_ctx, buf, true);
             }


### PR DESCRIPTION
Bug:
when there is no dirty buf in index table (example : all read ops or no ops), if we trigger cp flush, then future in cp_ctx of index will not be completed and then the whole cp_flush is stuck.

Fix: 
complete the future in cp_ctx if dirty buf is empty