### PR TITLE
Fix root collapse CP hang and add regression test

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.5.0"
+    version = "7.5.1"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/btree/detail/btree_remove_impl.ipp
+++ b/src/include/homestore/btree/detail/btree_remove_impl.ipp
@@ -200,6 +200,24 @@ btree_status_t Btree< K, V >::check_collapse_root(ReqT& req) {
         goto done;
     }
 
+    // CRITICAL: Write the child node BEFORE calling on_root_changed()
+    // This prevents two critical CP hang scenarios:
+    // 1. CLEAN Buffer Case:
+    //    If child is CLEAN (created in previous CP), on_root_changed() would add it as a
+    //    dependency to Meta buffer via link_buf(). Since CLEAN buffers never enter the CP
+    //    dirty list, Meta's wait_count would never decrement to 0, causing CP hang.
+    // 2. Overlapping CP Case:
+    //    Without this write_node(), there's a gap between dependency creation (link_buf in
+    //    on_root_changed) and dirty list addition (write_buf in later transact_nodes). If
+    //    CP switches during this gap:
+    //    - Meta buffer added to CP X dirty list with wait_count=1
+    //    - Child buffer added to CP X+1 dirty list (wrong CP!)
+    //    - Meta in CP X waits forever for child that's in CP X+1
+    //    This creates cross-CP dependency causing CP hang.
+    //
+    // By calling write_node() here, we ensure the child is already in the current CP's
+    // dirty list before on_root_changed() creates the dependency link.
+    write_node(child, req.m_op_context);
     ret = on_root_changed(child, req.m_op_context);
     if (ret != btree_status_t::success) {
         unlock_node(child, locktype_t::WRITE);

--- a/src/lib/index/wb_cache.cpp
+++ b/src/lib/index/wb_cache.cpp
@@ -430,6 +430,16 @@ void IndexWBCache::link_buf(IndexBufferPtr const& up_buf, IndexBufferPtr const& 
         down_buf->m_up_buffer->remove_down_buffer(down_buf);
     }
     down_buf->m_up_buffer = real_up_buf;
+
+    // Log when adding CLEAN buffer as dependency, should not happen
+    if (down_buf->state() == index_buf_state_t::CLEAN) {
+        LOGWARNMOD(wbcache,
+                   "CLEAN_BUF_DEBUG: Adding CLEAN down_buf {} to up_buf {}, up_buf wait_count before={}, may lead to "
+                   "up_buf being stuck in cp flush",
+                   down_buf->blkid().to_integer(), real_up_buf->blkid().to_integer(),
+                   real_up_buf->m_wait_for_down_buffers.get());
+    }
+
     real_up_buf->add_down_buffer(down_buf);
 }
 
@@ -818,7 +828,11 @@ bool IndexWBCache::was_node_committed(IndexBufferPtr const& buf) {
 
 //////////////////// CP Related API section /////////////////////////////////
 folly::Future< bool > IndexWBCache::async_cp_flush(IndexCPContext* cp_ctx) {
+#ifdef _PRERELEASE
     LOGTRACEMOD(wbcache, "Starting Index CP Flush with cp \ndag={}", cp_ctx->to_string_with_dags());
+#else
+    LOGINFOMOD(wbcache, "Starting Index CP Flush with cp {}", cp_ctx->id());
+#endif
     // #ifdef _PRERELEASE
     //     static int id = 0;
     //     auto filename = "cp_" + std::to_string(id++) + "_" + std::to_string(rand() % 100) + ".dot";
@@ -833,6 +847,7 @@ folly::Future< bool > IndexWBCache::async_cp_flush(IndexCPContext* cp_ctx) {
         } else {
             CP_PERIODIC_LOG(DEBUG, unmove(cp_ctx->id()), "Btree does not have any dirty buffers to flush");
         }
+        cp_ctx->complete(true);
         return folly::makeFuture< bool >(true); // nothing to flush
     }
 

--- a/src/lib/index/wb_cache.cpp
+++ b/src/lib/index/wb_cache.cpp
@@ -831,7 +831,9 @@ folly::Future< bool > IndexWBCache::async_cp_flush(IndexCPContext* cp_ctx) {
 #ifdef _PRERELEASE
     LOGTRACEMOD(wbcache, "Starting Index CP Flush with cp \ndag={}", cp_ctx->to_string_with_dags());
 #else
-    LOGINFOMOD(wbcache, "Starting Index CP Flush with cp {}", cp_ctx->id());
+    LOGINFOMOD(wbcache, "Starting Index CP Flush with cp {}, dirty_buf_count={}, nodes_added={}, nodes_removed={}",
+               cp_ctx->id(), cp_ctx->m_dirty_buf_count.get(), cp_ctx->m_num_nodes_added.load(),
+               cp_ctx->m_num_nodes_removed.load());
 #endif
     // #ifdef _PRERELEASE
     //     static int id = 0;

--- a/src/tests/test_index_btree.cpp
+++ b/src/tests/test_index_btree.cpp
@@ -455,6 +455,111 @@ TYPED_TEST(BtreeTest, ThreadedCpFlush) {
     LOGINFO("ThreadedCpFlush test end");
 }
 
+/**
+ * RootCollapseCpFlush - Verify root collapse works correctly across CP boundaries
+ *
+ * Test Objective:
+ * Ensure that when root collapse occurs and the promoted child buffer is added to the same CP with the meta buf,
+ * the CP flush completes successfully without hanging.
+ *
+ * Test Scenario:
+ * This test constructs a two-CP scenario:
+ *
+ * CP2 (Setup):
+ * - Insert 600 entries → creates 3-child tree (depth=1, interior=1, leaf=3)
+ * - Delete 300 entries → triggers merge, leaving root with only 1 edge child
+ *   (depth=1, interior=1, leaf=1, root.total_entries()==0)
+ * - Trigger CP2 to flush → all buffers become CLEAN for next CP
+ *
+ * CP3 (Collapse):
+ * - Remove non-existent key → triggers check_collapse_root()
+ * - Edge child (CLEAN, created in CP2) gets promoted to new_root
+ * - No subsequent modifications → child stays CLEAN
+ * - Trigger CP3 → must complete successfully
+ */
+TYPED_TEST(BtreeTest, RootCollapseCpFlush) {
+    LOGINFO("=== Root Collapse CP Flush Test ===");
+
+    // Node capacity is ~170-200 entries per leaf (empirically determined with 4KB nodes)
+    // 600 entries creates 3 children: each leaf holds ~200 entries
+    const uint32_t total_entries = 600;
+
+    // Delete 300 entries to trigger merge down to 1 child
+    // Remaining 300 entries fit in single leaf → root left with only edge
+    const uint32_t delete_count = 300;
+
+    LOGINFO("CP2 Phase - Step 1: Insert {} entries to create 3-child tree", total_entries);
+    for (uint32_t i = 0; i < total_entries; ++i) {
+        this->put(i, btree_put_type::INSERT);
+    }
+
+    auto [interior_before, leaf_before] = this->m_bt->compute_node_count();
+    uint32_t depth_before = this->m_bt->get_btree_depth();
+    LOGINFO("After insert: depth={}, interior={}, leaf={}", depth_before, interior_before, leaf_before);
+
+    if (depth_before == 0) {
+        LOGWARN("Tree did not split - need more entries. Skipping test.");
+        return;
+    }
+
+    // Step 2: Delete entries to trigger merge → root left with only edge (total_entries==0)
+    LOGINFO("CP2 Phase - Step 2: Deleting {} entries to trigger merge to 1 child", delete_count);
+    for (uint32_t i = 0; i < delete_count; ++i) {
+        this->remove_one(i);
+    }
+
+    auto [interior_mid, leaf_mid] = this->m_bt->compute_node_count();
+    uint32_t depth_mid = this->m_bt->get_btree_depth();
+    LOGINFO("After merge: depth={}, interior={}, leaf={}", depth_mid, interior_mid, leaf_mid);
+
+    // Trigger CP2 to flush all changes from Steps 1-2
+    LOGINFO("CP2 Phase - Step 3: Triggering CP2 to flush all merge changes");
+    test_common::HSTestHelper::trigger_cp(true /* wait */);
+    LOGINFO("CP2 completed - all buffers are now CLEAN for the next CP");
+
+    // CP3 Phase - Step 4: Remove non-existent key to trigger collapse
+    LOGINFO("CP3 Phase - Step 4: Removing non-existent key to trigger collapse");
+    const uint32_t non_existent_key = total_entries + 1000;
+    LOGINFO("Attempting to remove key {} (doesn't exist)", non_existent_key);
+    this->remove_one(non_existent_key); // Will trigger collapse on retry
+
+    auto [interior_after, leaf_after] = this->m_bt->compute_node_count();
+    uint32_t depth_after = this->m_bt->get_btree_depth();
+    uint64_t keys_after = this->m_bt->count_keys(this->m_bt->root_node_id());
+
+    LOGINFO("After collapse attempt: depth={}, interior={}, leaf={}, keys={}", depth_after, interior_after, leaf_after,
+            keys_after);
+
+    if (depth_after < depth_mid) {
+        LOGINFO("Root collapse occurred: depth {} → {}", depth_mid, depth_after);
+    } else {
+        LOGWARN("Root collapse did not occur - depth unchanged. Test may not verify the scenario.");
+    }
+
+    // CP3 Phase - Step 5: Verify CP3 completes successfully
+    LOGINFO("CP3 Phase - Step 5: Triggering CP3 to verify it completes successfully...");
+
+    std::atomic< bool > cp_done{false};
+    std::thread t([this, &cp_done]() {
+        test_common::HSTestHelper::trigger_cp(true /* wait */);
+        cp_done.store(true);
+    });
+
+    // Wait 10 seconds max
+    for (int i = 0; i < 100 && !cp_done.load(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    if (!cp_done.load()) {
+        LOGERROR("CP3 TIMEOUT, CP did not complete within timeout!");
+        t.detach();
+        FAIL() << "CP3 timeout - root collapse with CLEAN child failed to complete";
+    } else {
+        t.join();
+        LOGINFO("CP3 completed successfully");
+    }
+}
+
 template < typename TestType >
 struct BtreeConcurrentTest : public BtreeTestHelper< TestType >, public ::testing::Test {
     using T = TestType;

--- a/src/tests/test_index_btree.cpp
+++ b/src/tests/test_index_btree.cpp
@@ -480,6 +480,14 @@ TYPED_TEST(BtreeTest, ThreadedCpFlush) {
 TYPED_TEST(BtreeTest, RootCollapseCpFlush) {
     LOGINFO("=== Root Collapse CP Flush Test ===");
 
+#ifdef _PRERELEASE
+    // Use max/min keys to control tree structure more precisely
+    this->m_cfg.m_max_keys_in_node = 200;
+    this->m_cfg.m_min_keys_in_node = 100;
+    LOGINFO("Using m_max_keys_in_node={}, m_min_keys_in_node={}", this->m_cfg.m_max_keys_in_node,
+            this->m_cfg.m_min_keys_in_node);
+#endif
+
     // Node capacity is ~170-200 entries per leaf (empirically determined with 4KB nodes)
     // 600 entries creates 3 children: each leaf holds ~200 entries
     const uint32_t total_entries = 600;


### PR DESCRIPTION
This commit addresses two critical CP hang scenarios during root collapse  and updates the test to serve as a regression test.
 Root Cause Fix (btree_remove_impl.ipp):
     Add write_node(child) before on_root_changed() in check_collapse_root() to prevent two CP hang scenarios:
     a) CLEAN Buffer Case:
        If promoted child is CLEAN (from previous CP), on_root_changed() would add it as dependency to Meta buffer. Since CLEAN buffers never enter CP dirty list, Meta's wait_count never decrements, causing CP hang.
     b) Overlapping CP Case:
        Without write_node(), there's a gap between dependency creation (link_buf) and dirty list addition (write_buf). If CP switches during this gap, Meta goes to CP X with wait_count=1, but child goes to CP X+1, creating cross-CP dependency and CP hang.
     By calling write_node() before on_root_changed(), we ensure child is already in current CP's dirty list before dependency link is created.
Additional changes:
  - Add cp_ctx->complete() call for early return path in async_cp_flush()