### PR TITLE
SDSTOR-20656: Added wbc epochs and UT

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.5.17"
+    version = "7.5.18"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/include/homestore/index/index_internal.hpp
+++ b/src/include/homestore/index/index_internal.hpp
@@ -120,7 +120,8 @@ struct IndexBuffer : public sisl::ObjLifeCounter< IndexBuffer > {
     cp_id_t m_created_cp_id{-1};                                        // CP id when this buffer is created.
     std::atomic< index_buf_state_t > m_state{index_buf_state_t::CLEAN}; // Is buffer yet to persist?
     uint8_t* m_bytes{nullptr};                                          // Actual data buffer
-    uint32_t m_node_level{0};                                           // levels of the node in the btree
+    uint32_t m_node_level{};                                            // levels of the node in the btree
+    uint64_t m_chunk_epoch{};                                           // Track chunk epoch
 
     std::shared_ptr< IndexBuffer > m_up_buffer;             // Parent buffer in the chain to persisted
     sisl::atomic_counter< int > m_wait_for_down_buffers{0}; // Number of children need to wait for before persisting

--- a/src/lib/device/chunk.cpp
+++ b/src/lib/device/chunk.cpp
@@ -82,6 +82,8 @@ void Chunk::reset_block_allocator() {
     auto vdev_ptr = hs()->device_mgr()->get_vdev_mutable(vdev_id());
     RELEASE_ASSERT(vdev_ptr, "VDev not found for vdev_id: {}", vdev_id());
     vdev_ptr->reset_chunk_blk_allocator(this);
+
+    bump_wbc_epoch();
 }
 
 } // namespace homestore

--- a/src/lib/device/chunk.h
+++ b/src/lib/device/chunk.h
@@ -25,9 +25,10 @@ private:
     PhysicalDev* const m_pdev;
     const uint32_t m_chunk_slot;
     const uint32_t m_stream_id;
-    uint32_t m_vdev_ordinal{0};
+    uint32_t m_vdev_ordinal{};
     shared< BlkAllocator > m_blk_allocator;
     float blk_usage_report_threshold{0.9};
+    std::atomic<uint64_t> m_wbc_epoch{};
 
 public:
     static constexpr auto MAX_CHUNK_SIZE = std::numeric_limits< uint32_t >::max();
@@ -42,7 +43,7 @@ public:
     Chunk& operator=(Chunk&&) noexcept = delete;
     virtual ~Chunk() = default;
 
-    /////////////// Pointer Getters ////////////////////
+    /////////////// Pointer Getters /////////////////////
     const PhysicalDev* physical_dev() const { return m_pdev; }
     PhysicalDev* physical_dev_mutable() { return m_pdev; };
     const chunk_info& info() const { return m_chunk_info; }
@@ -84,6 +85,9 @@ public:
 
     ////////////// Misc ////////////////////////
     void reset_block_allocator();
+
+    uint64_t wbc_epoch() const { return m_wbc_epoch.load(std::memory_order_acquire); }
+    void bump_wbc_epoch() { m_wbc_epoch.fetch_add(1, std::memory_order_acq_rel); }
 
 private:
     void write_chunk_info();

--- a/src/lib/device/vchunk.cpp
+++ b/src/lib/device/vchunk.cpp
@@ -17,7 +17,7 @@
 #include "device/chunk.h"
 
 namespace homestore {
-VChunk::VChunk(cshared< Chunk >& chunk) : m_internal_chunk(chunk) {}
+VChunk::VChunk(cshared< Chunk > const& chunk) : m_internal_chunk(chunk) {}
 
 void VChunk::set_user_private(const sisl::blob& data) { m_internal_chunk->set_user_private(data); }
 

--- a/src/lib/index/wb_cache.cpp
+++ b/src/lib/index/wb_cache.cpp
@@ -94,33 +94,53 @@ void IndexWBCache::start_flush_threads() {
 
 BtreeNodePtr IndexWBCache::alloc_buf(uint32_t ordinal, node_initializer_t&& node_initializer) {
     auto cpg = cp_mgr().cp_guard();
-    auto cp_ctx = r_cast< IndexCPContext* >(cpg.context(cp_consumer_t::INDEX_SVC));
 
     // Alloc a block of data from underlying vdev
     MultiBlkId blkid;
     // Ordinal used as a hint in the case of custom chunk selector exists
     blk_alloc_hints hints;
     hints.application_hint = ordinal;
-    auto ret = m_vdev->alloc_contiguous_blks(1, hints, blkid);
-    if (ret != BlkAllocStatus::SUCCESS) { return nullptr; }
+
+    if (m_vdev->alloc_contiguous_blks(1, hints, blkid) != BlkAllocStatus::SUCCESS) {
+        return nullptr;
+    }
 
     // Alloc buffer and initialize the node
     auto idx_buf = std::make_shared< IndexBuffer >(blkid, m_node_size, m_vdev->align_size());
     idx_buf->m_created_cp_id = cpg->id();
     idx_buf->m_dirtied_cp_id = cpg->id();
+    idx_buf->m_chunk_epoch = current_chunk_epoch(idx_buf->blkid());
     auto node = node_initializer(idx_buf);
     idx_buf->m_node_level = node->level();
 
+    // Add the node to the cache. Skip if we are in recovery mode.
     if (!m_in_recovery) {
-        // Add the node to the cache. Skip if we are in recovery mode.
-        bool done = m_cache.insert(node);
-        HS_REL_ASSERT_EQ(done, true, "Unable to add alloc'd node to cache, low memory or duplicate inserts?");
+retry_insert:
+        BtreeNodePtr existing;
+        if (m_cache.get(idx_buf->blkid(), existing)) {
+            if (!is_stale_node(existing)) {
+                HS_REL_ASSERT(false, "alloc_buf found live duplicate cache entry for blkid {}",
+                              idx_buf->blkid().to_string());
+            }
+            LOGTRACEMOD(wbcache, "alloc_buf evicting stale node for blkid {}", idx_buf->blkid().to_string());
+            m_cache.remove(idx_buf->blkid(), existing);
+        }
+
+        if (!m_cache.insert(node)) {
+            if (m_cache.get(idx_buf->blkid(), existing) && is_stale_node(existing)) {
+                m_cache.remove(idx_buf->blkid(), existing);
+                goto retry_insert;
+            }
+            HS_REL_ASSERT(false, "Unable to add alloc'd node to cache, low memory or duplicate inserts?");
+        }
     }
 
-    // The entire index is updated in the commit path, so we alloc the blk and commit them right away
-    auto alloc_status = m_vdev->commit_blk(blkid);
-    // if any error happens when committing the blk to index service, we should assert and crash
-    if (alloc_status != BlkAllocStatus::SUCCESS) HS_REL_ASSERT(0, "Failed to commit blk: {}", blkid.to_string());
+    // The entire index is updated in the commit path, so we alloc the blk and commit them right away.
+    // If any error happens when committing the blk to index service, we should assert and crash
+    if (m_vdev->commit_blk(blkid) != BlkAllocStatus::SUCCESS) {
+        HS_REL_ASSERT(0, "Failed to commit blk: {}", blkid.to_string());
+    }
+
     return node;
 }
 
@@ -134,35 +154,54 @@ void IndexWBCache::write_buf(const BtreeNodePtr& node, const IndexBufferPtr& buf
             LOGTRACEMOD(wbcache, "write buf [{}] in recovery mode", buf->to_string());
             m_vdev->sync_write(r_cast< const char* >(buf->raw_buffer()), m_node_size, buf->m_blkid);
         }
-    } else {
-        if (node != nullptr) { m_cache.upsert(node); }
-        LOGTRACEMOD(wbcache, "add to dirty list cp {} {}", cp_ctx->id(), buf->to_string());
-        r_cast< IndexCPContext* >(cp_ctx)->add_to_dirty_list(buf);
-        resource_mgr().inc_dirty_buf_size(m_node_size);
+
+        return;
     }
+
+    if (node) {
+        RELEASE_ASSERT(static_cast<IndexBtreeNode*>(node.get())->m_idx_buf == buf, "node/buffer mismatch");
+        buf->m_chunk_epoch = current_chunk_epoch(buf->blkid());
+        m_cache.upsert(node);
+    }
+
+    LOGTRACEMOD(wbcache, "add to dirty list cp {} {}", cp_ctx->id(), buf->to_string());
+    r_cast<IndexCPContext*>(cp_ctx)->add_to_dirty_list(buf);
+    resource_mgr().inc_dirty_buf_size(m_node_size);
 }
 
 void IndexWBCache::read_buf(bnodeid_t id, BtreeNodePtr& node, node_initializer_t&& node_initializer) {
     auto const blkid = BlkId{id};
 
 retry:
-    // Check if the blkid is already in cache, if notL load and put it into the cache
-    if (!m_in_recovery && m_cache.get(blkid, node)) { return; }
+    // Check if the blkid is already in cache, if not load and put it into the cache
+    if (!m_in_recovery) {
+        if (m_cache.get(blkid, node)) {
+            if (!is_stale_node(node)) { return; }
+            LOGTRACEMOD(wbcache, "stale cache hit for blkid {}, removing and re-reading", blkid.to_string());
+            m_cache.remove(blkid, node);
+            node.reset();
+        }
+    }
 
     // Read the buffer from virtual device
     auto idx_buf = std::make_shared< IndexBuffer >(blkid, m_node_size, m_vdev->align_size());
+    idx_buf->m_chunk_epoch = current_chunk_epoch(blkid);
     m_vdev->sync_read(r_cast< char* >(idx_buf->raw_buffer()), m_node_size, blkid);
 
     // Create the btree node out of buffer
     node = node_initializer(idx_buf);
 
     // Push the node into cache
-    if (!m_in_recovery) {
-        bool done = m_cache.insert(node);
-        if (!done) {
-            // There is a race between 2 concurrent reads from vdev and other party won the race. Re-read from cache
-            goto retry;
-        }
+    if (m_in_recovery || m_cache.insert(node)) { return; }
+
+    if (!m_cache.get(blkid, node)) {
+        HS_REL_ASSERT(false, "Failed to insert read buf {} into cache", blkid.to_string());
+    }
+
+    if (is_stale_node(node)) {
+        LOGTRACEMOD(wbcache, "stale cache race for blkid {}, removing and retrying", blkid.to_string());
+        m_cache.remove(blkid, node);
+        goto retry;
     }
 }
 
@@ -1205,6 +1244,26 @@ void IndexWBCache::get_next_bufs_internal(IndexCPContext* cp_ctx, uint32_t max_c
             // There is some leader buffer still flushing, once done its completion will flush this buffer
         }
     }
+}
+
+uint64_t IndexWBCache::current_chunk_epoch(const BlkId& blkid) const {
+    auto* chunk = hs()->device_mgr()->get_chunk_mutable(blkid.chunk_num());
+    RELEASE_ASSERT(chunk != nullptr, "chunk {} not found", blkid.chunk_num());
+    return chunk->wbc_epoch();
+}
+
+bool IndexWBCache::is_stale_buf(const IndexBufferPtr& buf) const {
+    return buf->m_chunk_epoch != current_chunk_epoch(buf->blkid());
+}
+
+bool IndexWBCache::is_stale_node(const BtreeNodePtr& node) const {
+    if (!hs()->index_service().get_chunk_selector()) [[likely]] {
+        return false;
+    }
+
+    auto* idx_node = static_cast<IndexBtreeNode*>(node.get());
+    RELEASE_ASSERT(idx_node != nullptr && idx_node->m_idx_buf != nullptr, "invalid cached node");
+    return is_stale_buf(idx_node->m_idx_buf);
 }
 
 /*

--- a/src/lib/index/wb_cache.hpp
+++ b/src/lib/index/wb_cache.hpp
@@ -93,5 +93,11 @@ private:
     void load_buf(IndexBufferPtr const& buf);
     void update_up_buffer_counters(IndexBufferPtr const& buf);
     void prune_up_buffers(IndexBufferPtr const& buf, std::vector< IndexBufferPtr >& bufs_to_repair);
+
+    // Helpers for maintaining cache validity
+    uint64_t current_chunk_epoch(const BlkId& blkid) const;
+    // These two always return false if chunk selector is not in use
+    bool is_stale_buf(const IndexBufferPtr& buf) const;
+    bool is_stale_node(const BtreeNodePtr& node) const;
 };
 } // namespace homestore

--- a/src/tests/test_index_crash_recovery.cpp
+++ b/src/tests/test_index_crash_recovery.cpp
@@ -1985,6 +1985,303 @@ TEST_F(IndexCrashCreatedFreedReuseTest, CreatedAndFreedBlkReusedByRecoveryRepair
     }
 }
 
+class SameChunkSelector : public ChunkSelector {
+public:
+    void add_chunk(cshared<Chunk>& chunk) override {
+        if (!m_fixed_chunk) {
+            m_fixed_chunk = chunk;
+        }
+        m_chunks.push_back(chunk);
+    }
+
+    void foreach_chunks(std::function<void(cshared<Chunk>&)>&& cb) override {
+        for (auto& c : m_chunks) {
+            cb(c);
+        }
+    }
+
+    cshared<Chunk> select_chunk(blk_count_t, const blk_alloc_hints&) override {
+        HS_REL_ASSERT(m_fixed_chunk != nullptr, "SameChunkSelector: no chunk was added before select_chunk");
+        return m_fixed_chunk;
+    }
+
+private:
+    shared<Chunk> m_fixed_chunk;
+    std::vector<shared<Chunk>> m_chunks;
+};
+
+struct DeterministicChunkSelectorWbcReuseTest : public test_common::HSTestHelper,
+                                                BtreeTestHelper< FixedLenBtree >,
+                                                public ::testing::Test {
+    using T = FixedLenBtree;
+    using K = typename T::KeyType;
+    using V = typename T::ValueType;
+    using BaseBt = typename T::BtreeType;
+
+    std::shared_ptr< SameChunkSelector > m_same_chunk_selector;
+
+    class InspectableBtree : public BaseBt {
+    public:
+        using BaseBt::BaseBt;
+
+        std::set< bnodeid_t > collect_node_ids() const {
+            std::set< bnodeid_t > ids;
+            collect_node_ids_recurse(this->root_node_id(), ids);
+            return ids;
+        }
+
+        void warm_all_nodes_into_wbc() {
+            auto ids = collect_node_ids();
+            for (auto const node_id : ids) {
+                BtreeNodePtr node;
+                auto ret = this->read_node_impl(node_id, node);
+                ASSERT_EQ(ret, btree_status_t::success)
+                    << "failed to read node " << BlkId{node_id}.to_string();
+            }
+        }
+
+        BtreeNodePtr read_node_for_test(bnodeid_t node_id) {
+            BtreeNodePtr node;
+            auto ret = this->read_node_impl(node_id, node);
+            EXPECT_EQ(ret, btree_status_t::success);
+            return node;
+        }
+
+    private:
+        void collect_node_ids_recurse(bnodeid_t node_id, std::set< bnodeid_t >& ids) const {
+            if ((node_id == empty_bnodeid) || ids.contains(node_id)) { return; }
+
+            BtreeNodePtr node;
+            if ((this->read_node_impl(node_id, node) != btree_status_t::success) || node->is_node_deleted()) { return; }
+
+            ids.insert(node_id);
+
+            if (node->is_leaf()) { return; }
+
+            for (uint32_t i = 0; i < node->total_entries(); ++i) {
+                BtreeLinkInfo child_info;
+                node->get_nth_value(i, &child_info, false /* copy */);
+                collect_node_ids_recurse(child_info.bnode_id(), ids);
+            }
+
+            if (node->has_valid_edge()) { collect_node_ids_recurse(node->get_edge_value().bnode_id(), ids); }
+        }
+    };
+
+    class TestIndexServiceCallbacks : public IndexServiceCallbacks {
+    public:
+        explicit TestIndexServiceCallbacks(DeterministicChunkSelectorWbcReuseTest* test) : m_test(test) {}
+
+        std::shared_ptr< IndexTableBase > on_index_table_found(superblk< index_table_sb >&& sb) override {
+            m_test->init_cfg();
+            auto bt = std::make_shared< InspectableBtree >(std::move(sb), m_test->m_cfg);
+            m_test->m_last_recovered_bt = bt;
+            return bt;
+        }
+
+    private:
+        DeterministicChunkSelectorWbcReuseTest* m_test;
+    };
+
+    DeterministicChunkSelectorWbcReuseTest() : ::testing::Test() { this->m_is_multi_threaded = false; }
+
+    void init_cfg() {
+        this->m_cfg = BtreeConfig(hs()->index_service().node_size());
+        this->m_cfg.m_leaf_node_type = T::leaf_node_type;
+        this->m_cfg.m_int_node_type = T::interior_node_type;
+        this->m_cfg.m_max_keys_in_node = 5;
+        this->m_cfg.m_min_keys_in_node = 2;
+    }
+
+    void SetUp() override {
+        HS_SETTINGS_FACTORY().modifiable_settings([](auto& s) {
+            s.generic.cache_max_throttle_cnt = 10000;
+            s.generic.cp_timer_us = 0x8000000000000000;
+            s.resource_limits.dirty_buf_percent = 100;
+            HS_SETTINGS_FACTORY().save();
+        });
+
+        m_same_chunk_selector = std::make_shared< SameChunkSelector >();
+
+        this->start_homestore(
+            "test_index_crash_recovery",
+            {{HS_SERVICE::META, {.size_pct = 10.0}},
+             {HS_SERVICE::INDEX,
+              {.size_pct = 10.0,
+               .index_chunk_selector = m_same_chunk_selector,
+               .index_svc_cbs = new TestIndexServiceCallbacks(this)}}},
+            nullptr, {}, true /* init_device */);
+
+        BtreeTestHelper< FixedLenBtree >::SetUp();
+        init_cfg();
+
+        ASSERT_NE(hs()->index_service().get_chunk_selector(), nullptr)
+            << "IndexService chunk selector was not installed";
+    }
+
+    void restart_homestore(uint32_t shutdown_delay_sec = 3) override {
+        this->params(HS_SERVICE::INDEX).index_svc_cbs = new TestIndexServiceCallbacks(this);
+        this->params(HS_SERVICE::INDEX).index_chunk_selector = m_same_chunk_selector;
+        test_common::HSTestHelper::restart_homestore(shutdown_delay_sec);
+    }
+
+    void TearDown() override {
+        BtreeTestHelper< FixedLenBtree >::TearDown();
+        this->shutdown_homestore(false);
+    }
+
+    std::shared_ptr< InspectableBtree > create_btree() {
+        auto uuid = boost::uuids::random_generator()();
+        auto parent_uuid = boost::uuids::random_generator()();
+        auto bt = std::make_shared< InspectableBtree >(uuid, parent_uuid, 0, this->m_cfg);
+        hs()->index_service().add_index_table(bt);
+        return bt;
+    }
+
+    void destroy_btree(std::shared_ptr< InspectableBtree >& bt) {
+        hs()->index_service().remove_index_table(bt);
+        bt->destroy();
+        bt.reset();
+    }
+
+    btree_status_t insert_key(std::shared_ptr< InspectableBtree >& bt, uint32_t key_num) {
+        K key{key_num};
+        V value{V::generate_rand()};
+        auto req = BtreeSinglePutRequest{&key, &value, btree_put_type::INSERT};
+        req.enable_route_tracing();
+        return bt->put(req);
+    }
+
+    btree_status_t insert_range(std::shared_ptr< InspectableBtree >& bt, uint32_t begin, uint32_t end) {
+        for (uint32_t k = begin; k < end; ++k) {
+            auto ret = insert_key(bt, k);
+            if (ret != btree_status_t::success) {
+                LOGINFO("insert_range failed at key={} ret={}", k, enum_name(ret));
+                return ret;
+            }
+        }
+        return btree_status_t::success;
+    }
+
+    uint64_t chunk_epoch(chunk_num_t chunk_num) {
+        auto* chunk = hs()->device_mgr()->get_chunk_mutable(chunk_num);
+        EXPECT_NE(chunk, nullptr);
+        return chunk->wbc_epoch();
+    }
+
+    uint64_t node_epoch(const BtreeNodePtr& node) {
+        auto* idx_node = static_cast<IndexBtreeNode*>(node.get());
+        EXPECT_NE(idx_node, nullptr);
+        EXPECT_NE(idx_node->m_idx_buf, nullptr);
+        return idx_node->m_idx_buf->m_chunk_epoch;
+    }
+
+    uint32_t assert_all_nodes_on_same_chunk(std::shared_ptr< InspectableBtree >& bt) {
+        auto ids = bt->collect_node_ids();
+        HS_DBG_ASSERT_GT(ids.size(), 1u, "expected more than one node");
+
+        auto it = ids.begin();
+        auto expected_chunk = BlkId{*it}.chunk_num();
+
+        for (auto const id : ids) {
+            auto const chunk_num = BlkId{id}.chunk_num();
+            DEBUG_ASSERT_EQ(chunk_num, expected_chunk,
+                "node {} landed on chunk {} but expected chunk {}", BlkId{id}.to_string(), chunk_num, expected_chunk);
+        }
+
+        return expected_chunk;
+    }
+
+    void clear_chunk_bitmap(chunk_num_t chunk_num) {
+        Chunk* chunk = hs()->device_mgr()->get_chunk_mutable(chunk_num);
+        ASSERT_NE(chunk, nullptr) << "chunk " << chunk_num << " not found";
+
+        // Zero the alloc bitmap so the next btree reuses bt1 blkids
+        chunk->reset_block_allocator();
+    }
+
+    std::shared_ptr< InspectableBtree > m_last_recovered_bt;
+};
+
+TEST_F(DeterministicChunkSelectorWbcReuseTest, DestroyedBtreeStaleWbcEntriesCorruptNextBtreeOnSameChunk) {
+    // Create and populate bt1
+    auto bt1 = create_btree();
+    insert_range(bt1, 0, 256);
+    test_common::HSTestHelper::trigger_cp(true);
+
+    auto const bt1_node_ids = bt1->collect_node_ids();
+    ASSERT_FALSE(bt1_node_ids.empty());
+
+    auto const bt1_chunk = assert_all_nodes_on_same_chunk(bt1);
+
+    // Force bt1 nodes into wbc
+    bt1->warm_all_nodes_into_wbc();
+
+    // Destroy bt1 and leave stale entries in wbc
+    destroy_btree(bt1);
+
+    // Clear the chunk
+    clear_chunk_bitmap(bt1_chunk);
+
+    // Create bt2 on the same chunk with stale WBC entries still present;
+    // Duplicate insert should happen here on root creation if wbc epochs don't work
+    auto bt2 = create_btree();
+
+    ASSERT_EQ(BlkId{bt2->root_node_id()}.chunk_num(), bt1_chunk)
+        << "bt2 root did not land on the expected reused chunk";
+
+    ASSERT_TRUE(bt1_node_ids.contains(bt2->root_node_id()))
+        << "bt2 root did not immediately reuse a bt1 blkid; setup is not deterministic";
+
+    // This is where the wbc duplicate-insert/corruption shows up
+    // if wbc epochs function incorrectly and create_btree() didn't trigger it
+    auto ret = insert_range(bt2, 100000, 100128);
+    ASSERT_EQ(ret, btree_status_t::success);
+}
+
+TEST_F(DeterministicChunkSelectorWbcReuseTest, ChunkEpochInvalidatesStaleWbcEntriesOnChunkReuse) {
+    auto bt1 = create_btree();
+    insert_range(bt1, 0, 256);
+    test_common::HSTestHelper::trigger_cp(true);
+
+    auto const bt1_root = bt1->root_node_id();
+    auto const bt1_chunk = assert_all_nodes_on_same_chunk(bt1);
+
+    // Keep one old cached node alive so we can inspect its epoch after chunk reset
+    auto stale_root = bt1->read_node_for_test(bt1_root);
+    auto const old_node_epoch = node_epoch(stale_root);
+    auto const old_chunk_epoch = chunk_epoch(bt1_chunk);
+    ASSERT_EQ(old_node_epoch, old_chunk_epoch);
+
+    // Populate WBC with bt1 nodes
+    bt1->warm_all_nodes_into_wbc();
+
+    // Destroy bt1 and leave stale entries in wbc
+    destroy_btree(bt1);
+
+    // Clear the chunk
+    clear_chunk_bitmap(bt1_chunk);
+
+    auto const new_chunk_epoch = chunk_epoch(bt1_chunk);
+    ASSERT_GT(new_chunk_epoch, old_chunk_epoch);
+
+    // Old cached node should now be stale by epoch
+    ASSERT_EQ(node_epoch(stale_root), old_node_epoch);
+    ASSERT_NE(node_epoch(stale_root), new_chunk_epoch);
+
+    // Recreate btree on the same chunk. With epoch invalidation, this should not collide with stale WBC
+    auto bt2 = create_btree();
+    ASSERT_EQ(BlkId{bt2->root_node_id()}.chunk_num(), bt1_chunk);
+
+    auto new_root = bt2->read_node_for_test(bt2->root_node_id());
+    ASSERT_EQ(node_epoch(new_root), new_chunk_epoch);
+    ASSERT_NE(node_epoch(new_root), node_epoch(stale_root));
+
+    // And the tree should be usable
+    insert_range(bt2, 100000, 100128);
+    bt2->warm_all_nodes_into_wbc();
+}
+
 #endif
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
0. Create homestore with chunk selector
1. Create btree1 and populate it
2. Nodes get into wbc cache
3. Destroy btree1 (wbc purge is not done, also volume's chunk bitmap is not cleared)
4. Create btree2 and populate it
5. Nodes get into wbc cache and we get cache corruption, duplicate inserts

This change adds a generation counter per chunk to invalidate stale WBC entries without scanning or deleting them one by  one when custom chunk selector is in use.

When a btree is destroyed with chunk selector enabled, its chunks can be reset and reused by a later btree. The problem is that old WBC entries may still exist for the same BlkIds. When a new btree reuses those BlkIds, WBC can see the old cached entry and treat the new allocation as a duplicate insert, or return stale data.

Instead, each chunk now has a monotonically increasing epoch. Every IndexBuffer records the epoch of the chunk it belongs to. On chunk reset, the chunk epoch is bumped. After that, any cached node whose stored epoch no longer matches the chunk's current epoch is treated as stale and evicted lazily on the next cache access or allocation.

This gives us O(1) invalidation at chunk-reset time, avoids walking millions of WBC entries during destroy, and makes BlkId reuse safe after chunk reset.

If chunk selector is not in use and chunk epochs are never bumped, the stale-entry checks are effectively no-ops.