### PR TITLE
SDSTOR-24993: propagate journal flush I/O errors to write_async callback

### DIFF
--- a/src/include/homestore/logstore/log_store.hpp
+++ b/src/include/homestore/logstore/log_store.hpp
@@ -283,6 +283,15 @@ public:
 
     auto get_comp_cb() const { return m_comp_cb; }
 
+    /**
+     * @brief Opt in to receiving a failure-status completion when a flush I/O error occurs, instead of the
+     * completion callback never being invoked at all (today's behavior for every log store). Off by
+     * default so existing callers (e.g. the RAFT/Solo repl_dev log stores) are completely unaffected --
+     * this is additive, not a behavior change, until a store explicitly opts in.
+     */
+    void set_propagates_write_errors(bool propagate) { m_propagates_write_errors = propagate; }
+    bool propagates_write_errors() const { return m_propagates_write_errors; }
+
     void stop();
 
 private:
@@ -290,6 +299,7 @@ private:
     std::shared_ptr< LogDev > m_logdev;
     sisl::StreamTracker< logstore_record > m_records;
     bool m_append_mode{false};
+    bool m_propagates_write_errors{false};
     log_req_comp_cb_t m_comp_cb;
     log_found_cb_t m_found_cb;
     log_replay_done_cb_t m_replay_done_cb;

--- a/src/include/homestore/logstore/log_store_internal.hpp
+++ b/src/include/homestore/logstore/log_store_internal.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <mutex>
 #include <set>
+#include <system_error>
 #include <unordered_map>
 #include <vector>
 
@@ -38,13 +39,16 @@ struct logdev_key;
 
 typedef int64_t logid_t;
 typedef int64_t logstore_seq_num_t;
-typedef std::function< void(logstore_req*, logdev_key) > log_req_comp_cb_t;
+// status is default-constructed (no error) on success; set on a flush I/O error (a sync_pwritev
+// failure that today returns from LogDev::flush() without ever reaching this callback at all).
+typedef std::function< void(logstore_req*, logdev_key, std::error_condition) > log_req_comp_cb_t;
 typedef sisl::byte_view log_buffer;
 typedef uint32_t logstore_id_t;
 typedef uint32_t logdev_id_t;
 
-typedef std::function< void(logstore_req*, logdev_key) > log_req_comp_cb_t;
-typedef std::function< void(logstore_seq_num_t, sisl::io_blob&, logdev_key, void*) > log_write_comp_cb_t;
+typedef std::function< void(logstore_req*, logdev_key, std::error_condition) > log_req_comp_cb_t;
+typedef std::function< void(logstore_seq_num_t, sisl::io_blob&, logdev_key, std::error_condition, void*) >
+    log_write_comp_cb_t;
 typedef std::function< void(logstore_seq_num_t, log_buffer, void*) > log_found_cb_t;
 typedef std::function< void(std::shared_ptr< HomeLogStore >) > log_store_opened_cb_t;
 typedef std::function< void(std::shared_ptr< HomeLogStore >, logstore_seq_num_t) > log_replay_done_cb_t;

--- a/src/lib/logstore/log_dev.cpp
+++ b/src/lib/logstore/log_dev.cpp
@@ -17,6 +17,7 @@
 #include <condition_variable>
 #include <cstring>
 #include <iterator>
+#include <system_error>
 
 #include <sisl/fds/vector_pool.hpp>
 #include <iomgr/iomgr_flip.hpp>
@@ -530,11 +531,16 @@ bool LogDev::flush() {
         HISTOGRAM_OBSERVE(logstore_service().m_metrics, logdev_flush_records_distribution, lg->nrecords());
         HISTOGRAM_OBSERVE(logstore_service().m_metrics, logdev_flush_size_distribution, lg->actual_data_size());
 
-        // TODO:: add logic to handle this error in upper layer
         auto error = m_vdev_jd->sync_pwritev(lg->iovecs().data(), int_cast(lg->iovecs().size()), lg->m_log_dev_offset);
+#ifdef _PRERELEASE
+        if (iomgr_flip::instance()->test_flip("simulate_log_flush_error")) {
+            error = std::make_error_code(std::errc::io_error);
+        }
+#endif
         if (error) {
             THIS_LOGDEV_LOG(ERROR, "Fail to sync write to journal vde , error code {} : {}", error.value(),
                             error.message());
+            on_flush_completion(lg, std::make_error_condition(std::errc::io_error));
             return false;
         }
 
@@ -544,17 +550,24 @@ bool LogDev::flush() {
     return true;
 }
 
-void LogDev::on_flush_completion(LogGroup* lg) {
+void LogDev::on_flush_completion(LogGroup* lg, std::error_condition status) {
     auto done_time = Clock::now();
     THIS_LOGDEV_LOG(TRACE, "Flush completed for logid[{} - {}]", lg->m_flush_log_idx_from, lg->m_flush_log_idx_upto);
-
-    m_log_records->complete(lg->m_flush_log_idx_from, lg->m_flush_log_idx_upto);
-    m_last_crc = lg->header()->cur_grp_crc;
-    std::unordered_map< logid_t, logstore_req* > req_map;
 
     auto from_indx = lg->m_flush_log_idx_from;
     auto upto_indx = lg->m_flush_log_idx_upto;
     auto dev_offset = lg->m_log_dev_offset;
+
+    // Collect every request in the flushed range first (single pass under the stream-tracker lock), and
+    // on the failure path check whether every one of them belongs to a log store that opted in via
+    // set_propagates_write_errors(true). If any hasn't, bail out having touched nothing at all -- no
+    // records completed, no bookkeeping advanced, no callback invoked -- which is exactly what happens
+    // today on this error path. That preserves both "no regression" for existing (non-opted-in) log
+    // stores (e.g. RAFT/Solo repl_dev's own journals) and their accidental-but-relied-upon resilience to
+    // a transient I/O error: since nothing here is touched, the next flush() attempt naturally re-collects
+    // this same still-active range and retries the write.
+    std::unordered_map< logid_t, logstore_req* > req_map;
+    bool all_propagate = true;
     for (auto idx = from_indx; idx <= upto_indx; ++idx) {
         logstore_req* req;
         logstore_id_t store_id;
@@ -578,12 +591,33 @@ void LogDev::on_flush_completion(LogGroup* lg) {
         HomeLogStore* log_store = req->log_store;
         HS_LOG_ASSERT_EQ(log_store->get_store_id(), store_id,
                          "Expecting store id in log store and flush completion to match");
-        HISTOGRAM_OBSERVE(logstore_service().m_metrics, logstore_append_latency, get_elapsed_time_us(req->start_time));
 #ifdef _PRERELEASE
         HISTOGRAM_OBSERVE(logstore_service().m_metrics, logstore_stream_tracker_lock_latency, lock_latency);
 #endif
-        log_store->on_write_completion(req, logdev_key{idx, dev_offset}, logdev_key{from_indx, dev_offset});
+        if (status && !log_store->propagates_write_errors()) { all_propagate = false; }
         req_map[idx] = req;
+    }
+
+    if (status && !all_propagate) { return; }
+
+    m_log_records->complete(from_indx, upto_indx);
+    // The failed group's header already baked the pre-write m_last_crc into its own prev_grp_crc chain
+    // link (LogGroup::finish(), called from prepare_flush() before the write was even attempted) -- since
+    // nothing here was actually made durable, m_last_crc must stay put so the next group that *is*
+    // written durably still chains from the last real, on-disk CRC.
+    if (!status) { m_last_crc = lg->header()->cur_grp_crc; }
+
+    if (!status) {
+        // Must run in idx order (from_indx..upto_indx), not req_map's unspecified hash order:
+        // on_write_completion's m_tail_lsn/trunc_key bookkeeping is order-sensitive within a single log
+        // store when that store allows out-of-order lsn writes (unlike the callback-firing loop below,
+        // which is explicitly order-independent).
+        for (auto idx = from_indx; idx <= upto_indx; ++idx) {
+            auto* req = req_map[idx];
+            HISTOGRAM_OBSERVE(logstore_service().m_metrics, logstore_append_latency,
+                              get_elapsed_time_us(req->start_time));
+            req->log_store->on_write_completion(req, logdev_key{idx, dev_offset}, logdev_key{from_indx, dev_offset});
+        }
     }
     HISTOGRAM_OBSERVE(logstore_service().m_metrics, logdev_flush_time_us,
                       get_elapsed_time_us(m_last_flush_time, done_time));
@@ -592,15 +626,17 @@ void LogDev::on_flush_completion(LogGroup* lg) {
     free_log_group(lg);
     m_log_records->truncate(upto_indx);
     m_last_flush_idx = upto_indx;
-    m_last_flush_ld_key = logdev_key{from_indx, dev_offset};
+    // Same reasoning as m_last_crc above: this dev_offset was never actually written on the failure path,
+    // so it must never be recorded as a safe truncation/replay reference point.
+    if (!status) { m_last_flush_ld_key = logdev_key{from_indx, dev_offset}; }
 
     // since we support out-of-order lsn write, so no need to guarantee the order of logstore write completion
     for (auto const& [idx, req] : req_map) {
         m_pending_callback++;
-        auto callback_lambda = [this, dev_offset, idx, req]() {
+        auto callback_lambda = [this, dev_offset, idx, req, status]() {
             auto ld_key = logdev_key{idx, dev_offset};
             auto comp_cb = req->log_store->get_comp_cb();
-            (req->cb) ? req->cb(req, ld_key) : comp_cb(req, ld_key);
+            (req->cb) ? req->cb(req, ld_key, status) : comp_cb(req, ld_key, status);
             m_pending_callback--;
         };
 

--- a/src/lib/logstore/log_dev.hpp
+++ b/src/lib/logstore/log_dev.hpp
@@ -749,7 +749,12 @@ private:
      */
     void unreserve_store_id(logstore_id_t store_id);
 
-    void on_flush_completion(LogGroup* lg);
+    // status is default-constructed (no error) on the normal success path. On a flush I/O failure, called
+    // with a failure status *only if* every record in the flushed range belongs to a log store that has
+    // opted in via HomeLogStore::set_propagates_write_errors(true) -- otherwise this is not called at all,
+    // preserving today's exact behavior (and its accidental but relied-upon retry-on-transient-error
+    // resilience) for every log store that hasn't opted in.
+    void on_flush_completion(LogGroup* lg, std::error_condition status = {});
     void on_log_store_found(logstore_id_t store_id, const logstore_superblk& sb);
     void handle_unopened_log_stores(bool format);
     void on_logfound(logstore_id_t id, logstore_seq_num_t seq_num, logdev_key ld_key, logdev_key flush_ld_key,

--- a/src/lib/logstore/log_store.cpp
+++ b/src/lib/logstore/log_store.cpp
@@ -74,8 +74,8 @@ logstore_seq_num_t HomeLogStore::write_async(logstore_seq_num_t seq_num, const s
     auto* req = logstore_req::make(this, seq_num, b);
     req->cookie = cookie;
 
-    auto ret = write_async(req, [cb](logstore_req* req, logdev_key written_lkey) {
-        if (cb) { cb(req->seq_num, req->data, written_lkey, req->cookie); }
+    auto ret = write_async(req, [cb](logstore_req* req, logdev_key written_lkey, std::error_condition status) {
+        if (cb) { cb(req->seq_num, req->data, written_lkey, status, req->cookie); }
         logstore_req::free(req);
     });
     decr_pending_request_num();

--- a/src/lib/replication/log_store/home_raft_log_store.cpp
+++ b/src/lib/replication/log_store/home_raft_log_store.cpp
@@ -13,6 +13,8 @@
  *
  *********************************************************************************/
 
+#include <system_error>
+
 #include "home_raft_log_store.h"
 #include "storage_engine_buffer.h"
 #include <sisl/fds/utils.hpp>
@@ -165,9 +167,10 @@ ulong HomeRaftLogStore::append(nuraft::ptr< nuraft::log_entry >& entry) {
     REPL_STORE_LOG(TRACE, "append entry term={}, log_val_type={} size={}", entry->get_term(),
                    static_cast< uint32_t >(entry->get_val_type()), entry->get_buf().size());
     auto buf = entry->serialize();
-    auto const next_seq =
-        m_log_store->append_async(sisl::io_blob{buf->data_begin(), uint32_cast(buf->size()), false /* is_aligned */},
-                                  nullptr /* cookie */, [buf](int64_t, sisl::io_blob&, logdev_key, void*) {});
+    auto const next_seq = m_log_store->append_async(
+        sisl::io_blob{buf->data_begin(), uint32_cast(buf->size()), false /* is_aligned */}, nullptr /* cookie */,
+        // status intentionally unused here -- tracked under SDSTOR-25623, not fixed as part of this change.
+        [buf](int64_t, sisl::io_blob&, logdev_key, std::error_condition, void*) {});
     ulong lsn = to_repl_lsn(next_seq);
 
     auto position_in_cache = lsn % m_log_entry_cache.size();
@@ -187,9 +190,10 @@ void HomeRaftLogStore::write_at(ulong index, nuraft::ptr< nuraft::log_entry >& e
     // calls, but it is dangerous to set higher number.
     m_last_durable_lsn = -1;
 
-    auto const appended_seq =
-        m_log_store->append_async(sisl::io_blob{buf->data_begin(), uint32_cast(buf->size()), false /* is_aligned */},
-                                  nullptr /* cookie */, [buf](int64_t, sisl::io_blob&, logdev_key, void*) {});
+    auto const appended_seq = m_log_store->append_async(
+        sisl::io_blob{buf->data_begin(), uint32_cast(buf->size()), false /* is_aligned */}, nullptr /* cookie */,
+        // status intentionally unused here -- tracked under SDSTOR-25623, not fixed as part of this change.
+        [buf](int64_t, sisl::io_blob&, logdev_key, std::error_condition, void*) {});
     HS_REL_ASSERT_EQ(to_repl_lsn(appended_seq), static_cast< repl_lsn_t >(index),
                      "write_at appended lsn mismatch: expected {} actual {}", index, to_repl_lsn(appended_seq));
 

--- a/src/lib/replication/repl_dev/solo_repl_dev.cpp
+++ b/src/lib/replication/repl_dev/solo_repl_dev.cpp
@@ -1,4 +1,5 @@
 #include <latch>
+#include <system_error>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 #include "replication/repl_dev/solo_repl_dev.h"
 #include "replication/repl_dev/common.h"
@@ -78,7 +79,9 @@ void SoloReplDev::write_journal(repl_req_ptr_t rreq) {
 
     m_data_journal->append_async(
         sisl::io_blob{rreq->raw_journal_buf(), rreq->journal_entry_size(), false /* is_aligned */},
-        nullptr /* cookie */, [this, rreq](int64_t lsn, sisl::io_blob&, homestore::logdev_key, void*) mutable {
+        nullptr /* cookie */,
+        // status intentionally unused here -- tracked under SDSTOR-25623, not fixed as part of this change.
+        [this, rreq](int64_t lsn, sisl::io_blob&, homestore::logdev_key, std::error_condition, void*) mutable {
             rreq->set_lsn(lsn);
             m_listener->on_pre_commit(rreq->lsn(), rreq->header(), rreq->key(), rreq);
 

--- a/src/tests/log_store_benchmark.cpp
+++ b/src/tests/log_store_benchmark.cpp
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <random>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #include <benchmark/benchmark.h>
@@ -114,7 +115,7 @@ private:
         DLOGDEBUG("Appending log entry for iteration_ind={} ind={}", iter_ind, ind);
         m_log_store->append_async(
             sisl::io_blob(uintptr_cast(m_data[iter_ind].data()), uint32_cast(m_data[iter_ind].size()), false), nullptr,
-            [this](logstore_seq_num_t, sisl::io_blob&, bool, void*) {
+            [this](logstore_seq_num_t, sisl::io_blob&, bool, std::error_condition, void*) {
                 if (m_outstanding.fetch_sub(1, std::memory_order_acq_rel) < int_cast(m_q_depth)) { issue_io(); };
             });
         return true;

--- a/src/tests/test_log_store.cpp
+++ b/src/tests/test_log_store.cpp
@@ -23,6 +23,7 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <future>
 #include <iterator>
 #include <limits>
 #include <map>
@@ -32,6 +33,7 @@
 #include <random> // std::default_random_engine
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <type_traits>
 #include <vector>
@@ -152,7 +154,9 @@ public:
                 auto* d = prepare_data(lsn, io_memory);
                 m_log_store->write_async(lsn, {uintptr_cast(d), d->total_size(), false}, nullptr,
                                          [io_memory, d, this](logstore_seq_num_t seq_num, const sisl::io_blob& b,
-                                                              logdev_key ld_key, void* ctx) {
+                                                              logdev_key ld_key, std::error_condition status,
+                                                              void* ctx) {
+                                             assert(!status);
                                              assert(ld_key);
                                              if (io_memory) {
                                                  iomanager.iobuf_free(uintptr_cast(d));
@@ -869,6 +873,10 @@ protected:
         }
     }
 
+    HomeLogStore* raw_log_store(size_t idx = 0) {
+        return SampleDB::instance().m_log_store_clients[idx]->m_log_store.get();
+    }
+
 private:
     SampleLogStoreClient* pick_log_store() {
         static thread_local std::random_device rd{};
@@ -1184,6 +1192,51 @@ TEST_F(LogStoreTest, FlushSync) {
     fc->remove_flip("simulate_log_flush_delay");
 #endif
 }
+
+#ifdef _PRERELEASE
+TEST_F(LogStoreTest, FlushIOErrorPropagatesToCallback) {
+    LOGINFO("Step 1: Reinit with no records -- this test issues its own single write directly");
+    this->init(0);
+
+    auto* log_store = this->raw_log_store(0);
+    LOGINFO("Step 2: Opt this log store in to flush-failure propagation (off by default for everyone else)");
+    log_store->set_propagates_write_errors(true);
+
+    LOGINFO("Step 3: Arm a flip to force the next flush's sync_pwritev to fail");
+    flip::FlipClient* fc = iomgr_flip::client_instance();
+    flip::FlipFrequency freq;
+    freq.set_count(1);
+    freq.set_percent(100);
+    flip::FlipCondition dont_care_cond;
+    fc->create_condition("", flip::Operator::DONT_CARE, (int)1, &dont_care_cond);
+    fc->inject_noreturn_flip("simulate_log_flush_error", {dont_care_cond}, freq);
+
+    LOGINFO("Step 4: Issue one write with a status-aware callback and force a flush");
+    bool io_memory{false};
+    const auto lsn = log_store->get_contiguous_issued_seq_num(-1) + 1;
+    auto* d = SampleLogStoreClient::prepare_data(lsn, io_memory);
+    std::promise< std::error_condition > status_promise;
+    auto status_future = status_promise.get_future();
+    log_store->write_async(lsn, {uintptr_cast(d), d->total_size(), false}, nullptr,
+                           [&status_promise, d, io_memory](logstore_seq_num_t, const sisl::io_blob&, logdev_key,
+                                                            std::error_condition status, void*) {
+                               if (io_memory) {
+                                   iomanager.iobuf_free(uintptr_cast(d));
+                               } else {
+                                   std::free(voidptr_cast(d));
+                               }
+                               status_promise.set_value(status);
+                           });
+    log_store->flush();
+
+    LOGINFO("Step 5: The callback must fire with a failure status -- pre-fix, it would never fire at all");
+    auto const wait_status = status_future.wait_for(std::chrono::seconds(30));
+    fc->remove_flip("simulate_log_flush_error");
+    ASSERT_EQ(wait_status, std::future_status::ready)
+        << "flush-failure completion callback was never invoked (would hang forever pre-fix)";
+    ASSERT_TRUE(bool(status_future.get())) << "expected a failure status on the callback, got success";
+}
+#endif
 
 TEST_F(LogStoreTest, DeleteMultipleLogStores) {
     const auto nrecords = (SISL_OPTIONS["num_records"].as< uint32_t >() * 5) / 100;

--- a/src/tests/test_log_store_long_run.cpp
+++ b/src/tests/test_log_store_long_run.cpp
@@ -32,6 +32,7 @@
 #include <random> // std::default_random_engine
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <type_traits>
 #include <vector>
@@ -125,7 +126,9 @@ public:
             auto* d = prepare_data(lsn, io_memory);
             m_log_store->write_async(
                 lsn, {uintptr_cast(d), d->total_size(), false}, nullptr,
-                [io_memory, d, this](logstore_seq_num_t seq_num, const sisl::io_blob& b, logdev_key ld_key, void* ctx) {
+                [io_memory, d, this](logstore_seq_num_t seq_num, const sisl::io_blob& b, logdev_key ld_key,
+                                     std::error_condition status, void* ctx) {
+                    assert(!status);
                     assert(ld_key);
                     if (io_memory) {
                         iomanager.iobuf_free(uintptr_cast(d));


### PR DESCRIPTION
## Summary

`LogDev::flush()` returns `false` on a `sync_pwritev` journal I/O error without ever invoking the append's completion callback (`log_dev.cpp`, right after the `sync_pwritev` call — the existing `// TODO:: add logic to handle this error in upper layer` marks this exact gap). Verified this is a real, reachable failure path (not asserted away anywhere in the write chain down through `PhysicalDev`/`VirtualDev`) and that the callback is never invoked at all in this case — not "invoked without a status," genuinely never invoked — permanently suspending the awaiting caller (e.g. CRAFT's `write_slot` in HomeBlocks, `co_await`ing a `value_awaitable` that will never complete).

## Fix

- `log_req_comp_cb_t` / `log_write_comp_cb_t` now carry a trailing `std::error_condition status` (default-constructed / no-error on the existing success path).
- `LogDev::on_flush_completion` takes an optional `status` (default success). On a flush I/O error, `flush()` now calls it with a failure status instead of silently returning.
- A log store must explicitly opt in via `HomeLogStore::set_propagates_write_errors(true)` to actually receive a failure notification on flush error. Off by default, so **every existing caller (RAFT's `HomeRaftLogStore`, `SoloReplDev`, and all existing tests/benchmark) compiles and behaves exactly as before** — verified this matters: `SoloReplDev::write_journal`'s callback unconditionally calls `on_commit()` on invocation, so making it fire on an undurable write without also fixing that call site first would turn today's failure mode (hang) into a silent false-commit, which is strictly worse. That broader fix (and `HomeRaftLogStore::end_of_append_batch` separately ignoring `flush()`'s own bool return) is tracked under SDSTOR-25623, deliberately not part of this change.
- On the failure path (only reachable for opted-in stores): the affected log records are still marked complete and `m_last_flush_idx` advances (so the failed batch is resolved exactly once, never silently retried/double-notified), but `m_last_crc` and `m_last_flush_ld_key` are left untouched, since the failed group's data was never actually made durable and must not join the on-disk CRC chain or become a truncation/recovery reference point.

## Testing

New test `LogStoreTest.FlushIOErrorPropagatesToCallback` in `test_log_store.cpp`: opts a log store in, arms a new `iomgr_flip` (`simulate_log_flush_error`, mirroring the existing `simulate_log_flush_delay` pattern) to force the next flush's `sync_pwritev` to fail, and asserts the write's callback fires with a failure status instead of hanging forever.

Full HomeStore test suite run in progress on this change; will update once complete.

## Jira

https://jirap.corp.ebay.com/browse/SDSTOR-24993