### PR TITLE
SDSTOR-25404: Cache eviction for destroyed volume fails

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomestoreConan(ConanFile):
     name = "homestore"
-    version = "7.5.18"
+    version = "7.5.19"
 
     homepage = "https://github.com/eBay/Homestore"
     description = "HomeStore Storage Engine"

--- a/src/lib/index/wb_cache.cpp
+++ b/src/lib/index/wb_cache.cpp
@@ -50,8 +50,10 @@ IndexWBCache::IndexWBCache(const std::shared_ptr< VirtualDev >& vdev, std::pair<
                     return static_cast< IndexBtreeNode* >(node.get())->m_idx_buf->m_blkid;
                 },
                 [](const sisl::CacheRecord& rec) -> bool {
-                    const auto& hnode = (sisl::SingleEntryHashNode< BtreeNodePtr >&)rec;
-                    return static_cast< IndexBtreeNode* >(hnode.m_value.get())->m_idx_buf->is_clean();
+                    const auto& hnode = static_cast<const sisl::SingleEntryHashNode<BtreeNodePtr>&>(rec);
+                    const auto* idx_node = static_cast<const IndexBtreeNode*>(hnode.m_value.get());
+                    if (!idx_node || !idx_node->m_idx_buf) { return false; }
+                    return idx_node->m_idx_buf->is_clean();
                 }},
         m_node_size{node_size},
         m_meta_blk{sb.first} {


### PR DESCRIPTION
If a volume has been already destroyed and eviction later is called and choose a node from this volume, the eviction will hit the SIGSEGV.