### PR TITLE
Fix race condition between cp flush and chunk reset

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.5.1"
+    version = "7.5.2"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"
@@ -53,7 +53,7 @@ class HomestoreConan(ConanFile):
 
     def requirements(self):
         self.requires("iomgr/[^12]@oss/master", transitive_headers=True)
-        self.requires("sisl/[^13.2.3]@oss/master", transitive_headers=True)
+        self.requires("sisl/[^13.2.4]@oss/master", transitive_headers=True)
         self.requires("nuraft_mesg/[^4]@oss/main", transitive_headers=True)
 
         self.requires("farmhash/cci.20190513@", transitive_headers=True)

--- a/src/include/homestore/btree/detail/btree_remove_impl.ipp
+++ b/src/include/homestore/btree/detail/btree_remove_impl.ipp
@@ -217,6 +217,7 @@ btree_status_t Btree< K, V >::check_collapse_root(ReqT& req) {
     //
     // By calling write_node() here, we ensure the child is already in the current CP's
     // dirty list before on_root_changed() creates the dependency link.
+    BT_LOG(DEBUG, "going to update new root, child_id={} root_id={}", child->node_id(), root->node_id());
     write_node(child, req.m_op_context);
     ret = on_root_changed(child, req.m_op_context);
     if (ret != btree_status_t::success) {

--- a/src/include/homestore/index/index_table.hpp
+++ b/src/include/homestore/index/index_table.hpp
@@ -299,6 +299,8 @@ protected:
 
         node->set_checksum();
         auto prev_state = idx_node->m_idx_buf->m_state.exchange(index_buf_state_t::DIRTY);
+        LOGTRACEMOD(wbcache, "write_node_impl: node_id={} cp_id={} prev_state={} -> DIRTY", node->node_id(),
+                    cp_ctx->id(), static_cast<int>(prev_state));
         idx_node->m_idx_buf->m_node_level = node->level();
         if (prev_state == index_buf_state_t::CLEAN) {
             // It was clean before, dirtying it first time, add it to the wb_cache list to flush

--- a/src/lib/blkalloc/append_blk_allocator.cpp
+++ b/src/lib/blkalloc/append_blk_allocator.cpp
@@ -16,6 +16,7 @@
 #include <homestore/checkpoint/cp_mgr.hpp>
 #include <homestore/checkpoint/cp.hpp>
 #include <homestore/meta_service.hpp>
+#include <iomgr/iomgr_flip.hpp>
 
 #include "append_blk_allocator.h"
 
@@ -125,6 +126,14 @@ BlkAllocStatus AppendBlkAllocator::reserve_on_cache(BlkId const& blkid) {
 
 void AppendBlkAllocator::cp_flush(CP* cp) {
     // check if current cp's context has dirty buffer already
+    std::lock_guard lg(m_sb_mtx);
+
+#ifdef _PRERELEASE
+    // Flip point: inside cp_flush with lock held
+    if (iomgr_flip::instance()->callback_flip("inside_append_cp_flush")) {
+        LOGINFO("Flip triggered: inside_append_cp_flush");
+    }
+#endif
     if (m_is_dirty.exchange(false)) {
         m_sb->commit_offset = m_commit_offset.load();
         m_sb->freeable_nblks = m_freeable_nblks.load();
@@ -146,13 +155,17 @@ bool AppendBlkAllocator::is_blk_alloced(const BlkId& in_bid, bool) const {
 }
 
 void AppendBlkAllocator::reset() {
+    std::lock_guard lg(m_sb_mtx);
     m_is_dirty.store(false);
     m_sb.destroy();
     meta_service().deregister_handler(get_name());
 }
 
-bool AppendBlkAllocator::is_blk_alloced_on_disk(BlkId const& bid, bool) const {
-    return bid.blk_num() < m_sb->commit_offset;
+bool AppendBlkAllocator::is_blk_alloced_on_disk(BlkId const& bid, bool use_lock) const {
+    std::lock_guard lg(m_sb_mtx);
+    if (!m_sb.is_empty()) { return bid.blk_num() < m_sb->commit_offset; }
+    // if allocator is reset, the sb will be destroyed, and all the blks will be treated as free;
+    return false;
 }
 
 std::string AppendBlkAllocator::get_name() const { return "AppendBlkAlloc_chunk_" + std::to_string(m_chunk_id); }

--- a/src/lib/blkalloc/append_blk_allocator.h
+++ b/src/lib/blkalloc/append_blk_allocator.h
@@ -127,6 +127,7 @@ private:
     std::atomic< blk_num_t > m_commit_offset{0};      // offset in on-disk version
     std::atomic< bool > m_is_dirty{false};
     // AppendBlkAllocMetrics m_metrics;
+    std::mutex m_sb_mtx; // Mutex used while operating on superblk to avoid race condition between cp flush and reset
     superblk< append_blk_sb_t > m_sb; // only cp will be writing to this disk
 };
 

--- a/src/lib/device/chunk.cpp
+++ b/src/lib/device/chunk.cpp
@@ -63,7 +63,22 @@ nlohmann::json Chunk::get_status([[maybe_unused]] int log_level) const {
 }
 
 void Chunk::reset_block_allocator() {
+#ifdef _PRERELEASE
+    // Flip point: before calling allocator reset()
+    if (iomgr_flip::instance()->callback_flip("before_allocator_reset", chunk_id())) {
+        LOGINFO("Flip triggered: before_allocator_reset for chunk_id={}", chunk_id());
+    }
+#endif
+
     m_blk_allocator->reset();
+
+#ifdef _PRERELEASE
+    // Flip point: after reset(), before replacing allocator
+    if (iomgr_flip::instance()->callback_flip("after_allocator_reset", chunk_id())) {
+        LOGINFO("Flip triggered: after_allocator_reset for chunk_id={}", chunk_id());
+    }
+#endif
+
     auto vdev_ptr = hs()->device_mgr()->get_vdev_mutable(vdev_id());
     RELEASE_ASSERT(vdev_ptr, "VDev not found for vdev_id: {}", vdev_id());
     vdev_ptr->reset_chunk_blk_allocator(this);

--- a/src/lib/device/chunk.h
+++ b/src/lib/device/chunk.h
@@ -20,7 +20,7 @@ class BlkAllocator;
 class CP;
 class Chunk {
 private:
-    std::mutex m_mgmt_mutex;
+    std::shared_mutex m_mgmt_mutex;
     chunk_info m_chunk_info;
     PhysicalDev* const m_pdev;
     const uint32_t m_chunk_slot;
@@ -67,12 +67,19 @@ public:
     nlohmann::json get_status([[maybe_unused]] int log_level) const;
     const BlkAllocator* blk_allocator() const { return m_blk_allocator.get(); }
     BlkAllocator* blk_allocator_mutable() { return m_blk_allocator.get(); }
+    std::shared_ptr< BlkAllocator > blk_allocator_shared() {
+        std::shared_lock lg{m_mgmt_mutex};
+        return m_blk_allocator;
+    }
     float get_blk_usage_report_threshold() const { return blk_usage_report_threshold; }
     float get_blk_usage() const;
 
     ////////////// Setters /////////////////////
     void set_user_private(const sisl::blob& data);
-    void set_block_allocator(cshared< BlkAllocator >& blkalloc) { m_blk_allocator = blkalloc; }
+    void set_block_allocator(cshared< BlkAllocator >& blkalloc) {
+        std::unique_lock lg{m_mgmt_mutex};
+        m_blk_allocator = blkalloc;
+    }
     void set_vdev_ordinal(uint32_t vdev_ordinal) { m_vdev_ordinal = vdev_ordinal; }
 
     ////////////// Misc ////////////////////////

--- a/src/lib/device/virtual_dev.cpp
+++ b/src/lib/device/virtual_dev.cpp
@@ -743,7 +743,18 @@ void VirtualDev::cp_flush(VDevCPContext* v_cp_ctx) {
     // pass down cp so that underlying components can get their customized CP context if needed;
     m_chunk_selector->foreach_chunks([this, cp](cshared< Chunk >& chunk) {
         HS_LOG(TRACE, device, "Flushing chunk: {}, vdev: {}", chunk->chunk_id(), m_vdev_info.name);
-        chunk->blk_allocator_mutable()->cp_flush(cp);
+        // Hold shared_ptr to prevent allocator from being reset during cp_flush.
+        // This fixes race with GC's purge_reserved_chunk() which calls reset_block_allocator().
+        auto alloc_ptr = chunk->blk_allocator_shared();
+
+#ifdef _PRERELEASE
+        // Flip point: after getting shared_ptr, before calling cp_flush
+        if (iomgr_flip::instance()->callback_flip("after_get_allocator_shared", chunk->chunk_id())) {
+            LOGINFO("Flip triggered: after_get_allocator_shared for chunk_id={}", chunk->chunk_id());
+        }
+#endif
+
+        alloc_ptr->cp_flush(cp);
     });
 
     // All of the blkids which were captured in the current vdev cp context will now be freed and hence available for

--- a/src/lib/index/wb_cache.cpp
+++ b/src/lib/index/wb_cache.cpp
@@ -828,13 +828,10 @@ bool IndexWBCache::was_node_committed(IndexBufferPtr const& buf) {
 
 //////////////////// CP Related API section /////////////////////////////////
 folly::Future< bool > IndexWBCache::async_cp_flush(IndexCPContext* cp_ctx) {
-#ifdef _PRERELEASE
-    LOGTRACEMOD(wbcache, "Starting Index CP Flush with cp \ndag={}", cp_ctx->to_string_with_dags());
-#else
     LOGINFOMOD(wbcache, "Starting Index CP Flush with cp {}, dirty_buf_count={}, nodes_added={}, nodes_removed={}",
-               cp_ctx->id(), cp_ctx->m_dirty_buf_count.get(), cp_ctx->m_num_nodes_added.load(),
-               cp_ctx->m_num_nodes_removed.load());
-#endif
+           cp_ctx->id(), cp_ctx->m_dirty_buf_count.get(), cp_ctx->m_num_nodes_added.load(),
+           cp_ctx->m_num_nodes_removed.load());
+    LOGTRACEMOD(wbcache, "Index CP Flush with cp {}, \ndag={}", cp_ctx->id(), cp_ctx->to_string_with_dags());
     // #ifdef _PRERELEASE
     //     static int id = 0;
     //     auto filename = "cp_" + std::to_string(id++) + "_" + std::to_string(rand() % 100) + ".dot";

--- a/src/tests/test_data_service.cpp
+++ b/src/tests/test_data_service.cpp
@@ -38,7 +38,9 @@
 #include "device/chunk.h"
 #include "common/homestore_config.hpp"
 #include "common/homestore_assert.hpp"
+#define private public
 #include "blkalloc/blk_allocator.h"
+#include "blkalloc/append_blk_allocator.h"
 #include "test_common/bits_generator.hpp"
 #include "test_common/homestore_test_common.hpp"
 
@@ -1020,6 +1022,284 @@ TEST_F(BlkDataServiceTest, TestRestartWithMissingDrive) {
     wait_for_outstanding_io_done();
     LOGINFO("Step 11: I/O completed, do shutdown.");
 }
+
+// Separate test fixture for tests requiring append allocator
+class BlkDataServiceAppendTest : public testing::Test {
+public:
+    BlkDataService& inst() { return homestore::data_service(); }
+
+    virtual void SetUp() override {
+        m_helper.start_homestore(
+            "test_data_service_append",
+            {{HS_SERVICE::META, {.size_pct = 5.0}},
+             {HS_SERVICE::DATA, {.size_pct = 80.0, .blkalloc_type = homestore::blk_allocator_type_t::append}}});
+    }
+
+    virtual void TearDown() override { m_helper.shutdown_homestore(); }
+
+private:
+    test_common::HSTestHelper m_helper;
+};
+
+#ifdef _PRERELEASE
+// Scenario 1: Order: reset_block_allocator completes first -> cp_flush runs
+// Test that cp_flush can execute successfully after reset_block_allocator is called
+TEST_F(BlkDataServiceAppendTest, TestResetCompletedBeforeCpFlush) {
+    vdev_info vinfo;
+    auto data_vdev = inst().open_vdev(vinfo, true);
+    auto chunks = data_vdev->get_chunks();
+
+    auto it = std::find_if(chunks.begin(), chunks.end(), [](const auto& pair) {
+        return pair.second && pair.second->blk_allocator() &&
+            pair.second->blk_allocator()->get_name().find("append_chunk_") == 0;
+    });
+    ASSERT_NE(it, chunks.end()) << "No AppendBlkAllocator chunks found";
+    auto chunk = it->second;
+    auto chunk_id = chunk->chunk_id();
+    static_cast< AppendBlkAllocator* >(chunk->blk_allocator_mutable())->m_is_dirty.store(true);
+
+    LOGINFO("Scenario 1: Testing chunk_id={}", chunk_id);
+
+    std::atomic< bool > cp_flush_got_shared_ptr{false};
+    std::atomic< bool > reset_completed{false};
+    std::atomic< bool > cp_flush_completed{false};
+
+    auto* fc = iomgr_flip::client_instance();
+    flip::FlipCondition dont_care = fc->create_condition("", flip::Operator::DONT_CARE, 0);
+    flip::FlipFrequency freq;
+    freq.set_count(10);
+    freq.set_percent(100);
+
+    // Flip 1: After getting shared_ptr, wait for reset_block_allocator to complete
+    fc->inject_callback_flip< void, uint16_t >(
+        "after_get_allocator_shared", {dont_care}, freq, std::function< void(uint16_t) >([&, chunk_id](uint16_t cid) {
+            if (cid != chunk_id) return;
+            LOGINFO("Scenario 1: cp_flush got shared_ptr for chunk_id={}", cid);
+            cp_flush_got_shared_ptr.store(true);
+
+            // Wait for reset_block_allocator to complete
+            for (int i = 0; i < 200 && !reset_completed.load(); ++i) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+            RELEASE_ASSERT(reset_completed.load(), "reset_block_allocator should complete before cp_flush continues");
+            LOGINFO("Scenario 1: cp_flush proceeding after reset_block_allocator completed");
+        }));
+
+    // Flip 2: Before calling reset(), wait for cp_flush to get shared_ptr
+    fc->inject_callback_flip< void, uint16_t >(
+        "before_allocator_reset", {dont_care}, freq, std::function< void(uint16_t) >([&, chunk_id](uint16_t cid) {
+            if (cid != chunk_id) return;
+            for (int i = 0; i < 200 && !cp_flush_got_shared_ptr.load(); ++i) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+            RELEASE_ASSERT(cp_flush_got_shared_ptr.load(), "cp_flush should get shared_ptr first");
+            LOGINFO("Scenario 1: About to call reset() after cp_flush got shared_ptr");
+        }));
+
+    std::thread flush_thread([&]() {
+        VDevCPContext cp_ctx(nullptr);
+        data_vdev->cp_flush(&cp_ctx);
+        cp_flush_completed.store(true);
+        LOGINFO("Scenario 1: cp_flush completed successfully");
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    std::thread reset_thread([&]() {
+        chunk->reset_block_allocator();
+        reset_completed.store(true);
+        LOGINFO("Scenario 1: reset_block_allocator completed");
+    });
+
+    flush_thread.join();
+    reset_thread.join();
+
+    // Cleanup: remove injected flips
+    fc->remove_flip("after_get_allocator_shared");
+    fc->remove_flip("before_allocator_reset");
+
+    ASSERT_TRUE(cp_flush_completed.load());
+    ASSERT_TRUE(reset_completed.load());
+    LOGINFO("Scenario 1: PASSED - Order: get_ptr -> reset_block_allocator -> cp_flush");
+}
+
+// Scenario 2: Order: cp_flush holds shared_ptr -> old allocator reset -> cp_flush on old -> create new allocator
+// Test that cp_flush executes after old allocator reset, then new allocator is created
+TEST_F(BlkDataServiceAppendTest, TestResetDuringCpFlushHoldsSharedPtr) {
+    vdev_info vinfo;
+    auto data_vdev = inst().open_vdev(vinfo, true);
+    auto chunks = data_vdev->get_chunks();
+
+    auto it = std::find_if(chunks.begin(), chunks.end(), [](const auto& pair) {
+        return pair.second && pair.second->blk_allocator() &&
+            pair.second->blk_allocator()->get_name().find("append_chunk_") == 0;
+    });
+    ASSERT_NE(it, chunks.end());
+    auto chunk = it->second;
+    auto chunk_id = chunk->chunk_id();
+    static_cast< AppendBlkAllocator* >(chunk->blk_allocator_mutable())->m_is_dirty.store(true);
+
+    LOGINFO("Scenario 2: Testing chunk_id={}", chunk_id);
+
+    std::atomic< bool > cp_flush_got_shared_ptr{false};
+    std::atomic< bool > old_allocator_reset{false};
+    std::atomic< bool > reset_completed{false};
+    std::atomic< bool > cp_flush_completed{false};
+
+    auto* fc = iomgr_flip::client_instance();
+    flip::FlipCondition dont_care = fc->create_condition("", flip::Operator::DONT_CARE, 0);
+    flip::FlipFrequency freq;
+    freq.set_count(10);
+    freq.set_percent(100);
+
+    // Flip 1: After getting shared_ptr, wait for old allocator reset to complete
+    fc->inject_callback_flip< void, uint16_t >(
+        "after_get_allocator_shared", {dont_care}, freq, std::function< void(uint16_t) >([&, chunk_id](uint16_t cid) {
+            if (cid != chunk_id) return;
+            LOGINFO("Scenario 2: cp_flush got shared_ptr for chunk_id={}", cid);
+            cp_flush_got_shared_ptr.store(true);
+
+            // Wait for old allocator reset to complete
+            for (int i = 0; i < 200 && !old_allocator_reset.load(); ++i) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+            RELEASE_ASSERT(old_allocator_reset.load(), "Old allocator reset should complete before cp_flush continues");
+            LOGINFO("Scenario 2: cp_flush proceeding after old allocator reset completed");
+        }));
+
+    // Flip 2: Before calling reset(), wait for cp_flush to get shared_ptr
+    fc->inject_callback_flip< void, uint16_t >(
+        "before_allocator_reset", {dont_care}, freq, std::function< void(uint16_t) >([&, chunk_id](uint16_t cid) {
+            if (cid != chunk_id) return;
+            for (int i = 0; i < 200 && !cp_flush_got_shared_ptr.load(); ++i) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+            RELEASE_ASSERT(cp_flush_got_shared_ptr.load(), "cp_flush should get shared_ptr first");
+            LOGINFO("Scenario 2: About to call reset() on old allocator");
+        }));
+
+    // Flip 3: After old allocator reset completes, mark flag and wait for cp_flush to finish
+    fc->inject_callback_flip< void, uint16_t >(
+        "after_allocator_reset", {dont_care}, freq, std::function< void(uint16_t) >([&, chunk_id](uint16_t cid) {
+            if (cid != chunk_id) return;
+            LOGINFO("Scenario 2: Old allocator reset() completed");
+            old_allocator_reset.store(true);
+
+            // Wait for cp_flush to complete on old allocator before creating new one
+            for (int i = 0; i < 200 && !cp_flush_completed.load(); ++i) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+            RELEASE_ASSERT(cp_flush_completed.load(), "cp_flush should complete before creating new allocator");
+            LOGINFO("Scenario 2: cp_flush completed, proceeding to create new allocator");
+        }));
+
+    std::thread flush_thread([&]() {
+        VDevCPContext cp_ctx(nullptr);
+        data_vdev->cp_flush(&cp_ctx);
+        cp_flush_completed.store(true);
+        LOGINFO("Scenario 2: cp_flush completed successfully on old allocator");
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    std::thread reset_thread([&]() {
+        chunk->reset_block_allocator();
+        reset_completed.store(true);
+        LOGINFO("Scenario 2: reset_block_allocator completed (new allocator created)");
+    });
+
+    flush_thread.join();
+    reset_thread.join();
+
+    // Cleanup: remove injected flips
+    fc->remove_flip("after_get_allocator_shared");
+    fc->remove_flip("before_allocator_reset");
+    fc->remove_flip("after_allocator_reset");
+
+    ASSERT_TRUE(cp_flush_completed.load());
+    ASSERT_TRUE(reset_completed.load());
+    ASSERT_TRUE(old_allocator_reset.load());
+    LOGINFO("Scenario 2: PASSED - Order: get_ptr -> old_allocator_reset -> cp_flush -> create new allocator");
+}
+
+// Scenario 3: Order: cp_flush acquires mutex first -> reset_block_allocator blocks on mutex
+// Test that mutex protects m_sb during concurrent cp_flush and reset_block_allocator
+TEST_F(BlkDataServiceAppendTest, TestCpFlushBlocksResetWithMutex) {
+    vdev_info vinfo;
+    auto data_vdev = inst().open_vdev(vinfo, true);
+    auto chunks = data_vdev->get_chunks();
+
+    auto it = std::find_if(chunks.begin(), chunks.end(), [](const auto& pair) {
+        return pair.second && pair.second->blk_allocator() &&
+            pair.second->blk_allocator()->get_name().find("append_chunk_") == 0;
+    });
+    ASSERT_NE(it, chunks.end());
+    auto chunk = it->second;
+    auto chunk_id = chunk->chunk_id();
+    static_cast< AppendBlkAllocator* >(chunk->blk_allocator_mutable())->m_is_dirty.store(true);
+
+    LOGINFO("Scenario 3: Testing chunk_id={}", chunk_id);
+
+    std::atomic< bool > cp_flush_inside{false};
+    std::atomic< bool > reset_completed{false};
+    std::atomic< bool > cp_flush_completed{false};
+
+    auto* fc = iomgr_flip::client_instance();
+    flip::FlipCondition dont_care = fc->create_condition("", flip::Operator::DONT_CARE, 0);
+    flip::FlipFrequency freq;
+    freq.set_count(10);
+    freq.set_percent(100);
+
+    // Flip 1: Inside cp_flush with lock held, give reset time to attempt acquiring lock
+    fc->inject_callback_flip< void >(
+        "inside_append_cp_flush", {dont_care}, freq, std::function< void() >([&]() {
+            LOGINFO("Scenario 3: Inside cp_flush with lock held");
+            cp_flush_inside.store(true);
+
+            // Give reset_block_allocator time to attempt acquiring lock
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+            LOGINFO("Scenario 3: cp_flush continuing (reset_block_allocator should be blocked on lock)");
+        }));
+
+    // Flip 2: Before calling reset(), wait for cp_flush to be inside critical section
+    fc->inject_callback_flip< void, uint16_t >(
+        "before_allocator_reset", {dont_care}, freq, std::function< void(uint16_t) >([&, chunk_id](uint16_t cid) {
+            if (cid != chunk_id) return;
+            for (int i = 0; i < 200 && !cp_flush_inside.load(); ++i) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+            RELEASE_ASSERT(cp_flush_inside.load(), "cp_flush should be inside critical section");
+            LOGINFO("Scenario 3: cp_flush is inside, about to call reset() (should block on m_sb_mtx)");
+        }));
+
+    std::thread flush_thread([&]() {
+        chunk->blk_allocator_shared()->cp_flush(nullptr);
+        cp_flush_completed.store(true);
+        LOGINFO("Scenario 3: cp_flush completed successfully");
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    std::thread reset_thread([&]() {
+        chunk->reset_block_allocator();
+        reset_completed.store(true);
+        LOGINFO("Scenario 3: reset_block_allocator completed (after waiting for cp_flush lock)");
+    });
+
+    flush_thread.join();
+    reset_thread.join();
+
+    // Cleanup: remove injected flips
+    fc->remove_flip("inside_append_cp_flush");
+    fc->remove_flip("before_allocator_reset");
+
+    ASSERT_TRUE(cp_flush_completed.load());
+    ASSERT_TRUE(reset_completed.load());
+    LOGINFO("Scenario 3: PASSED - mutex protected m_sb from concurrent reset_block_allocator during cp_flush");
+}
+
+#endif // _PRERELEASE
 
 // Stream related test
 


### PR DESCRIPTION
Upper layer (GC) calls reset before chunk usage, which resets the old blk allocator. If the chunk is being cp flushed, resetting the allocator destroys the space, causing crashes when accessing invalid memory.